### PR TITLE
Use arenas and TokenReference instead of Cow<Token>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Fields of `Token` and `Position` have been made private with public accessors
+- Added `TokenKind` to get the kind of a token without any additional data
+- Changed signatures from `Token` to `TokenReference`, which dereference to tokens
+- Added mutation methods: `set_start_position`, `set_end_position`, `set_token_type` for `TokenReference` objects
+- Added `Ast::update_positions` to update all the position structs if you mutate it
 
 ## [0.3.0] - 2019-05-24
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-if"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ctor"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -35,6 +40,7 @@ name = "full_moon"
 version = "0.3.1"
 dependencies = [
  "full_moon_derive 0.1.1",
+ "generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -48,6 +54,14 @@ version = "0.1.1"
 dependencies = [
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "generational-arena"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -208,8 +222,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4024f96ffa0ebaaf36aa589cd41f2fd69f3a5e6fd02c86e11e12cdf41d5b46a3"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytecount"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +49,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "full_moon"
 version = "0.3.1"
 dependencies = [
+ "bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "full_moon_derive 0.1.1",
  "generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -236,6 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum bytecount 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be0fdd54b507df8f22012890aadd099979befdba27713c767993f8380112ca7c"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,11 +36,17 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "either"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "full_moon"
 version = "0.3.1"
 dependencies = [
  "full_moon_derive 0.1.1",
  "generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -62,6 +68,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -225,7 +239,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum generational-arena 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4024f96ffa0ebaaf36aa589cd41f2fd69f3a5e6fd02c86e11e12cdf41d5b46a3"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ no-source-tests = []
 only-source-tests = []
 
 [dependencies]
+bytecount = "0.5"
 full_moon_derive = { path = "./full-moon-derive", version = "0.1.1" }
 generational-arena = "0.2"
 itertools = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ only-source-tests = []
 
 [dependencies]
 full_moon_derive = { path = "./full-moon-derive", version = "0.1.1" }
+generational-arena = "0.2"
 lazy_static = "1.3"
 regex = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ only-source-tests = []
 [dependencies]
 full_moon_derive = { path = "./full-moon-derive", version = "0.1.1" }
 generational-arena = "0.2"
+itertools = "0.8"
 lazy_static = "1.3"
 regex = "1.1"
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1874,9 +1874,7 @@ impl<'a> Ast<'a> {
         if tokens.last().ok_or(AstError::Empty)?.token_type() != &TokenType::Eof {
             Err(AstError::NoEof)
         } else {
-            let tokens = Arc::new(
-                Arena::from_iter(tokens)
-            );
+            let tokens = Arc::new(Arena::from_iter(tokens));
 
             let mut state = ParserState::new(Arc::clone(&tokens));
 
@@ -1950,10 +1948,7 @@ impl<'a> Ast<'a> {
 
     /// An iterator over the tokens used to create the Ast
     pub fn iter_tokens(&self) -> impl Iterator<Item = &Token<'a>> {
-        self
-            .tokens
-            .iter()
-            .map(|(_, token)| token)
+        self.tokens.iter().map(|(_, token)| token)
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1555,6 +1555,10 @@ impl<'a> LocalAssignment<'a> {
     pub fn iter_name_list(&self) -> impl Iterator<Item = &TokenReference<'a>> {
         self.name_list.iter()
     }
+
+    pub fn iter_name_list_mut(&mut self) -> impl Iterator<Item = &mut TokenReference<'a>> {
+        self.name_list.iter_mut()
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt;
 
-#[derive(Clone, Copy, PartialEq)]
+// This is cloned everywhere, so make sure cloning is as inexpensive as possible
+#[derive(Clone, PartialEq)]
 struct ParserState<'a> {
     index: usize,
     len: usize,
@@ -13,8 +14,8 @@ struct ParserState<'a> {
 }
 
 impl<'a> ParserState<'a> {
-    fn advance(self) -> Option<ParserState<'a>> {
-        let mut state = self;
+    fn advance(&self) -> Option<ParserState<'a>> {
+        let mut state = self.clone();
 
         loop {
             state = ParserState {
@@ -29,7 +30,7 @@ impl<'a> ParserState<'a> {
         }
     }
 
-    pub fn peek<'b>(self) -> Cow<'b, Token<'a>> {
+    pub fn peek<'b>(&self) -> Cow<'b, Token<'a>> {
         if self.index >= self.len {
             panic!("peek failed, when there should always be an eof");
         }
@@ -84,7 +85,7 @@ macro_rules! define_parser {
 macro_rules! parse_first_of {
     ($state:ident, {$($parser:expr => $constructor:expr,)+}) => ({
         $(
-            match $parser.parse($state) {
+            match $parser.parse($state.clone()) {
                 Ok((state, node)) => return Ok((state, $constructor(node.into()))),
                 Err(InternalAstError::NoMatch) => {},
                 Err(other) => return Err(other),
@@ -149,7 +150,7 @@ where
     ) -> Result<(ParserState<'a>, Vec<T>), InternalAstError<'a>> {
         let mut nodes = Vec::new();
         loop {
-            match self.0.parse(state) {
+            match self.0.parse(state.clone()) {
                 Ok((new_state, node)) => {
                     state = new_state;
                     nodes.push(node);
@@ -182,17 +183,17 @@ where
     ) -> Result<(ParserState<'a>, Vec<T>), InternalAstError<'a>> {
         let mut nodes = Vec::new();
 
-        if let Ok((new_state, node)) = keep_going!(self.0.parse(state)) {
+        if let Ok((new_state, node)) = keep_going!(self.0.parse(state.clone())) {
             state = new_state;
             nodes.push(node);
         } else {
-            return Ok((state, Vec::new()));
+            return Ok((state.clone(), Vec::new()));
         }
 
-        while let Ok((new_state, _)) = keep_going!(self.1.parse(state)) {
+        while let Ok((new_state, _)) = keep_going!(self.1.parse(state.clone())) {
             state = new_state;
 
-            match self.0.parse(state) {
+            match self.0.parse(state.clone()) {
                 Ok((new_state, node)) => {
                     state = new_state;
                     nodes.push(node);
@@ -236,11 +237,11 @@ impl<'a, ItemParser: Parser<'a>, Delimiter: Parser<'a>> Parser<'a>
         state: ParserState<'a>,
     ) -> Result<(ParserState<'a>, Vec<ItemParser::Item>), InternalAstError<'a>> {
         let mut nodes = Vec::new();
-        let (mut state, node) = self.0.parse(state)?;
+        let (mut state, node) = self.0.parse(state.clone())?;
         nodes.push(node);
 
-        while let Ok((new_state, _)) = self.1.parse(state) {
-            match self.0.parse(new_state) {
+        while let Ok((new_state, _)) = self.1.parse(state.clone()) {
+            match self.0.parse(new_state.clone()) {
                 Ok((new_state, node)) => {
                     state = new_state;
                     nodes.push(node);
@@ -343,18 +344,18 @@ impl<'a> Block<'a> {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct ParseBlock;
-define_parser!(ParseBlock, Block<'a>, |_, mut state| {
+define_parser!(ParseBlock, Block<'a>, |_, mut state: ParserState<'a>| {
     let mut stmts = Vec::new();
-    while let Ok((new_state, stmt)) = keep_going!(ParseStmt.parse(state)) {
+    while let Ok((new_state, stmt)) = keep_going!(ParseStmt.parse(state.clone())) {
         state = new_state;
-        if let Ok((new_state, _)) = ParseSymbol(Symbol::Semicolon).parse(state) {
+        if let Ok((new_state, _)) = ParseSymbol(Symbol::Semicolon).parse(state.clone()) {
             state = new_state;
         }
         stmts.push(stmt);
     }
 
-    if let Ok((mut state, last_stmt)) = keep_going!(ParseLastStmt.parse(state)) {
-        if let Ok((new_state, _)) = ParseSymbol(Symbol::Semicolon).parse(state) {
+    if let Ok((mut state, last_stmt)) = keep_going!(ParseLastStmt.parse(state.clone())) {
+        if let Ok((new_state, _)) = ParseSymbol(Symbol::Semicolon).parse(state.clone()) {
             state = new_state;
         }
 
@@ -392,14 +393,14 @@ struct ParseLastStmt;
 define_parser!(
     ParseLastStmt,
     LastStmt<'a>,
-    |_, state| if let Ok((state, _)) = ParseSymbol(Symbol::Return).parse(state) {
+    |_, state: ParserState<'a>| if let Ok((state, _)) = ParseSymbol(Symbol::Return).parse(state.clone()) {
         let (state, returns) = expect!(
             state,
-            ZeroOrMoreDelimited(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state),
+            ZeroOrMoreDelimited(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state.clone()),
             "return values"
         );
         Ok((state, LastStmt::Return(returns)))
-    } else if let Ok((state, _)) = ParseSymbol(Symbol::Break).parse(state) {
+    } else if let Ok((state, _)) = ParseSymbol(Symbol::Break).parse(state.clone()) {
         Ok((state, LastStmt::Break))
     } else {
         Err(InternalAstError::NoMatch)
@@ -435,33 +436,33 @@ pub enum Field<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseField;
-define_parser!(ParseField, Field<'a>, |_, state| {
-    if let Ok((state, _)) = ParseSymbol(Symbol::LeftBracket).parse(state) {
-        let (state, key) = expect!(state, ParseExpression.parse(state), "expected key");
+define_parser!(ParseField, Field<'a>, |_, state: ParserState<'a>| {
+    if let Ok((state, _)) = ParseSymbol(Symbol::LeftBracket).parse(state.clone()) {
+        let (state, key) = expect!(state, ParseExpression.parse(state.clone()), "expected key");
         let (state, _) = expect!(
             state,
-            ParseSymbol(Symbol::RightBracket).parse(state),
+            ParseSymbol(Symbol::RightBracket).parse(state.clone()),
             "expected ']'"
         );
         let (state, _) = expect!(
             state,
-            ParseSymbol(Symbol::Equal).parse(state),
+            ParseSymbol(Symbol::Equal).parse(state.clone()),
             "expected '='"
         );
-        let (state, value) = expect!(state, ParseExpression.parse(state), "expected value");
+        let (state, value) = expect!(state, ParseExpression.parse(state.clone()), "expected value");
         let (key, value) = (Box::new(key), Box::new(value));
-        return Ok((state, Field::ExpressionKey { key, value }));
-    } else if let Ok((state, key)) = keep_going!(ParseIdentifier.parse(state)) {
-        if let Ok((state, _)) = ParseSymbol(Symbol::Equal).parse(state) {
-            let (state, value) = expect!(state, ParseExpression.parse(state), "expected value");
+        return Ok((state.clone(), Field::ExpressionKey { key, value }));
+    } else if let Ok((state, key)) = keep_going!(ParseIdentifier.parse(state.clone())) {
+        if let Ok((state, _)) = ParseSymbol(Symbol::Equal).parse(state.clone()) {
+            let (state, value) = expect!(state, ParseExpression.parse(state.clone()), "expected value");
             let (key, value) = (Box::new(key), Box::new(value));
-            return Ok((state, Field::NameKey { key, value }));
+            return Ok((state.clone(), Field::NameKey { key, value }));
         }
     }
 
-    if let Ok((state, expr)) = keep_going!(ParseExpression.parse(state)) {
+    if let Ok((state, expr)) = keep_going!(ParseExpression.parse(state.clone())) {
         let expr = Box::new(expr);
-        return Ok((state, Field::NoKey(expr)));
+        return Ok((state.clone(), Field::NoKey(expr)));
     }
 
     Err(InternalAstError::NoMatch)
@@ -487,15 +488,15 @@ impl<'a> TableConstructor<'a> {
 }
 
 struct ParseTableConstructor;
-define_parser!(ParseTableConstructor, TableConstructor<'a>, |_, state| {
-    let (mut state, _) = ParseSymbol(Symbol::LeftBrace).parse(state)?;
+define_parser!(ParseTableConstructor, TableConstructor<'a>, |_, state: ParserState<'a>| {
+    let (mut state, _) = ParseSymbol(Symbol::LeftBrace).parse(state.clone())?;
     let mut fields = Vec::new();
 
-    while let Ok((new_state, field)) = keep_going!(ParseField.parse(state)) {
-        let field_sep = if let Ok((new_state, separator)) = ParseSymbol(Symbol::Comma).parse(new_state) {
+    while let Ok((new_state, field)) = keep_going!(ParseField.parse(state.clone())) {
+        let field_sep = if let Ok((new_state, separator)) = ParseSymbol(Symbol::Comma).parse(new_state.clone()) {
             state = new_state;
             Some(separator)
-        } else if let Ok((new_state, separator)) = ParseSymbol(Symbol::Semicolon).parse(new_state) {
+        } else if let Ok((new_state, separator)) = ParseSymbol(Symbol::Semicolon).parse(new_state.clone()) {
             state = new_state;
             Some(separator)
         } else {
@@ -512,7 +513,7 @@ define_parser!(ParseTableConstructor, TableConstructor<'a>, |_, state| {
 
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::RightBrace).parse(state),
+        ParseSymbol(Symbol::RightBrace).parse(state.clone()),
         "expected '}'"
     );
 
@@ -570,10 +571,10 @@ struct ParseExpression;
 define_parser!(
     ParseExpression,
     Expression<'a>,
-    |_, state| if let Ok((state, value)) = keep_going!(ParseValue.parse(state)) {
-        let (state, binop) = if let Ok((state, bin_op)) = ParseBinOp.parse(state) {
+    |_, state: ParserState<'a>| if let Ok((state, value)) = keep_going!(ParseValue.parse(state.clone())) {
+        let (state, binop) = if let Ok((state, bin_op)) = ParseBinOp.parse(state.clone()) {
             let (state, expression) =
-                expect!(state, ParseExpression.parse(state), "expected expression");
+                expect!(state, ParseExpression.parse(state.clone()), "expected expression");
             (
                 state,
                 Some(BinOpRhs {
@@ -586,9 +587,9 @@ define_parser!(
         };
 
         Ok((state, Expression::Value { value, binop }))
-    } else if let Ok((state, unop)) = keep_going!(ParseUnOp.parse(state)) {
+    } else if let Ok((state, unop)) = keep_going!(ParseUnOp.parse(state.clone())) {
         let (state, expression) =
-            expect!(state, ParseExpression.parse(state), "expected expression");
+            expect!(state, ParseExpression.parse(state.clone()), "expected expression");
         Ok((
             state,
             Expression::UnaryOperator {
@@ -606,12 +607,12 @@ struct ParseParenExpression;
 define_parser!(
     ParseParenExpression,
     Expression<'a>,
-    |_, state| if let Ok((state, _)) = ParseSymbol(Symbol::LeftParen).parse(state) {
+    |_, state: ParserState<'a>| if let Ok((state, _)) = ParseSymbol(Symbol::LeftParen).parse(state.clone()) {
         let (state, expression) =
-            expect!(state, ParseExpression.parse(state), "expected expression");
+            expect!(state, ParseExpression.parse(state.clone()), "expected expression");
         let (state, _) = expect!(
             state,
-            ParseSymbol(Symbol::RightParen).parse(state),
+            ParseSymbol(Symbol::RightParen).parse(state.clone()),
             "expected ')'"
         );
         Ok((state, expression))
@@ -694,7 +695,7 @@ pub enum Stmt<'a> {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct ParseStmt;
-define_parser!(ParseStmt, Stmt<'a>, |_, state| parse_first_of!(state, {
+define_parser!(ParseStmt, Stmt<'a>, |_, state: ParserState<'a>| parse_first_of!(state, {
     ParseAssignment => Stmt::Assignment,
     ParseFunctionCall => Stmt::FunctionCall,
     ParseDo => Stmt::Do,
@@ -722,7 +723,7 @@ pub enum Prefix<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParsePrefix;
-define_parser!(ParsePrefix, Prefix<'a>, |_, state| parse_first_of!(state, {
+define_parser!(ParsePrefix, Prefix<'a>, |_, state: ParserState<'a>| parse_first_of!(state, {
     ParseParenExpression => Prefix::Expression,
     ParseIdentifier => Prefix::Name,
 }));
@@ -740,18 +741,18 @@ pub enum Index<'a> {
 }
 
 struct ParseIndex;
-define_parser!(ParseIndex, Index<'a>, |_, state| if let Ok((state, _)) =
-    ParseSymbol(Symbol::LeftBracket).parse(state)
+define_parser!(ParseIndex, Index<'a>, |_, state: ParserState<'a>| if let Ok((state, _)) =
+    ParseSymbol(Symbol::LeftBracket).parse(state.clone())
 {
-    let (state, expression) = expect!(state, ParseExpression.parse(state), "expected expression");
+    let (state, expression) = expect!(state, ParseExpression.parse(state.clone()), "expected expression");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::RightBracket).parse(state),
+        ParseSymbol(Symbol::RightBracket).parse(state.clone()),
         "expected ']'"
     );
     Ok((state, Index::Brackets(expression)))
-} else if let Ok((state, _)) = ParseSymbol(Symbol::Dot).parse(state) {
-    let (state, name) = expect!(state, ParseIdentifier.parse(state), "expected name");
+} else if let Ok((state, _)) = ParseSymbol(Symbol::Dot).parse(state.clone()) {
+    let (state, name) = expect!(state, ParseIdentifier.parse(state.clone()), "expected name");
     Ok((state, Index::Dot(name)))
 } else {
     Err(InternalAstError::NoMatch)
@@ -775,24 +776,24 @@ struct ParseFunctionArgs;
 define_parser!(
     ParseFunctionArgs,
     FunctionArgs<'a>,
-    |_, state| if let Ok((state, _)) = keep_going!(ParseSymbol(Symbol::LeftParen).parse(state)) {
+    |_, state: ParserState<'a>| if let Ok((state, _)) = keep_going!(ParseSymbol(Symbol::LeftParen).parse(state.clone())) {
         let (state, expr_list) = expect!(
             state,
-            ZeroOrMoreDelimited(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state),
+            ZeroOrMoreDelimited(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state.clone()),
             "expected arguments"
         );
         let (state, _) = expect!(
             state,
-            ParseSymbol(Symbol::RightParen).parse(state),
+            ParseSymbol(Symbol::RightParen).parse(state.clone()),
             "expected ')'"
         );
         Ok((state, FunctionArgs::Parentheses(expr_list)))
-    } else if let Ok((state, table_constructor)) = keep_going!(ParseTableConstructor.parse(state)) {
+    } else if let Ok((state, table_constructor)) = keep_going!(ParseTableConstructor.parse(state.clone())) {
         Ok((
             state,
             FunctionArgs::TableConstructor(Box::new(table_constructor)),
         ))
-    } else if let Ok((state, string)) = keep_going!(ParseStringLiteral.parse(state)) {
+    } else if let Ok((state, string)) = keep_going!(ParseStringLiteral.parse(state.clone())) {
         Ok((state, FunctionArgs::String(string)))
     } else {
         Err(InternalAstError::NoMatch)
@@ -840,40 +841,40 @@ impl<'a> NumericFor<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseNumericFor;
-define_parser!(ParseNumericFor, NumericFor<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::For).parse(state)?;
-    let (state, index_variable) = expect!(state, ParseIdentifier.parse(state), "expected names");
-    let (state, _) = ParseSymbol(Symbol::Equal).parse(state)?; // Numeric fors run before generic fors, so we can't guarantee this
+define_parser!(ParseNumericFor, NumericFor<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::For).parse(state.clone())?;
+    let (state, index_variable) = expect!(state, ParseIdentifier.parse(state.clone()), "expected names");
+    let (state, _) = ParseSymbol(Symbol::Equal).parse(state.clone())?; // Numeric fors run before generic fors, so we can't guarantee this
     let (state, start) = expect!(
         state,
-        ParseExpression.parse(state),
+        ParseExpression.parse(state.clone()),
         "expected start expression"
     );
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::Comma).parse(state),
+        ParseSymbol(Symbol::Comma).parse(state.clone()),
         "expected comma"
     );
     let (state, end) = expect!(
         state,
-        ParseExpression.parse(state),
+        ParseExpression.parse(state.clone()),
         "expected end expression"
     );
-    let (state, step) = if let Ok((state, _)) = ParseSymbol(Symbol::Comma).parse(state) {
+    let (state, step) = if let Ok((state, _)) = ParseSymbol(Symbol::Comma).parse(state.clone()) {
         let (state, expression) = expect!(
             state,
-            ParseExpression.parse(state),
+            ParseExpression.parse(state.clone()),
             "expected limit expression"
         );
         (state, Some(expression))
     } else {
         (state, None)
     };
-    let (state, _) = expect!(state, ParseSymbol(Symbol::Do).parse(state), "expected 'do'");
-    let (state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+    let (state, _) = expect!(state, ParseSymbol(Symbol::Do).parse(state.clone()), "expected 'do'");
+    let (state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::End).parse(state),
+        ParseSymbol(Symbol::End).parse(state.clone()),
         "expected 'end'"
     );
 
@@ -920,24 +921,24 @@ impl<'a> GenericFor<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseGenericFor;
-define_parser!(ParseGenericFor, GenericFor<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::For).parse(state)?;
+define_parser!(ParseGenericFor, GenericFor<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::For).parse(state.clone())?;
     let (state, names) = expect!(
         state,
-        OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma), false).parse(state),
+        OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma), false).parse(state.clone()),
         "expected names"
     );
-    let (state, _) = expect!(state, ParseSymbol(Symbol::In).parse(state), "expected 'in'"); // Numeric fors run before here, so there has to be an in
+    let (state, _) = expect!(state, ParseSymbol(Symbol::In).parse(state.clone()), "expected 'in'"); // Numeric fors run before here, so there has to be an in
     let (state, expr_list) = expect!(
         state,
-        OneOrMore(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state),
+        OneOrMore(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state.clone()),
         "expected expression"
     );
-    let (state, _) = expect!(state, ParseSymbol(Symbol::Do).parse(state), "expected 'do'");
-    let (state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+    let (state, _) = expect!(state, ParseSymbol(Symbol::Do).parse(state.clone()), "expected 'do'");
+    let (state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::End).parse(state),
+        ParseSymbol(Symbol::End).parse(state.clone()),
         "expected 'end'"
     );
     Ok((
@@ -988,18 +989,18 @@ impl<'a> If<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseIf;
-define_parser!(ParseIf, If<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::If).parse(state)?;
-    let (state, condition) = expect!(state, ParseExpression.parse(state), "expected condition");
+define_parser!(ParseIf, If<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::If).parse(state.clone())?;
+    let (state, condition) = expect!(state, ParseExpression.parse(state.clone()), "expected condition");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::Then).parse(state),
+        ParseSymbol(Symbol::Then).parse(state.clone()),
         "expected 'then'"
     );
-    let (mut state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+    let (mut state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
 
     let mut else_ifs = Vec::new();
-    while let Ok((new_state, _)) = ParseSymbol(Symbol::ElseIf).parse(state) {
+    while let Ok((new_state, _)) = ParseSymbol(Symbol::ElseIf).parse(state.clone()) {
         let (new_state, condition) = expect!(
             state,
             ParseExpression.parse(new_state),
@@ -1015,8 +1016,8 @@ define_parser!(ParseIf, If<'a>, |_, state| {
         else_ifs.push((condition, block));
     }
 
-    let (state, r#else) = if let Ok((state, _)) = ParseSymbol(Symbol::Else).parse(state) {
-        let (state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+    let (state, r#else) = if let Ok((state, _)) = ParseSymbol(Symbol::Else).parse(state.clone()) {
+        let (state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
         (state, Some(block))
     } else {
         (state, None)
@@ -1024,7 +1025,7 @@ define_parser!(ParseIf, If<'a>, |_, state| {
 
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::End).parse(state),
+        ParseSymbol(Symbol::End).parse(state.clone()),
         "expected 'end'"
     );
 
@@ -1066,14 +1067,14 @@ impl<'a> While<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseWhile;
-define_parser!(ParseWhile, While<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::While).parse(state)?;
-    let (state, condition) = expect!(state, ParseExpression.parse(state), "expected condition");
-    let (state, _) = expect!(state, ParseSymbol(Symbol::Do).parse(state), "expected 'do'");
-    let (state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+define_parser!(ParseWhile, While<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::While).parse(state.clone())?;
+    let (state, condition) = expect!(state, ParseExpression.parse(state.clone()), "expected condition");
+    let (state, _) = expect!(state, ParseSymbol(Symbol::Do).parse(state.clone()), "expected 'do'");
+    let (state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::End).parse(state),
+        ParseSymbol(Symbol::End).parse(state.clone()),
         "expected 'end'"
     );
     Ok((state, While { condition, block }))
@@ -1102,15 +1103,15 @@ impl<'a> Repeat<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseRepeat;
-define_parser!(ParseRepeat, Repeat<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::Repeat).parse(state)?;
-    let (state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+define_parser!(ParseRepeat, Repeat<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::Repeat).parse(state.clone())?;
+    let (state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::Until).parse(state),
+        ParseSymbol(Symbol::Until).parse(state.clone()),
         "expected 'until'"
     );
-    let (state, until) = expect!(state, ParseExpression.parse(state), "expected condition");
+    let (state, until) = expect!(state, ParseExpression.parse(state.clone()), "expected condition");
     Ok((state, Repeat { until, block }))
 });
 
@@ -1136,10 +1137,10 @@ impl<'a> MethodCall<'a> {
 }
 
 struct ParseMethodCall;
-define_parser!(ParseMethodCall, MethodCall<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::Colon).parse(state)?;
-    let (state, name) = expect!(state, ParseIdentifier.parse(state), "expected method");
-    let (state, args) = expect!(state, ParseFunctionArgs.parse(state), "expected args");
+define_parser!(ParseMethodCall, MethodCall<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::Colon).parse(state.clone())?;
+    let (state, name) = expect!(state, ParseIdentifier.parse(state.clone()), "expected method");
+    let (state, args) = expect!(state, ParseFunctionArgs.parse(state.clone()), "expected args");
     Ok((state, MethodCall { name, args }))
 });
 
@@ -1156,7 +1157,7 @@ pub enum Call<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseCall;
-define_parser!(ParseCall, Call<'a>, |_, state| parse_first_of!(state, {
+define_parser!(ParseCall, Call<'a>, |_, state: ParserState<'a>| parse_first_of!(state, {
     ParseFunctionArgs => Call::AnonymousCall,
     ParseMethodCall => Call::MethodCall,
 }));
@@ -1184,40 +1185,40 @@ impl<'a> FunctionBody<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseFunctionBody;
-define_parser!(ParseFunctionBody, FunctionBody<'a>, |_, state| {
+define_parser!(ParseFunctionBody, FunctionBody<'a>, |_, state: ParserState<'a>| {
     let (mut state, _) = expect!(
         state,
-        ParseSymbol(Symbol::LeftParen).parse(state),
+        ParseSymbol(Symbol::LeftParen).parse(state.clone()),
         "expected '('"
     );
     let mut parameters = Vec::new();
 
     if let Ok((new_state, names)) =
-        keep_going!(OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma), false).parse(state))
+        keep_going!(OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma), false).parse(state.clone()))
     {
         state = new_state;
         parameters.extend(names.into_iter().map(Parameter::Name));
 
-        if let Ok((new_state, _)) = ParseSymbol(Symbol::Comma).parse(state) {
+        if let Ok((new_state, _)) = ParseSymbol(Symbol::Comma).parse(state.clone()) {
             if let Ok((new_state, ellipse)) = ParseSymbol(Symbol::Ellipse).parse(new_state) {
                 state = new_state;
                 parameters.push(Parameter::Ellipse(ellipse));
             }
         }
-    } else if let Ok((new_state, ellipse)) = ParseSymbol(Symbol::Ellipse).parse(state) {
+    } else if let Ok((new_state, ellipse)) = ParseSymbol(Symbol::Ellipse).parse(state.clone()) {
         state = new_state;
         parameters.push(Parameter::Ellipse(ellipse));
     }
 
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::RightParen).parse(state),
+        ParseSymbol(Symbol::RightParen).parse(state.clone()),
         "expected ')'"
     );
-    let (state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+    let (state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::End).parse(state),
+        ParseSymbol(Symbol::End).parse(state.clone()),
         "expected 'end'"
     );
     Ok((state, FunctionBody { parameters, block }))
@@ -1225,9 +1226,9 @@ define_parser!(ParseFunctionBody, FunctionBody<'a>, |_, state| {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseFunction;
-define_parser!(ParseFunction, FunctionBody<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::Function).parse(state)?;
-    ParseFunctionBody.parse(state)
+define_parser!(ParseFunction, FunctionBody<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::Function).parse(state.clone())?;
+    ParseFunctionBody.parse(state.clone())
 });
 
 /// A parameter in a function declaration
@@ -1255,7 +1256,7 @@ pub enum Suffix<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseSuffix;
-define_parser!(ParseSuffix, Suffix<'a>, |_, state| parse_first_of!(state, {
+define_parser!(ParseSuffix, Suffix<'a>, |_, state: ParserState<'a>| parse_first_of!(state, {
     ParseCall => Suffix::Call,
     ParseIndex => Suffix::Index,
 }));
@@ -1283,9 +1284,9 @@ impl<'a> VarExpression<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseVarExpression;
-define_parser!(ParseVarExpression, VarExpression<'a>, |_, state| {
-    let (state, prefix) = ParsePrefix.parse(state)?;
-    let (state, suffixes) = ZeroOrMore(ParseSuffix).parse(state)?;
+define_parser!(ParseVarExpression, VarExpression<'a>, |_, state: ParserState<'a>| {
+    let (state, prefix) = ParsePrefix.parse(state.clone())?;
+    let (state, suffixes) = ZeroOrMore(ParseSuffix).parse(state.clone())?;
 
     if let Some(Suffix::Index(_)) = suffixes.last() {
         Ok((state, VarExpression { prefix, suffixes }))
@@ -1307,7 +1308,7 @@ pub enum Var<'a> {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct ParseVar;
-define_parser!(ParseVar, Var<'a>, |_, state| parse_first_of!(state, {
+define_parser!(ParseVar, Var<'a>, |_, state: ParserState<'a>| parse_first_of!(state, {
     ParseVarExpression => Var::Expression,
     ParseIdentifier => Var::Name,
 }));
@@ -1335,12 +1336,12 @@ impl<'a> Assignment<'a> {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct ParseAssignment;
-define_parser!(ParseAssignment, Assignment<'a>, |_, state| {
-    let (state, var_list) = OneOrMore(ParseVar, ParseSymbol(Symbol::Comma), false).parse(state)?;
-    let (state, _) = ParseSymbol(Symbol::Equal).parse(state)?;
+define_parser!(ParseAssignment, Assignment<'a>, |_, state: ParserState<'a>| {
+    let (state, var_list) = OneOrMore(ParseVar, ParseSymbol(Symbol::Comma), false).parse(state.clone())?;
+    let (state, _) = ParseSymbol(Symbol::Equal).parse(state.clone())?;
     let (state, expr_list) = expect!(
         state,
-        OneOrMore(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state),
+        OneOrMore(ParseExpression, ParseSymbol(Symbol::Comma), false).parse(state.clone()),
         "expected values"
     );
 
@@ -1376,11 +1377,11 @@ impl<'a> LocalFunction<'a> {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct ParseLocalFunction;
-define_parser!(ParseLocalFunction, LocalFunction<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::Local).parse(state)?;
-    let (state, _) = ParseSymbol(Symbol::Function).parse(state)?;
-    let (state, name) = expect!(state, ParseIdentifier.parse(state), "expected name");
-    let (state, func_body) = ParseFunctionBody.parse(state)?;
+define_parser!(ParseLocalFunction, LocalFunction<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::Local).parse(state.clone())?;
+    let (state, _) = ParseSymbol(Symbol::Function).parse(state.clone())?;
+    let (state, name) = expect!(state, ParseIdentifier.parse(state.clone()), "expected name");
+    let (state, func_body) = ParseFunctionBody.parse(state.clone())?;
     Ok((state, LocalFunction { name, func_body }))
 });
 
@@ -1407,16 +1408,16 @@ impl<'a> LocalAssignment<'a> {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 struct ParseLocalAssignment;
-define_parser!(ParseLocalAssignment, LocalAssignment<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::Local).parse(state)?;
+define_parser!(ParseLocalAssignment, LocalAssignment<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::Local).parse(state.clone())?;
     let (state, name_list) = expect!(
         state,
-        OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma), false).parse(state),
+        OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Comma), false).parse(state.clone()),
         "expected name"
     );
-    let (state, expr_list) = match ParseSymbol(Symbol::Equal).parse(state) {
+    let (state, expr_list) = match ParseSymbol(Symbol::Equal).parse(state.clone()) {
         Ok((state, _)) => OneOrMore(ParseExpression, ParseSymbol(Symbol::Comma), false)
-            .parse(state)
+            .parse(state.clone())
             .or_else(|_| {
                 Err(InternalAstError::UnexpectedToken {
                     token: state.peek(),
@@ -1438,12 +1439,12 @@ define_parser!(ParseLocalAssignment, LocalAssignment<'a>, |_, state| {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseDo;
-define_parser!(ParseDo, Block<'a>, |_, state| {
-    let (state, _) = ParseSymbol(Symbol::Do).parse(state)?;
-    let (state, block) = expect!(state, ParseBlock.parse(state), "expected block");
+define_parser!(ParseDo, Block<'a>, |_, state: ParserState<'a>| {
+    let (state, _) = ParseSymbol(Symbol::Do).parse(state.clone())?;
+    let (state, block) = expect!(state, ParseBlock.parse(state.clone()), "expected block");
     let (state, _) = expect!(
         state,
-        ParseSymbol(Symbol::End).parse(state),
+        ParseSymbol(Symbol::End).parse(state.clone()),
         "expected 'end'"
     );
 
@@ -1473,9 +1474,9 @@ impl<'a> FunctionCall<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseFunctionCall;
-define_parser!(ParseFunctionCall, FunctionCall<'a>, |_, state| {
-    let (state, prefix) = ParsePrefix.parse(state)?;
-    let (state, suffixes) = ZeroOrMore(ParseSuffix).parse(state)?;
+define_parser!(ParseFunctionCall, FunctionCall<'a>, |_, state: ParserState<'a>| {
+    let (state, prefix) = ParsePrefix.parse(state.clone())?;
+    let (state, suffixes) = ZeroOrMore(ParseSuffix).parse(state.clone())?;
 
     if let Some(Suffix::Call(_)) = suffixes.last() {
         Ok((state, FunctionCall { prefix, suffixes }))
@@ -1507,12 +1508,12 @@ impl<'a> FunctionName<'a> {
 
 #[derive(Clone, Debug, PartialEq)]
 struct ParseFunctionName;
-define_parser!(ParseFunctionName, FunctionName<'a>, |_, state| {
+define_parser!(ParseFunctionName, FunctionName<'a>, |_, state: ParserState<'a>| {
     let (state, names) =
-        OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Dot), false).parse(state)?;
-    let (state, colon_name) = if let Ok((state, _)) = ParseSymbol(Symbol::Colon).parse(state) {
+        OneOrMore(ParseIdentifier, ParseSymbol(Symbol::Dot), false).parse(state.clone())?;
+    let (state, colon_name) = if let Ok((state, _)) = ParseSymbol(Symbol::Colon).parse(state.clone()) {
         let (state, colon_name) =
-            expect!(state, ParseIdentifier.parse(state), "expected method name");
+            expect!(state, ParseIdentifier.parse(state.clone()), "expected method name");
         (state, Some(colon_name))
     } else {
         (state, None)
@@ -1548,16 +1549,16 @@ struct ParseFunctionDeclaration;
 define_parser!(
     ParseFunctionDeclaration,
     FunctionDeclaration<'a>,
-    |_, state| {
-        let (state, _) = ParseSymbol(Symbol::Function).parse(state)?;
+    |_, state: ParserState<'a>| {
+        let (state, _) = ParseSymbol(Symbol::Function).parse(state.clone())?;
         let (state, name) = expect!(
             state,
-            ParseFunctionName.parse(state),
+            ParseFunctionName.parse(state.clone()),
             "expected function name"
         );
         let (state, body) = expect!(
             state,
-            ParseFunctionBody.parse(state),
+            ParseFunctionBody.parse(state.clone()),
             "expected function body"
         );
         Ok((state, FunctionDeclaration { name, body }))
@@ -1594,10 +1595,10 @@ macro_rules! make_op {
 
         #[derive(Clone, Debug, PartialEq)]
         struct $parser;
-        define_parser!($parser, $enum<'a>, |_, state| {
+        define_parser!($parser, $enum<'a>, |_, state: ParserState<'a>| {
             $(
-                if let Ok((state, _)) = ParseSymbol(Symbol::$operator).parse(state) {
-                    return Ok((state, $enum::$operator(state.peek())));
+                if let Ok((state, _)) = ParseSymbol(Symbol::$operator).parse(state.clone()) {
+                    return Ok((state.clone(), $enum::$operator(state.peek())));
                 }
             )+
 
@@ -1737,7 +1738,7 @@ impl<'a> Ast<'a> {
                 state = state.advance().unwrap();
             }
 
-            match ParseBlock.parse(state) {
+            match ParseBlock.parse(state.clone()) {
                 Ok((state, block)) => {
                     if state.index == tokens.len() - 1 {
                         Ok(Ast {
@@ -1805,7 +1806,7 @@ mod tests {
             tokens: tokens.as_ptr(),
         };
 
-        let (state, commas) = ZeroOrMore(ParseSymbol(Symbol::Comma)).parse(state).unwrap();
+        let (state, commas) = ZeroOrMore(ParseSymbol(Symbol::Comma)).parse(state.clone()).unwrap();
 
         assert_eq!(
             state,
@@ -1828,7 +1829,7 @@ mod tests {
             tokens: tokens.as_ptr(),
         };
 
-        let (state, commas) = ZeroOrMore(ParseSymbol(Symbol::Comma)).parse(state).unwrap();
+        let (state, commas) = ZeroOrMore(ParseSymbol(Symbol::Comma)).parse(state.clone()).unwrap();
 
         assert_eq!(
             state,
@@ -1853,7 +1854,7 @@ mod tests {
 
         assert!(
             OneOrMore(ParseSymbol(Symbol::End), ParseSymbol(Symbol::Comma), false)
-                .parse(state)
+                .parse(state.clone())
                 .is_err()
         );
     }
@@ -1869,7 +1870,7 @@ mod tests {
 
         let (state, commas) =
             OneOrMore(ParseSymbol(Symbol::End), ParseSymbol(Symbol::Comma), false)
-                .parse(state)
+                .parse(state.clone())
                 .expect("OneOrMore failed");
 
         assert_eq!(
@@ -1894,7 +1895,7 @@ mod tests {
         };
 
         let (state, commas) = OneOrMore(ParseSymbol(Symbol::End), ParseSymbol(Symbol::Comma), true)
-            .parse(state)
+            .parse(state.clone())
             .unwrap();
 
         assert_eq!(
@@ -1920,7 +1921,7 @@ mod tests {
 
         assert!(
             OneOrMore(ParseSymbol(Symbol::End), ParseSymbol(Symbol::Comma), true)
-                .parse(state)
+                .parse(state.clone())
                 .is_err()
         );
     }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -292,7 +292,7 @@ define_parser!(
         let expecting = TokenType::Symbol { symbol: this.0 };
         let token = state.peek();
 
-        if token.token_type() == &expecting {
+        if *token.token_type() == expecting {
             Ok((state.advance().ok_or(InternalAstError::NoMatch)?, token))
         } else {
             Err(InternalAstError::NoMatch)
@@ -308,7 +308,7 @@ define_parser!(
     TokenReference<'a>,
     |_, state: ParserState<'a>| {
         let token = state.peek();
-        if let TokenType::Number { .. } = token.token_type() {
+        if let TokenType::Number { .. } = *token.token_type() {
             Ok((state.advance().ok_or(InternalAstError::NoMatch)?, token))
         } else {
             Err(InternalAstError::NoMatch)
@@ -324,7 +324,7 @@ define_parser!(
     TokenReference<'a>,
     |_, state: ParserState<'a>| {
         let token = state.peek();
-        if let TokenType::StringLiteral { .. } = token.token_type() {
+        if let TokenType::StringLiteral { .. } = *token.token_type() {
             Ok((state.advance().ok_or(InternalAstError::NoMatch)?, token))
         } else {
             Err(InternalAstError::NoMatch)
@@ -1735,7 +1735,7 @@ struct ParseIdentifier;
 #[rustfmt::skip]
 define_parser!(ParseIdentifier, TokenReference<'a>, |_, state: ParserState<'a>| {
     let next_token = state.peek();
-    match &next_token.token_type() {
+    match &*next_token.token_type() {
         TokenType::Identifier { .. } => Ok((
             state.advance().ok_or(InternalAstError::NoMatch)?,
             next_token,
@@ -1873,7 +1873,7 @@ impl<'a> Ast<'a> {
     /// More likely, if the tokens pass are invalid Lua 5.1 code, an
     /// UnexpectedToken error will be returned.
     pub fn from_tokens(tokens: Vec<Token<'a>>) -> Result<Ast<'a>, AstError<'a>> {
-        if tokens.last().ok_or(AstError::Empty)?.token_type() != &TokenType::Eof {
+        if *tokens.last().ok_or(AstError::Empty)?.token_type() != TokenType::Eof {
             Err(AstError::NoEof)
         } else {
             let tokens = Arc::new(Arena::from_iter(tokens));

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,4 +1,4 @@
-use crate::tokenizer::{Symbol, Token, TokenReference, TokenType};
+use crate::tokenizer::{Symbol, Token, TokenKind, TokenReference, TokenType};
 use full_moon_derive::Visit;
 use generational_arena::Arena;
 use itertools::Itertools;
@@ -308,7 +308,7 @@ define_parser!(
     TokenReference<'a>,
     |_, state: ParserState<'a>| {
         let token = state.peek();
-        if let TokenType::Number { .. } = *token.token_type() {
+        if token.token_kind() == TokenKind::Number {
             Ok((state.advance().ok_or(InternalAstError::NoMatch)?, token))
         } else {
             Err(InternalAstError::NoMatch)
@@ -324,7 +324,7 @@ define_parser!(
     TokenReference<'a>,
     |_, state: ParserState<'a>| {
         let token = state.peek();
-        if let TokenType::StringLiteral { .. } = *token.token_type() {
+        if token.token_kind() == TokenKind::StringLiteral {
             Ok((state.advance().ok_or(InternalAstError::NoMatch)?, token))
         } else {
             Err(InternalAstError::NoMatch)
@@ -1735,8 +1735,8 @@ struct ParseIdentifier;
 #[rustfmt::skip]
 define_parser!(ParseIdentifier, TokenReference<'a>, |_, state: ParserState<'a>| {
     let next_token = state.peek();
-    match &*next_token.token_type() {
-        TokenType::Identifier { .. } => Ok((
+    match next_token.token_kind() {
+        TokenKind::Identifier => Ok((
             state.advance().ok_or(InternalAstError::NoMatch)?,
             next_token,
         )),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1556,6 +1556,7 @@ impl<'a> LocalAssignment<'a> {
         self.name_list.iter()
     }
 
+    /// A mutable iterator over the names being assigned to, the `x, y` part of `local x, y = 1, 2`
     pub fn iter_name_list_mut(&mut self) -> impl Iterator<Item = &mut TokenReference<'a>> {
         self.name_list.iter_mut()
     }
@@ -1957,6 +1958,8 @@ impl<'a> Ast<'a> {
         self.tokens.iter().map(|(_, token)| token).sorted()
     }
 
+    /// Will update the positions of all the tokens in the tree
+    /// Necessary if you are both mutating the tree and need the positions of the tokens
     pub fn update_positions(&mut self) {
         use crate::tokenizer::Position;
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1959,6 +1959,7 @@ impl<'a> Ast<'a> {
 
     pub fn update_positions(&mut self) {
         use crate::tokenizer::Position;
+
         let mut start_position = Position {
             bytes: 0,
             character: 1,
@@ -1970,14 +1971,10 @@ impl<'a> Ast<'a> {
         for (_, token) in self.tokens.iter() {
             let display = token.to_string();
 
-            let new_lines = match display
-                .as_bytes()
-                .iter()
-                .filter(|&&c| c == b'\n')
-                .count() {
-                    0 | 1 => 0,
-                    n => n,
-                };
+            let new_lines = match bytecount::count(display.as_bytes(), b'\n') {
+                0 | 1 => 0,
+                n => n,
+            };
 
             let end_position = if token.token_kind() == TokenKind::Eof {
                 start_position

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,7 +3,6 @@ use full_moon_derive::Visit;
 use generational_arena::Arena;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
 use std::fmt;
 use std::iter::FromIterator;
 use std::sync::Arc;
@@ -24,7 +23,7 @@ impl<'a> ParserState<'a> {
             state = ParserState {
                 index: state.index + 1,
                 len: self.len,
-                tokens: self.tokens,
+                tokens: Arc::clone(&self.tokens),
             };
 
             if !state.peek().token_type().ignore() {
@@ -1907,20 +1906,20 @@ impl<'a> Ast<'a> {
                         })
                     } else {
                         Err(AstError::UnexpectedToken {
-                            token: *state.peek(),
+                            token: (*state.peek()).to_owned(),
                             additional: Some("leftover token"),
                         })
                     }
                 }
 
                 Err(InternalAstError::NoMatch) => Err(AstError::UnexpectedToken {
-                    token: *state.peek(),
+                    token: (*state.peek()).to_owned(),
                     additional: None,
                 }),
 
                 Err(InternalAstError::UnexpectedToken { token, additional }) => {
                     Err(AstError::UnexpectedToken {
-                        token: *token,
+                        token: (*token).to_owned(),
                         additional,
                     })
                 }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,6 +1,7 @@
 use crate::tokenizer::{Symbol, Token, TokenReference, TokenType};
 use full_moon_derive::Visit;
 use generational_arena::Arena;
+use itertools::Itertools;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -50,6 +51,7 @@ impl<'a> ParserState<'a> {
             index: self
                 .tokens
                 .iter()
+                .sorted_by(|left, right| left.1.cmp(&right.1))
                 .nth(self.index)
                 .expect("couldn't peek, no eof?")
                 .0,
@@ -1948,7 +1950,7 @@ impl<'a> Ast<'a> {
 
     /// An iterator over the tokens used to create the Ast
     pub fn iter_tokens(&self) -> impl Iterator<Item = &Token<'a>> {
-        self.tokens.iter().map(|(_, token)| token)
+        self.tokens.iter().map(|(_, token)| token).sorted()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 
 //! # Full Moon
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 
 //! # Full Moon
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn parse(code: &str) -> Result<ast::Ast, Error> {
 }
 
 /// Prints back Lua code from an [Ast](ast/struct.Ast.html)
-pub fn print<'a>(ast: &'a ast::Ast<'a>) -> String {
+pub fn print(ast: &ast::Ast) -> String {
     ast.iter_tokens()
         .fold(String::new(), |acc, token| acc + &token.to_string())
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -258,6 +258,10 @@ impl<'a> Token<'a> {
     }
 }
 
+// Token provides no mutability on its own, and all official ways
+// of mutating Token require &mut self.
+unsafe impl<'a> Sync for Token<'a> {}
+
 impl<'a> fmt::Display for Token<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         use self::TokenType::*;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -294,7 +294,9 @@ impl<'ast> VisitMut<'ast> for Token<'ast> {
 pub enum TokenReference<'a> {
     /// Token is borrowed from an Ast's arena
     Borrowed {
+        #[doc(hidden)]
         arena: Arc<Arena<Token<'a>>>,
+        #[doc(hidden)]
         index: Index,
     },
 
@@ -308,7 +310,7 @@ impl<'a> std::ops::Deref for TokenReference<'a> {
     fn deref(&self) -> &Self::Target {
         match self {
             TokenReference::Borrowed { arena, index } => {
-                Arc::clone(&arena).get(*index).expect("arena doesn't have index?")
+                arena.get(*index).expect("arena doesn't have index?")
             }
 
             TokenReference::Owned(token) => &token
@@ -341,8 +343,8 @@ impl<'ast> Visit<'ast> for TokenReference<'ast> {
 }
 
 impl<'ast> VisitMut<'ast> for TokenReference<'ast> {
-    fn visit_mut<V: VisitorMut<'ast>>(&mut self, visitor: &mut V) {
-        (**self).visit_mut(visitor);
+    fn visit_mut<V: VisitorMut<'ast>>(&mut self, _visitor: &mut V) {
+        unimplemented!()
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -313,7 +313,7 @@ impl<'a> std::ops::Deref for TokenReference<'a> {
                 arena.get(*index).expect("arena doesn't have index?")
             }
 
-            TokenReference::Owned(token) => &token
+            TokenReference::Owned(token) => &token,
         }
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -231,10 +231,10 @@ pub enum TokenKind {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Token<'a> {
-    start_position: Cell<Position>,
-    end_position: Cell<Position>,
+    pub(crate) start_position: Cell<Position>,
+    pub(crate) end_position: Cell<Position>,
     #[cfg_attr(feature = "serde", serde(borrow))]
-    token_type: RefCell<TokenType<'a>>,
+    pub(crate) token_type: RefCell<TokenType<'a>>,
 }
 
 impl<'a> Token<'a> {
@@ -367,7 +367,7 @@ impl<'a> PartialEq<Self> for TokenReference<'a> {
     }
 }
 
-impl<'a> Eq for TokenReference<'a> { }
+impl<'a> Eq for TokenReference<'a> {}
 
 impl<'a> Ord for TokenReference<'a> {
     fn cmp(&self, other: &Self) -> Ordering {
@@ -429,9 +429,9 @@ impl<'ast> VisitMut<'ast> for TokenReference<'ast> {
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Position {
-    bytes: usize,
-    character: usize,
-    line: usize,
+    pub(crate) bytes: usize,
+    pub(crate) character: usize,
+    pub(crate) line: usize,
 }
 
 impl Position {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -253,11 +253,6 @@ impl<'a> Token<'a> {
         self.token_type.borrow()
     }
 
-    /// The type of token as well as the data needed to represent it
-    pub fn token_type_mut(&mut self) -> std::cell::RefMut<TokenType<'a>> {
-        self.token_type.borrow_mut()
-    }
-
     pub fn token_kind(&self) -> TokenKind {
         self.token_type().kind()
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -201,6 +201,19 @@ impl<'a> TokenType<'a> {
         }
     }
 
+    /// Returns the [`TokenKind`](enum.TokenKind.html) of the token type.
+    ///
+    /// ```rust
+    /// use std::borrow::Cow;
+    /// use full_moon::tokenizer::{TokenKind, TokenType};
+    ///
+    /// assert_eq!(
+    ///     TokenType::Identifier {
+    ///         identifier: Cow::from("hello")
+    ///     }.kind(),
+    ///     TokenKind::Identifier,
+    /// );
+    /// ```
     pub fn kind(&self) -> TokenKind {
         match self {
             TokenType::Eof => TokenKind::Eof,
@@ -215,15 +228,24 @@ impl<'a> TokenType<'a> {
     }
 }
 
+/// The kind of token. Contains no additional data.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TokenKind {
+    /// End of file, should always be the very last token
     Eof,
+    /// An identifier, such as `foo`
     Identifier,
+    /// A multi line comment in the format of --[[ comment ]]
     MultiLineComment,
+    /// A literal number, such as `3.3`
     Number,
+    /// A single line comment, such as `-- comment`
     SingleLineComment,
+    /// A literal string, such as "Hello, world"
     StringLiteral,
+    /// A [`Symbol`](enum.Symbol.html), such as `local` or `+`
     Symbol,
+    /// Whitespace, such as tabs or new lines
     Whitespace,
 }
 
@@ -248,11 +270,14 @@ impl<'a> Token<'a> {
         self.end_position.get()
     }
 
-    /// The type of token as well as the data needed to represent it
+    /// The [type](enum.TokenType.html) of token as well as the data needed to represent it
+    /// If you don't need any other information, use [`token_kind`](#method.token_kind) instead.
     pub fn token_type(&self) -> std::cell::Ref<TokenType<'a>> {
         self.token_type.borrow()
     }
 
+    /// The [kind](enum.TokenKind.html) of token with no additional data.
+    /// If you need any information such as idenitfier names, use [`token_type`](#method.token_type) instead.
     pub fn token_kind(&self) -> TokenKind {
         self.token_type().kind()
     }
@@ -321,15 +346,8 @@ pub enum TokenReference<'a> {
 }
 
 impl<'a> TokenReference<'a> {
-    pub fn set_start_position(&mut self, new_position: Position) {
-        self.start_position.set(new_position);
-    }
-
-    /// Set a new end position for the token.
-    pub fn set_end_position(&mut self, new_position: Position) {
-        self.end_position.set(new_position);
-    }
-
+    /// Sets the type of token. Note that positions will not update after using this function.
+    /// If you need them to, call [`Ast::update_positions`](../ast/struct.Ast.html#method.update_positions)
     pub fn set_token_type(&mut self, new_token_type: TokenType<'a>) {
         *self.token_type.borrow_mut() = new_token_type;
     }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -338,7 +338,7 @@ pub enum TokenReference<'a> {
     },
 
     /// Token reference was manually created, likely through deserialization
-    Owned(Token<'a>),
+    Owned(#[doc(hidden)] Token<'a>),
 }
 
 impl<'a> TokenReference<'a> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -397,8 +397,17 @@ impl<'ast> Visit<'ast> for TokenReference<'ast> {
 }
 
 impl<'ast> VisitMut<'ast> for TokenReference<'ast> {
-    fn visit_mut<V: VisitorMut<'ast>>(&mut self, _visitor: &mut V) {
-        unimplemented!()
+    fn visit_mut<V: VisitorMut<'ast>>(&mut self, visitor: &mut V) {
+        match self.token_kind() {
+            TokenKind::Eof => visitor.visit_eof(self),
+            TokenKind::Identifier => visitor.visit_identifier(self),
+            TokenKind::MultiLineComment => visitor.visit_multi_line_comment(self),
+            TokenKind::Number => visitor.visit_number(self),
+            TokenKind::SingleLineComment => visitor.visit_single_line_comment(self),
+            TokenKind::StringLiteral => visitor.visit_string_literal(self),
+            TokenKind::Symbol => visitor.visit_symbol(self),
+            TokenKind::Whitespace => visitor.visit_whitespace(self),
+        }
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -283,10 +283,6 @@ impl<'a> Token<'a> {
     }
 }
 
-// Token provides no mutability on its own, and all official ways
-// of mutating Token require &mut self.
-unsafe impl<'a> Sync for Token<'a> {}
-
 impl<'a> fmt::Display for Token<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         use self::TokenType::*;

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -321,6 +321,21 @@ pub enum TokenReference<'a> {
     Owned(Token<'a>),
 }
 
+impl<'a> TokenReference<'a> {
+    pub fn set_start_position(&mut self, new_position: Position) {
+        self.start_position.set(new_position);
+    }
+
+    /// Set a new end position for the token.
+    pub fn set_end_position(&mut self, new_position: Position) {
+        self.end_position.set(new_position);
+    }
+
+    pub fn set_token_type(&mut self, new_token_type: TokenType<'a>) {
+        *self.token_type.borrow_mut() = new_token_type;
+    }
+}
+
 impl<'a> std::ops::Deref for TokenReference<'a> {
     type Target = Token<'a>;
 
@@ -408,32 +423,6 @@ impl<'ast> VisitMut<'ast> for TokenReference<'ast> {
             TokenKind::Symbol => visitor.visit_symbol(self),
             TokenKind::Whitespace => visitor.visit_whitespace(self),
         }
-    }
-}
-
-/// A [RAII](https://en.wikipedia.org/wiki/Resource_acquisition_is_initialization) guard for mutating
-/// [`Token`](struct.Token.html) objects from a [`TokenReference`](enum.TokenReference.html).
-pub struct TokenReferenceGuard<'a> {
-    token: &'a Token<'a>,
-}
-
-impl<'a> TokenReferenceGuard<'a> {
-    /// Set a new start position for the token.
-    pub fn set_start_position(&mut self, new_position: Position) {
-        self.token.start_position.set(new_position);
-    }
-
-    /// Set a new end position for the token.
-    pub fn set_end_position(&mut self, new_position: Position) {
-        self.token.end_position.set(new_position);
-    }
-}
-
-impl<'a> std::ops::Deref for TokenReferenceGuard<'a> {
-    type Target = Token<'a>;
-
-    fn deref(&self) -> &Self::Target {
-        self.token
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -821,7 +821,7 @@ mod tests {
                 Ok(Some(token)) => {
                     let tokens = tokens($code).expect("couldn't tokenize");
                     let first_token = &tokens.get(0).expect("tokenized response is empty");
-                    assert_eq!(first_token.token_type, token.token_type);
+                    assert_eq!(*first_token.token_type(), token.token_type);
                 }
 
                 Err(advancement_error) => {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -330,15 +330,15 @@ impl<'a> PartialOrd for Token<'a> {
 #[derive(Clone)]
 pub enum TokenReference<'a> {
     /// Token is borrowed from an Ast's arena
+    #[doc(hidden)]
     Borrowed {
-        #[doc(hidden)]
         arena: Arc<Arena<Token<'a>>>,
-        #[doc(hidden)]
         index: Index,
     },
 
     /// Token reference was manually created, likely through deserialization
-    Owned(#[doc(hidden)] Token<'a>),
+    #[doc(hidden)]
+    Owned(Token<'a>),
 }
 
 impl<'a> TokenReference<'a> {

--- a/src/visitors.rs
+++ b/src/visitors.rs
@@ -1,5 +1,5 @@
 use crate::ast;
-use crate::tokenizer::Token;
+use crate::tokenizer::TokenReference;
 use std::borrow::Cow;
 
 macro_rules! create_visitor {
@@ -46,7 +46,7 @@ macro_rules! create_visitor {
 
             $(
                 #[allow(missing_docs)]
-                fn $visit_token(&mut self, _token: &Token<'ast>) { }
+                fn $visit_token(&mut self, _token: &TokenReference<'ast>) { }
             )+
         }
 
@@ -65,7 +65,7 @@ macro_rules! create_visitor {
 
             $(
                 #[allow(missing_docs)]
-                fn $visit_token(&mut self, _token: &mut Token<'ast>) { }
+                fn $visit_token(&mut self, _token: &mut TokenReference<'ast>) { }
             )+
         }
     };

--- a/tests/fail_cases.rs
+++ b/tests/fail_cases.rs
@@ -13,14 +13,16 @@ fn test_parser_fail_cases() {
         let entry = entry.unwrap();
         let path = entry.path();
         let source = fs::read_to_string(path.join("source.lua")).expect("couldn't read source.lua");
-        println!("testing {:?}", path);
 
         let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
 
         let tokens_path = path.join("tokens.json");
-        if let Ok(tokens_file) = fs::read_to_string(&tokens_path) {
+        let tokens_contents;
+
+        if let Ok(tokens_contents_tmp) = fs::read_to_string(&tokens_path) {
+            tokens_contents = tokens_contents_tmp;
             let expected_tokens: Vec<Token> =
-                serde_json::from_str(&tokens_file).expect("couldn't deserialize tokens file");
+                serde_json::from_str(&tokens_contents).expect("couldn't deserialize tokens file");
             assert_eq!(tokens, expected_tokens);
         } else {
             let mut file = File::create(&tokens_path).expect("couldn't write tokens file");

--- a/tests/pass_cases.rs
+++ b/tests/pass_cases.rs
@@ -34,10 +34,23 @@ fn test_pass_cases() {
             .expect("couldn't write to tokens file");
         }
 
-        let ast = ast::Ast::from_tokens(tokens)
+        let mut ast = ast::Ast::from_tokens(tokens)
             .unwrap_or_else(|error| panic!("couldn't make ast for {:?} - {:?}", path, error));
 
+        let old_positions: Vec<_> = ast
+            .iter_tokens()
+            .map(|token| (token.start_position(), token.end_position()))
+            .collect();
+        ast.update_positions();
+        assert_eq!(
+            old_positions,
+            ast.iter_tokens()
+                .map(|token| (token.start_position(), token.end_position()))
+                .collect::<Vec<_>>(),
+        );
+
         let ast_path = path.join("ast.json");
+
         if let Ok(ast_file) = fs::read_to_string(&ast_path) {
             let expected_ast =
                 serde_json::from_str(&ast_file).expect("couldn't deserialize ast file");

--- a/tests/pass_cases.rs
+++ b/tests/pass_cases.rs
@@ -17,9 +17,12 @@ fn test_pass_cases() {
         let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
 
         let tokens_path = path.join("tokens.json");
-        if let Ok(tokens_file) = fs::read_to_string(&tokens_path) {
+        let tokens_contents;
+
+        if let Ok(tokens_contents_tmp) = fs::read_to_string(&tokens_path) {
+            tokens_contents = tokens_contents_tmp;
             let expected_tokens: Vec<Token> =
-                serde_json::from_str(&tokens_file).expect("couldn't deserialize tokens file");
+                serde_json::from_str(&tokens_contents).expect("couldn't deserialize tokens file");
             assert_eq!(tokens, expected_tokens);
         } else {
             let mut file = File::create(&tokens_path).expect("couldn't write tokens file");

--- a/tests/visitors.rs
+++ b/tests/visitors.rs
@@ -65,7 +65,10 @@ fn test_visitor_mut() {
     impl<'ast> Visitor<'ast> for PositionValidator {
         fn visit_local_assignment(&mut self, assignment: &ast::LocalAssignment<'ast>) {
             for name in assignment.iter_name_list() {
-                assert_eq!(name.end_position().bytes() - name.start_position().bytes(), name.to_string().len());
+                assert_eq!(
+                    name.end_position().bytes() - name.start_position().bytes(),
+                    name.to_string().len()
+                );
             }
         }
     }

--- a/tests/visitors.rs
+++ b/tests/visitors.rs
@@ -44,9 +44,16 @@ fn test_visitor_mut() {
                     _ => unreachable!(),
                 }
 
+                let identifier_len = identifier.len();
+
                 name.set_token_type(tokenizer::TokenType::Identifier {
                     identifier: Cow::from(identifier),
                 });
+
+                assert_eq!(
+                    name.end_position().character() - name.start_position().character(),
+                    identifier_len,
+                );
             }
         }
     }

--- a/tests/visitors.rs
+++ b/tests/visitors.rs
@@ -1,4 +1,5 @@
-use full_moon::{ast, parse, visitors::Visitor};
+use full_moon::{ast, parse, print, tokenizer, visitors::{Visitor, VisitorMut}};
+use std::borrow::Cow;
 
 #[test]
 fn test_visitor() {
@@ -24,4 +25,33 @@ fn test_visitor() {
     visitor.visit_ast(&code);
 
     assert_eq!(visitor.called, vec!["foo", "bar"]);
+}
+
+#[test]
+fn test_visitor_mut() {
+    struct SnakeNamer;
+
+    impl<'ast> VisitorMut<'ast> for SnakeNamer {
+        fn visit_local_assignment(&mut self, assignment: &mut ast::LocalAssignment<'ast>) {
+            for name in assignment.iter_name_list_mut() {
+                let identifier;
+
+                match *name.token_type() {
+                    tokenizer::TokenType::Identifier { identifier: ref identifier_tmp } => {
+                        identifier = identifier_tmp.replace("s", "sss");
+                    },
+
+                    _ => unreachable!(),
+                }
+
+                name.set_token_type(tokenizer::TokenType::Identifier {
+                    identifier: Cow::from(identifier),
+                });
+            }
+        }
+    }
+
+    let mut code = parse("local dogs, snakes = 1").unwrap();
+    SnakeNamer.visit_ast(&mut code);
+    assert_eq!(print(&code), "local dogsss, sssnakesss = 1");
 }


### PR DESCRIPTION
Tokenization may have gotten slower, but I'm not sure by how much. ParserState is no longer a simple Copy, but now contains an Arc that needs to be cloned.

Closes #16, and opens up the door for mutability.

TODO:
- [x] Implement PartialOrd/Ord for Position, and then Token
- [x] Change `Ast::iter_tokens` to sort by position, as Arena iteration is undefined
- [x] Figure out how `VisitMut` should be implemented for `TokenReference`