### PR TITLE
Refactor some tokenize functions to use nom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.3"
 paste = "0.1"
 regex = "1.1"
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
-nom = "5.0.1"
+nom = "5.0"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ lazy_static = "1.3"
 paste = "0.1"
 regex = "1.1"
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
+nom = "5.0.1"
 
 [dev-dependencies]
 criterion = "0.2"

--- a/full-moon-derive/Cargo.toml
+++ b/full-moon-derive/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
+indexmap = "1.3"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["extra-traits"] }

--- a/full-moon-derive/src/lib.rs
+++ b/full-moon-derive/src/lib.rs
@@ -5,6 +5,7 @@ extern crate proc_macro;
 mod derive;
 mod node;
 mod owned;
+mod symbols;
 mod visit;
 
 use derive::DeriveGenerator;
@@ -24,4 +25,9 @@ pub fn derive_node(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(Owned)]
 pub fn derive_owned(input: TokenStream) -> TokenStream {
     owned::OwnedGenerator::derive(input)
+}
+
+#[proc_macro]
+pub fn symbols(input: TokenStream) -> TokenStream {
+    symbols::parse(input.into())
 }

--- a/full-moon-derive/src/symbols.rs
+++ b/full-moon-derive/src/symbols.rs
@@ -1,0 +1,139 @@
+// Used to create the Symbol enum, as well as the combinator for it
+// Needed because alt() only takes up to 21 elements
+// The combinator provided will give up to 20 symbols, with the last being an alt() for the rest.
+
+use indexmap::IndexMap;
+use quote::quote;
+use syn::{
+    self,
+    parse::{Parse, ParseStream},
+    parse_macro_input, Ident, LitStr, Token,
+};
+
+const ALT_LIMIT: usize = 21;
+
+#[derive(Debug)]
+struct SymbolsInput {
+    symbols: IndexMap<Ident, LitStr>,
+}
+
+#[derive(Debug)]
+enum ParseState {
+    Ident,
+    Arrow,
+    String,
+    Comma,
+}
+
+impl Parse for SymbolsInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut looking_for = ParseState::Ident;
+        let mut current_ident = None;
+        let mut symbols = IndexMap::new();
+
+        while !input.is_empty() {
+            looking_for = match looking_for {
+                ParseState::Ident => {
+                    current_ident = Some(input.parse()?);
+                    ParseState::Arrow
+                }
+
+                ParseState::Arrow => {
+                    input.parse::<Token![=>]>()?;
+                    ParseState::String
+                }
+
+                ParseState::String => {
+                    symbols.insert(current_ident.take().unwrap(), input.parse::<LitStr>()?);
+                    ParseState::Comma
+                }
+
+                ParseState::Comma => {
+                    input.parse::<Token![,]>()?;
+                    ParseState::Ident
+                }
+            };
+        }
+
+        Ok(Self { symbols })
+    }
+}
+
+pub fn parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let symbols = parse_macro_input!(input as SymbolsInput).symbols;
+
+    let string = symbols.values().collect::<Vec<_>>();
+    let splits = string.chunks(ALT_LIMIT).map(|string| {
+        quote! {
+            alt((#(
+                tag(#string),
+            )*))
+        }
+    });
+
+    let ident: Vec<_> = symbols.keys().collect();
+
+    let output = quote! {
+        /// A literal symbol, used for both words important to syntax (like while) and operators (like +)
+        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+        pub enum Symbol {
+            #(
+                #[cfg_attr(feature = "serde", serde(rename = #string))]
+                #[allow(missing_docs)]
+                #ident,
+            )*
+        }
+
+        impl<'a> fmt::Display for Symbol {
+            fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                match *self {
+                    #(Symbol::#ident => #string,)*
+                }
+                .fmt(formatter)
+            }
+        }
+
+        impl FromStr for Symbol {
+            type Err = ();
+
+            fn from_str(string: &str) -> Result<Self, Self::Err> {
+                Ok(match string {
+                    #(#string => Symbol::#ident,)*
+                    _ => return Err(()),
+                })
+            }
+        }
+
+        fn parse_symbol(code: &str) -> IResult<&str, &str> {
+            let combinator = alt((
+                #(
+                    #splits,
+                )*
+            ));
+
+            if code.chars().next().unwrap().is_ascii_alphanumeric() {
+                let identifier = match parse_identifier(code) {
+                    Ok((_, identifier)) => identifier,
+                    Err(_) => panic!("Parsing identifier failed"),
+                };
+
+                let expected_len = identifier.len();
+                let (input, find) = combinator(code)?;
+
+                if find.len() == expected_len {
+                    Ok((input, find))
+                } else {
+                    use nom::error::ParseError;
+
+                    // TODO: How does nom produce errors?
+                    Err(nom::Err::Error(("symbol not found", nom::error::ErrorKind::Alt)))
+                }
+            } else {
+                combinator(code)
+            }
+        }
+    };
+
+    output.into()
+}

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -592,19 +592,19 @@ fn parse_multi_line_comment_start(code: &str) -> IResult<&str, &str> {
 #[inline]
 fn parse_multi_line_comment_body<'a>(
     code: &'a str,
-    equality_symbol: &'a str,
+    block_count: &'a str,
 ) -> IResult<&'a str, &'a str> {
     recognize(many_till(
         anychar,
-        recognize(tuple((tag("]"), tag(equality_symbol), tag("]")))),
+        recognize(tuple((tag("]"), tag(block_count), tag("]")))),
     ))(code)
 }
 
 fn advance_comment(code: &str) -> Advancement {
-    if let Ok((code, equality_symbol)) = parse_multi_line_comment_start(code) {
-        return match parse_multi_line_comment_body(code, equality_symbol) {
+    if let Ok((code, block_count)) = parse_multi_line_comment_start(code) {
+        return match parse_multi_line_comment_body(code, block_count) {
             Ok((_, comment)) => {
-                let blocks = equality_symbol.len();
+                let blocks = block_count.len();
                 // Get the comment without the ending "]]"
                 let comment = &comment[..(comment.len() - "]]".len() - blocks)];
                 Ok(Some(TokenAdvancement {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -583,7 +583,6 @@ impl<'a> fmt::Display for StringLiteralQuoteType {
 }
 
 lazy_static! {
-    static ref PATTERN_IDENTIFIER: Regex = Regex::new(r"[^\W\d]+\w*").unwrap();
     static ref PATTERN_NUMBER: Regex = {
         let mut set = Vec::new();
 
@@ -765,8 +764,12 @@ fn advance_quote(code: &str) -> Advancement {
 
 fn advance_symbol(code: &str) -> Advancement {
     if code.chars().next().unwrap().is_ascii_alphanumeric() {
-        let identifier = PATTERN_IDENTIFIER.find(code).unwrap();
-        let expected_len = identifier.end() - identifier.start();
+        let identifier = match parse_identifier(code) {
+            Ok((_, identifier)) => identifier,
+            Err(_) => panic!("Parsing identifier failed"),
+        };
+
+        let expected_len = identifier.len();
 
         advance_regex!(&code[0..expected_len], PATTERN_SYMBOL, Symbol(find) {
             symbol: {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -3,8 +3,7 @@ use atomic_refcell::AtomicRefCell;
 use generational_arena::{Arena, Index};
 use lazy_static::lazy_static;
 use nom::{
-    bytes::complete::take_while,
-    character::{complete::alpha1, is_alphanumeric},
+    bytes::complete::{take_while, take_while1},
     combinator::recognize,
     sequence::pair,
     IResult,
@@ -677,9 +676,9 @@ fn advance_number(code: &str) -> Advancement {
 fn parse_identifier(code: &str) -> IResult<&str, &str> {
     recognize(pair(
         // Identifiers must start with at least 1 alphabetic character
-        alpha1,
+        take_while1(|x: char| x.is_ascii_alphabetic() || x == '_'),
         // And then they must be followed by 0 or more alphanumeric (or '_') characters
-        take_while(|x| is_alphanumeric(x as u8) || x == '_'),
+        take_while(|x: char| x.is_ascii_alphanumeric() || x == '_'),
     ))(code)
 }
 


### PR DESCRIPTION
The small unit tests in the file are succeeding but the `multi-line-comments-3` test in `tests/` is broken for some reason.