### PR TITLE
Fix #41

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -579,7 +579,7 @@ impl<'a> fmt::Display for StringLiteralQuoteType {
 lazy_static! {
     static ref PATTERN_IDENTIFIER: Regex = Regex::new(r"[^\W\d]+\w*").unwrap();
     static ref PATTERN_NUMBER: Regex =
-        Regex::new(r"^((-?0x[A-Fa-f\d]+)|(-?((\d*\.\d+)|(\d+))([eE]-?\d+)?))").unwrap();
+        Regex::new(r"^((0x[A-Fa-f\d]+)|(((\d*\.\d+)|(\d+))([eE]-?\d+)?))").unwrap();
     static ref PATTERN_COMMENT_MULTI_LINE_BEGIN: Regex = Regex::new(r"--\[(=*)\[").unwrap();
     static ref PATTERN_COMMENT_SINGLE_LINE: Regex = Regex::new(r"--([^\n]*)").unwrap();
     static ref PATTERN_STRING_MULTI_LINE_BEGIN: Regex = Regex::new(r"\[(=*)\[").unwrap();

--- a/tests/cases/pass/negative-numbers/ast.json
+++ b/tests/cases/pass/negative-numbers/ast.json
@@ -1,0 +1,422 @@
+{
+  "stmts": [
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "start_position": {
+              "bytes": 0,
+              "character": 1,
+              "line": 1
+            },
+            "end_position": {
+              "bytes": 5,
+              "character": 6,
+              "line": 1
+            },
+            "token_type": {
+              "type": "Symbol",
+              "symbol": "local"
+            }
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "start_position": {
+                    "bytes": 6,
+                    "character": 7,
+                    "line": 1
+                  },
+                  "end_position": {
+                    "bytes": 9,
+                    "character": 10,
+                    "line": 1
+                  },
+                  "token_type": {
+                    "type": "Identifier",
+                    "identifier": "foo"
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "start_position": {
+              "bytes": 10,
+              "character": 11,
+              "line": 1
+            },
+            "end_position": {
+              "bytes": 11,
+              "character": 12,
+              "line": 1
+            },
+            "token_type": {
+              "type": "Symbol",
+              "symbol": "="
+            }
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Var": {
+                      "Name": {
+                        "start_position": {
+                          "bytes": 12,
+                          "character": 13,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 13,
+                          "character": 14,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Identifier",
+                          "identifier": "x"
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "bin_op": {
+                      "Minus": {
+                        "start_position": {
+                          "bytes": 13,
+                          "character": 14,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 14,
+                          "character": 15,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "-"
+                        }
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Number": {
+                          "start_position": {
+                            "bytes": 14,
+                            "character": 15,
+                            "line": 1
+                          },
+                          "end_position": {
+                            "bytes": 15,
+                            "character": 16,
+                            "line": 1
+                          },
+                          "token_type": {
+                            "type": "Number",
+                            "text": "1"
+                          }
+                        }
+                      },
+                      "binop": null
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "start_position": {
+              "bytes": 16,
+              "character": 16,
+              "line": 1
+            },
+            "end_position": {
+              "bytes": 21,
+              "character": 6,
+              "line": 2
+            },
+            "token_type": {
+              "type": "Symbol",
+              "symbol": "local"
+            }
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "start_position": {
+                    "bytes": 22,
+                    "character": 7,
+                    "line": 2
+                  },
+                  "end_position": {
+                    "bytes": 25,
+                    "character": 10,
+                    "line": 2
+                  },
+                  "token_type": {
+                    "type": "Identifier",
+                    "identifier": "foo"
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "start_position": {
+              "bytes": 26,
+              "character": 11,
+              "line": 2
+            },
+            "end_position": {
+              "bytes": 27,
+              "character": 12,
+              "line": 2
+            },
+            "token_type": {
+              "type": "Symbol",
+              "symbol": "="
+            }
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Var": {
+                      "Name": {
+                        "start_position": {
+                          "bytes": 28,
+                          "character": 13,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 29,
+                          "character": 14,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Identifier",
+                          "identifier": "x"
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "bin_op": {
+                      "Minus": {
+                        "start_position": {
+                          "bytes": 30,
+                          "character": 15,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 31,
+                          "character": 16,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "-"
+                        }
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Number": {
+                          "start_position": {
+                            "bytes": 31,
+                            "character": 16,
+                            "line": 2
+                          },
+                          "end_position": {
+                            "bytes": 32,
+                            "character": 17,
+                            "line": 2
+                          },
+                          "token_type": {
+                            "type": "Number",
+                            "text": "1"
+                          }
+                        }
+                      },
+                      "binop": null
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "FunctionCall": {
+          "prefix": {
+            "Name": {
+              "start_position": {
+                "bytes": 33,
+                "character": 17,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 38,
+                "character": 6,
+                "line": 3
+              },
+              "token_type": {
+                "type": "Identifier",
+                "identifier": "print"
+              }
+            }
+          },
+          "suffixes": [
+            {
+              "Call": {
+                "AnonymousCall": {
+                  "Parentheses": {
+                    "arguments": {
+                      "pairs": [
+                        {
+                          "End": {
+                            "value": {
+                              "Number": {
+                                "start_position": {
+                                  "bytes": 39,
+                                  "character": 7,
+                                  "line": 3
+                                },
+                                "end_position": {
+                                  "bytes": 40,
+                                  "character": 8,
+                                  "line": 3
+                                },
+                                "token_type": {
+                                  "type": "Number",
+                                  "text": "1"
+                                }
+                              }
+                            },
+                            "binop": {
+                              "bin_op": {
+                                "Plus": {
+                                  "start_position": {
+                                    "bytes": 40,
+                                    "character": 8,
+                                    "line": 3
+                                  },
+                                  "end_position": {
+                                    "bytes": 41,
+                                    "character": 9,
+                                    "line": 3
+                                  },
+                                  "token_type": {
+                                    "type": "Symbol",
+                                    "symbol": "+"
+                                  }
+                                }
+                              },
+                              "rhs": {
+                                "unop": {
+                                  "Minus": {
+                                    "start_position": {
+                                      "bytes": 41,
+                                      "character": 9,
+                                      "line": 3
+                                    },
+                                    "end_position": {
+                                      "bytes": 42,
+                                      "character": 10,
+                                      "line": 3
+                                    },
+                                    "token_type": {
+                                      "type": "Symbol",
+                                      "symbol": "-"
+                                    }
+                                  }
+                                },
+                                "expression": {
+                                  "value": {
+                                    "Number": {
+                                      "start_position": {
+                                        "bytes": 42,
+                                        "character": 10,
+                                        "line": 3
+                                      },
+                                      "end_position": {
+                                        "bytes": 43,
+                                        "character": 11,
+                                        "line": 3
+                                      },
+                                      "token_type": {
+                                        "type": "Number",
+                                        "text": "3"
+                                      }
+                                    }
+                                  },
+                                  "binop": null
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "parentheses": {
+                      "tokens": [
+                        {
+                          "start_position": {
+                            "bytes": 38,
+                            "character": 6,
+                            "line": 3
+                          },
+                          "end_position": {
+                            "bytes": 39,
+                            "character": 7,
+                            "line": 3
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "("
+                          }
+                        },
+                        {
+                          "start_position": {
+                            "bytes": 43,
+                            "character": 11,
+                            "line": 3
+                          },
+                          "end_position": {
+                            "bytes": 44,
+                            "character": 12,
+                            "line": 3
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": ")"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      null
+    ]
+  ]
+}

--- a/tests/cases/pass/negative-numbers/source.lua
+++ b/tests/cases/pass/negative-numbers/source.lua
@@ -1,0 +1,3 @@
+local foo = x-1
+local foo = x -1
+print(1+-3)

--- a/tests/cases/pass/negative-numbers/tokens.json
+++ b/tests/cases/pass/negative-numbers/tokens.json
@@ -1,0 +1,481 @@
+[
+  {
+    "start_position": {
+      "bytes": 0,
+      "character": 1,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "foo"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 13,
+      "character": 14,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "x"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 13,
+      "character": 14,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 14,
+      "character": 15,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "-"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 14,
+      "character": 15,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 16,
+      "character": 16,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 16,
+      "character": 16,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 21,
+      "character": 6,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 21,
+      "character": 6,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 22,
+      "character": 7,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 22,
+      "character": 7,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 25,
+      "character": 10,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "foo"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 25,
+      "character": 10,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 26,
+      "character": 11,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 26,
+      "character": 11,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 27,
+      "character": 12,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 27,
+      "character": 12,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 28,
+      "character": 13,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 28,
+      "character": 13,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 29,
+      "character": 14,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "x"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 29,
+      "character": 14,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 30,
+      "character": 15,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 30,
+      "character": 15,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 31,
+      "character": 16,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "-"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 31,
+      "character": 16,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 32,
+      "character": 17,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 32,
+      "character": 17,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 33,
+      "character": 17,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 33,
+      "character": 17,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 38,
+      "character": 6,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "print"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 38,
+      "character": 6,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 39,
+      "character": 7,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "("
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 39,
+      "character": 7,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 40,
+      "character": 8,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 40,
+      "character": 8,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 41,
+      "character": 9,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "+"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 41,
+      "character": 9,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 42,
+      "character": 10,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "-"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 42,
+      "character": 10,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 43,
+      "character": 11,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "3"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 43,
+      "character": 11,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 44,
+      "character": 12,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": ")"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 44,
+      "character": 12,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 45,
+      "character": 12,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 45,
+      "character": 12,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 45,
+      "character": 12,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Eof"
+    }
+  }
+]

--- a/tests/cases/pass/unops/ast.json
+++ b/tests/cases/pass/unops/ast.json
@@ -61,25 +61,45 @@
             "pairs": [
               {
                 "End": {
-                  "value": {
-                    "Number": {
+                  "unop": {
+                    "Minus": {
                       "start_position": {
                         "bytes": 24,
                         "character": 25,
                         "line": 1
                       },
                       "end_position": {
-                        "bytes": 26,
-                        "character": 27,
+                        "bytes": 25,
+                        "character": 26,
                         "line": 1
                       },
                       "token_type": {
-                        "type": "Number",
-                        "text": "-3"
+                        "type": "Symbol",
+                        "symbol": "-"
                       }
                     }
                   },
-                  "binop": null
+                  "expression": {
+                    "value": {
+                      "Number": {
+                        "start_position": {
+                          "bytes": 25,
+                          "character": 26,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 26,
+                          "character": 27,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": "3"
+                        }
+                      }
+                    },
+                    "binop": null
+                  }
                 }
               }
             ]

--- a/tests/cases/pass/unops/tokens.json
+++ b/tests/cases/pass/unops/tokens.json
@@ -102,13 +102,29 @@
       "line": 1
     },
     "end_position": {
+      "bytes": 25,
+      "character": 26,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "-"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 25,
+      "character": 26,
+      "line": 1
+    },
+    "end_position": {
       "bytes": 26,
       "character": 27,
       "line": 1
     },
     "token_type": {
       "type": "Number",
-      "text": "-3"
+      "text": "3"
     }
   },
   {


### PR DESCRIPTION
No longer treats `-42` as a number token, but instead as a unary operation of `-` and `42`.