### PR TITLE
Syntax fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Updated function return type syntax under `roblox` feature flag
 
 ## [0.5.0] - 2020-04-21
 - TokenReference has been completely rewritten to now be a representation of an inner token and its leading/trailing trivia. It will eventually be renamed

--- a/src/ast/parsers.rs
+++ b/src/ast/parsers.rs
@@ -785,14 +785,14 @@ define_roblox_parser!(
     TypeSpecifier<'a>,
     Cow<'a, TokenReference<'a>>,
     |_, state: ParserState<'a>| {
-        let (state, fat_arrow) = ParseSymbol(Symbol::FatArrow).parse(state)?;
+        let (state, colon) = ParseSymbol(Symbol::Colon).parse(state)?;
         let (state, return_type) =
             expect!(state, ParseTypeInfo.parse(state), "expected return type");
 
         Ok((
             state,
             TypeSpecifier {
-                punctuation: fat_arrow,
+                punctuation: colon,
                 type_info: return_type,
             },
         ))
@@ -1226,11 +1226,11 @@ cfg_if::cfg_if! {
                     "expected `)` to match `(`"
                 );
 
-                if let Ok((state, arrow)) = ParseSymbol(Symbol::FatArrow).parse(state) {
+                if let Ok((state, arrow)) = ParseSymbol(Symbol::ThinArrow).parse(state) {
                     let (state, return_value) = expect!(
                         state,
                         ParseTypeInfo.parse(state),
-                        "expected return type after `=>`"
+                        "expected return type after `->`"
                     );
 
                     (

--- a/src/ast/types.rs
+++ b/src/ast/types.rs
@@ -28,7 +28,7 @@ pub enum TypeInfo<'a> {
         /// The argument types: `(string, number)`.
         #[cfg_attr(feature = "serde", serde(borrow))]
         arguments: Punctuated<'a, TypeInfo<'a>>,
-        /// The "fat arrow" (`=>`) in between the arguments and the return type.
+        /// The "thin arrow" (`->`) in between the arguments and the return type.
         #[cfg_attr(feature = "serde", serde(borrow))]
         arrow: Cow<'a, TokenReference<'a>>,
         /// The return type: `boolean`.

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -38,7 +38,6 @@ symbols!(
     While => "while",
 
     // TODO: This only is valid in Roblox
-    FatArrow => "=>",
     ThinArrow => "->",
     Caret => "^",
     Colon => ":",

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -39,6 +39,7 @@ symbols!(
 
     // TODO: This only is valid in Roblox
     FatArrow => "=>",
+    ThinArrow => "->",
     Caret => "^",
     Colon => ":",
     Comma => ",",

--- a/tests/roblox_cases/pass/types/ast.json
+++ b/tests/roblox_cases/pass/types/ast.json
@@ -1777,7 +1777,7 @@
                   },
                   "token_type": {
                     "type": "Symbol",
-                    "symbol": "=>"
+                    "symbol": "->"
                   }
                 },
                 "trailing_trivia": [
@@ -2128,7 +2128,7 @@
                   },
                   "token_type": {
                     "type": "Symbol",
-                    "symbol": "=>"
+                    "symbol": "->"
                   }
                 },
                 "trailing_trivia": [
@@ -2479,7 +2479,7 @@
                   },
                   "token_type": {
                     "type": "Symbol",
-                    "symbol": "=>"
+                    "symbol": "->"
                   }
                 },
                 "trailing_trivia": [
@@ -2884,7 +2884,7 @@
                   },
                   "token_type": {
                     "type": "Symbol",
-                    "symbol": "=>"
+                    "symbol": "->"
                   }
                 },
                 "trailing_trivia": [
@@ -3012,7 +3012,7 @@
                       },
                       "token_type": {
                         "type": "Symbol",
-                        "symbol": "=>"
+                        "symbol": "->"
                       }
                     },
                     "trailing_trivia": [
@@ -6320,7 +6320,7 @@
                               },
                               "end_position": {
                                 "bytes": 650,
-                                "character": 26,
+                                "character": 25,
                                 "line": 28
                               },
                               "token_type": {
@@ -6332,12 +6332,12 @@
                               {
                                 "start_position": {
                                   "bytes": 650,
-                                  "character": 26,
+                                  "character": 25,
                                   "line": 28
                                 },
                                 "end_position": {
                                   "bytes": 651,
-                                  "character": 27,
+                                  "character": 26,
                                   "line": 28
                                 },
                                 "token_type": {
@@ -6355,12 +6355,12 @@
                                   "token": {
                                     "start_position": {
                                       "bytes": 651,
-                                      "character": 27,
+                                      "character": 26,
                                       "line": 28
                                     },
                                     "end_position": {
                                       "bytes": 657,
-                                      "character": 33,
+                                      "character": 32,
                                       "line": 28
                                     },
                                     "token_type": {
@@ -6372,12 +6372,12 @@
                                     {
                                       "start_position": {
                                         "bytes": 657,
-                                        "character": 33,
+                                        "character": 32,
                                         "line": 28
                                       },
                                       "end_position": {
                                         "bytes": 658,
-                                        "character": 34,
+                                        "character": 33,
                                         "line": 28
                                       },
                                       "token_type": {
@@ -6393,12 +6393,12 @@
                                 "token": {
                                   "start_position": {
                                     "bytes": 658,
-                                    "character": 34,
+                                    "character": 33,
                                     "line": 28
                                   },
                                   "end_position": {
                                     "bytes": 659,
-                                    "character": 35,
+                                    "character": 34,
                                     "line": 28
                                   },
                                   "token_type": {
@@ -6410,12 +6410,12 @@
                                   {
                                     "start_position": {
                                       "bytes": 659,
-                                      "character": 35,
+                                      "character": 34,
                                       "line": 28
                                     },
                                     "end_position": {
                                       "bytes": 660,
-                                      "character": 36,
+                                      "character": 35,
                                       "line": 28
                                     },
                                     "token_type": {
@@ -6431,12 +6431,12 @@
                                   "token": {
                                     "start_position": {
                                       "bytes": 660,
-                                      "character": 36,
+                                      "character": 35,
                                       "line": 28
                                     },
                                     "end_position": {
                                       "bytes": 663,
-                                      "character": 39,
+                                      "character": 38,
                                       "line": 28
                                     },
                                     "token_type": {
@@ -6460,7 +6460,7 @@
                                     {
                                       "start_position": {
                                         "bytes": 663,
-                                        "character": 39,
+                                        "character": 38,
                                         "line": 28
                                       },
                                       "end_position": {

--- a/tests/roblox_cases/pass/types/ast.json
+++ b/tests/roblox_cases/pass/types/ast.json
@@ -5401,25 +5401,25 @@
                     "line": 21
                   },
                   "end_position": {
-                    "bytes": 555,
-                    "character": 31,
+                    "bytes": 554,
+                    "character": 30,
                     "line": 21
                   },
                   "token_type": {
                     "type": "Symbol",
-                    "symbol": "=>"
+                    "symbol": ":"
                   }
                 },
                 "trailing_trivia": [
                   {
                     "start_position": {
-                      "bytes": 555,
-                      "character": 31,
+                      "bytes": 554,
+                      "character": 30,
                       "line": 21
                     },
                     "end_position": {
-                      "bytes": 556,
-                      "character": 32,
+                      "bytes": 555,
+                      "character": 31,
                       "line": 21
                     },
                     "token_type": {
@@ -5434,13 +5434,13 @@
                   "leading_trivia": [],
                   "token": {
                     "start_position": {
-                      "bytes": 556,
-                      "character": 32,
+                      "bytes": 555,
+                      "character": 31,
                       "line": 21
                     },
                     "end_position": {
-                      "bytes": 562,
-                      "character": 38,
+                      "bytes": 561,
+                      "character": 37,
                       "line": 21
                     },
                     "token_type": {
@@ -5461,12 +5461,12 @@
                       "leading_trivia": [
                         {
                           "start_position": {
-                            "bytes": 562,
-                            "character": 38,
+                            "bytes": 561,
+                            "character": 37,
                             "line": 21
                           },
                           "end_position": {
-                            "bytes": 564,
+                            "bytes": 563,
                             "character": 2,
                             "line": 22
                           },
@@ -5478,12 +5478,12 @@
                       ],
                       "token": {
                         "start_position": {
-                          "bytes": 564,
+                          "bytes": 563,
                           "character": 2,
                           "line": 22
                         },
                         "end_position": {
-                          "bytes": 570,
+                          "bytes": 569,
                           "character": 8,
                           "line": 22
                         },
@@ -5495,12 +5495,12 @@
                       "trailing_trivia": [
                         {
                           "start_position": {
-                            "bytes": 570,
+                            "bytes": 569,
                             "character": 8,
                             "line": 22
                           },
                           "end_position": {
-                            "bytes": 571,
+                            "bytes": 570,
                             "character": 9,
                             "line": 22
                           },
@@ -5521,12 +5521,12 @@
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 571,
+                                      "bytes": 570,
                                       "character": 9,
                                       "line": 22
                                     },
                                     "end_position": {
-                                      "bytes": 576,
+                                      "bytes": 575,
                                       "character": 14,
                                       "line": 22
                                     },
@@ -5553,12 +5553,12 @@
               "leading_trivia": [
                 {
                   "start_position": {
-                    "bytes": 576,
+                    "bytes": 575,
                     "character": 14,
                     "line": 22
                   },
                   "end_position": {
-                    "bytes": 577,
+                    "bytes": 576,
                     "character": 14,
                     "line": 22
                   },
@@ -5570,12 +5570,12 @@
               ],
               "token": {
                 "start_position": {
-                  "bytes": 577,
+                  "bytes": 576,
                   "character": 14,
                   "line": 22
                 },
                 "end_position": {
-                  "bytes": 580,
+                  "bytes": 579,
                   "character": 4,
                   "line": 23
                 },
@@ -5598,12 +5598,12 @@
             "leading_trivia": [
               {
                 "start_position": {
-                  "bytes": 580,
+                  "bytes": 579,
                   "character": 4,
                   "line": 23
                 },
                 "end_position": {
-                  "bytes": 581,
+                  "bytes": 580,
                   "character": 4,
                   "line": 23
                 },
@@ -5614,12 +5614,12 @@
               },
               {
                 "start_position": {
-                  "bytes": 581,
+                  "bytes": 580,
                   "character": 4,
                   "line": 23
                 },
                 "end_position": {
-                  "bytes": 582,
+                  "bytes": 581,
                   "character": 1,
                   "line": 24
                 },
@@ -5631,12 +5631,12 @@
             ],
             "token": {
               "start_position": {
-                "bytes": 582,
+                "bytes": 581,
                 "character": 1,
                 "line": 24
               },
               "end_position": {
-                "bytes": 590,
+                "bytes": 589,
                 "character": 9,
                 "line": 25
               },
@@ -5648,12 +5648,12 @@
             "trailing_trivia": [
               {
                 "start_position": {
-                  "bytes": 590,
+                  "bytes": 589,
                   "character": 9,
                   "line": 25
                 },
                 "end_position": {
-                  "bytes": 591,
+                  "bytes": 590,
                   "character": 10,
                   "line": 25
                 },
@@ -5672,12 +5672,12 @@
                     "leading_trivia": [],
                     "token": {
                       "start_position": {
-                        "bytes": 591,
+                        "bytes": 590,
                         "character": 10,
                         "line": 25
                       },
                       "end_position": {
-                        "bytes": 594,
+                        "bytes": 593,
                         "character": 13,
                         "line": 25
                       },
@@ -5700,12 +5700,12 @@
                   "leading_trivia": [],
                   "token": {
                     "start_position": {
-                      "bytes": 594,
+                      "bytes": 593,
                       "character": 13,
                       "line": 25
                     },
                     "end_position": {
-                      "bytes": 595,
+                      "bytes": 594,
                       "character": 14,
                       "line": 25
                     },
@@ -5720,12 +5720,12 @@
                   "leading_trivia": [],
                   "token": {
                     "start_position": {
-                      "bytes": 620,
+                      "bytes": 619,
                       "character": 39,
                       "line": 25
                     },
                     "end_position": {
-                      "bytes": 621,
+                      "bytes": 620,
                       "character": 40,
                       "line": 25
                     },
@@ -5747,12 +5747,12 @@
                         "leading_trivia": [],
                         "token": {
                           "start_position": {
-                            "bytes": 595,
+                            "bytes": 594,
                             "character": 14,
                             "line": 25
                           },
                           "end_position": {
-                            "bytes": 596,
+                            "bytes": 595,
                             "character": 15,
                             "line": 25
                           },
@@ -5768,12 +5768,12 @@
                       "leading_trivia": [],
                       "token": {
                         "start_position": {
-                          "bytes": 604,
+                          "bytes": 603,
                           "character": 23,
                           "line": 25
                         },
                         "end_position": {
-                          "bytes": 605,
+                          "bytes": 604,
                           "character": 24,
                           "line": 25
                         },
@@ -5785,12 +5785,12 @@
                       "trailing_trivia": [
                         {
                           "start_position": {
-                            "bytes": 605,
+                            "bytes": 604,
                             "character": 24,
                             "line": 25
                           },
                           "end_position": {
-                            "bytes": 606,
+                            "bytes": 605,
                             "character": 25,
                             "line": 25
                           },
@@ -5810,12 +5810,12 @@
                         "leading_trivia": [],
                         "token": {
                           "start_position": {
-                            "bytes": 606,
+                            "bytes": 605,
                             "character": 25,
                             "line": 25
                           },
                           "end_position": {
-                            "bytes": 607,
+                            "bytes": 606,
                             "character": 26,
                             "line": 25
                           },
@@ -5831,12 +5831,12 @@
                       "leading_trivia": [],
                       "token": {
                         "start_position": {
-                          "bytes": 615,
+                          "bytes": 614,
                           "character": 34,
                           "line": 25
                         },
                         "end_position": {
-                          "bytes": 616,
+                          "bytes": 615,
                           "character": 35,
                           "line": 25
                         },
@@ -5848,12 +5848,12 @@
                       "trailing_trivia": [
                         {
                           "start_position": {
-                            "bytes": 616,
+                            "bytes": 615,
                             "character": 35,
                             "line": 25
                           },
                           "end_position": {
-                            "bytes": 617,
+                            "bytes": 616,
                             "character": 36,
                             "line": 25
                           },
@@ -5872,12 +5872,12 @@
                       "leading_trivia": [],
                       "token": {
                         "start_position": {
-                          "bytes": 617,
+                          "bytes": 616,
                           "character": 36,
                           "line": 25
                         },
                         "end_position": {
-                          "bytes": 620,
+                          "bytes": 619,
                           "character": 39,
                           "line": 25
                         },
@@ -5898,12 +5898,12 @@
                   "leading_trivia": [],
                   "token": {
                     "start_position": {
-                      "bytes": 596,
+                      "bytes": 595,
                       "character": 15,
                       "line": 25
                     },
                     "end_position": {
-                      "bytes": 597,
+                      "bytes": 596,
                       "character": 16,
                       "line": 25
                     },
@@ -5915,12 +5915,12 @@
                   "trailing_trivia": [
                     {
                       "start_position": {
-                        "bytes": 597,
+                        "bytes": 596,
                         "character": 16,
                         "line": 25
                       },
                       "end_position": {
-                        "bytes": 598,
+                        "bytes": 597,
                         "character": 17,
                         "line": 25
                       },
@@ -5936,12 +5936,12 @@
                     "leading_trivia": [],
                     "token": {
                       "start_position": {
-                        "bytes": 598,
+                        "bytes": 597,
                         "character": 17,
                         "line": 25
                       },
                       "end_position": {
-                        "bytes": 604,
+                        "bytes": 603,
                         "character": 23,
                         "line": 25
                       },
@@ -5959,12 +5959,12 @@
                   "leading_trivia": [],
                   "token": {
                     "start_position": {
-                      "bytes": 607,
+                      "bytes": 606,
                       "character": 26,
                       "line": 25
                     },
                     "end_position": {
-                      "bytes": 608,
+                      "bytes": 607,
                       "character": 27,
                       "line": 25
                     },
@@ -5976,12 +5976,12 @@
                   "trailing_trivia": [
                     {
                       "start_position": {
-                        "bytes": 608,
+                        "bytes": 607,
                         "character": 27,
                         "line": 25
                       },
                       "end_position": {
-                        "bytes": 609,
+                        "bytes": 608,
                         "character": 28,
                         "line": 25
                       },
@@ -5997,12 +5997,12 @@
                     "leading_trivia": [],
                     "token": {
                       "start_position": {
-                        "bytes": 609,
+                        "bytes": 608,
                         "character": 28,
                         "line": 25
                       },
                       "end_position": {
-                        "bytes": 615,
+                        "bytes": 614,
                         "character": 34,
                         "line": 25
                       },
@@ -6023,12 +6023,12 @@
               "leading_trivia": [
                 {
                   "start_position": {
-                    "bytes": 621,
+                    "bytes": 620,
                     "character": 40,
                     "line": 25
                   },
                   "end_position": {
-                    "bytes": 622,
+                    "bytes": 621,
                     "character": 40,
                     "line": 25
                   },
@@ -6040,12 +6040,12 @@
               ],
               "token": {
                 "start_position": {
-                  "bytes": 622,
+                  "bytes": 621,
                   "character": 40,
                   "line": 25
                 },
                 "end_position": {
-                  "bytes": 625,
+                  "bytes": 624,
                   "character": 4,
                   "line": 26
                 },
@@ -6068,12 +6068,12 @@
             "leading_trivia": [
               {
                 "start_position": {
-                  "bytes": 625,
+                  "bytes": 624,
                   "character": 4,
                   "line": 26
                 },
                 "end_position": {
-                  "bytes": 626,
+                  "bytes": 625,
                   "character": 4,
                   "line": 26
                 },
@@ -6084,12 +6084,12 @@
               },
               {
                 "start_position": {
-                  "bytes": 626,
+                  "bytes": 625,
                   "character": 4,
                   "line": 26
                 },
                 "end_position": {
-                  "bytes": 627,
+                  "bytes": 626,
                   "character": 1,
                   "line": 27
                 },
@@ -6101,12 +6101,12 @@
             ],
             "token": {
               "start_position": {
-                "bytes": 627,
+                "bytes": 626,
                 "character": 1,
                 "line": 27
               },
               "end_position": {
-                "bytes": 632,
+                "bytes": 631,
                 "character": 6,
                 "line": 28
               },
@@ -6118,12 +6118,12 @@
             "trailing_trivia": [
               {
                 "start_position": {
-                  "bytes": 632,
+                  "bytes": 631,
                   "character": 6,
                   "line": 28
                 },
                 "end_position": {
-                  "bytes": 633,
+                  "bytes": 632,
                   "character": 7,
                   "line": 28
                 },
@@ -6144,12 +6144,12 @@
                   "leading_trivia": [],
                   "token": {
                     "start_position": {
-                      "bytes": 633,
+                      "bytes": 632,
                       "character": 7,
                       "line": 28
                     },
                     "end_position": {
-                      "bytes": 636,
+                      "bytes": 635,
                       "character": 10,
                       "line": 28
                     },
@@ -6161,12 +6161,12 @@
                   "trailing_trivia": [
                     {
                       "start_position": {
-                        "bytes": 636,
+                        "bytes": 635,
                         "character": 10,
                         "line": 28
                       },
                       "end_position": {
-                        "bytes": 637,
+                        "bytes": 636,
                         "character": 11,
                         "line": 28
                       },
@@ -6184,12 +6184,12 @@
             "leading_trivia": [],
             "token": {
               "start_position": {
-                "bytes": 637,
+                "bytes": 636,
                 "character": 11,
                 "line": 28
               },
               "end_position": {
-                "bytes": 638,
+                "bytes": 637,
                 "character": 12,
                 "line": 28
               },
@@ -6201,12 +6201,12 @@
             "trailing_trivia": [
               {
                 "start_position": {
-                  "bytes": 638,
+                  "bytes": 637,
                   "character": 12,
                   "line": 28
                 },
                 "end_position": {
-                  "bytes": 639,
+                  "bytes": 638,
                   "character": 13,
                   "line": 28
                 },
@@ -6227,12 +6227,12 @@
                         "leading_trivia": [],
                         "token": {
                           "start_position": {
-                            "bytes": 639,
+                            "bytes": 638,
                             "character": 13,
                             "line": 28
                           },
                           "end_position": {
-                            "bytes": 647,
+                            "bytes": 646,
                             "character": 21,
                             "line": 28
                           },
@@ -6250,12 +6250,12 @@
                               "leading_trivia": [],
                               "token": {
                                 "start_position": {
-                                  "bytes": 647,
+                                  "bytes": 646,
                                   "character": 21,
                                   "line": 28
                                 },
                                 "end_position": {
-                                  "bytes": 648,
+                                  "bytes": 647,
                                   "character": 22,
                                   "line": 28
                                 },
@@ -6270,12 +6270,12 @@
                               "leading_trivia": [],
                               "token": {
                                 "start_position": {
-                                  "bytes": 648,
+                                  "bytes": 647,
                                   "character": 22,
                                   "line": 28
                                 },
                                 "end_position": {
-                                  "bytes": 649,
+                                  "bytes": 648,
                                   "character": 23,
                                   "line": 28
                                 },
@@ -6287,12 +6287,12 @@
                               "trailing_trivia": [
                                 {
                                   "start_position": {
-                                    "bytes": 649,
+                                    "bytes": 648,
                                     "character": 23,
                                     "line": 28
                                   },
                                   "end_position": {
-                                    "bytes": 650,
+                                    "bytes": 649,
                                     "character": 24,
                                     "line": 28
                                   },
@@ -6314,29 +6314,29 @@
                             "leading_trivia": [],
                             "token": {
                               "start_position": {
-                                "bytes": 650,
+                                "bytes": 649,
                                 "character": 24,
                                 "line": 28
                               },
                               "end_position": {
-                                "bytes": 652,
+                                "bytes": 650,
                                 "character": 26,
                                 "line": 28
                               },
                               "token_type": {
                                 "type": "Symbol",
-                                "symbol": "=>"
+                                "symbol": ":"
                               }
                             },
                             "trailing_trivia": [
                               {
                                 "start_position": {
-                                  "bytes": 652,
+                                  "bytes": 650,
                                   "character": 26,
                                   "line": 28
                                 },
                                 "end_position": {
-                                  "bytes": 653,
+                                  "bytes": 651,
                                   "character": 27,
                                   "line": 28
                                 },
@@ -6354,12 +6354,12 @@
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 653,
+                                      "bytes": 651,
                                       "character": 27,
                                       "line": 28
                                     },
                                     "end_position": {
-                                      "bytes": 659,
+                                      "bytes": 657,
                                       "character": 33,
                                       "line": 28
                                     },
@@ -6371,12 +6371,12 @@
                                   "trailing_trivia": [
                                     {
                                       "start_position": {
-                                        "bytes": 659,
+                                        "bytes": 657,
                                         "character": 33,
                                         "line": 28
                                       },
                                       "end_position": {
-                                        "bytes": 660,
+                                        "bytes": 658,
                                         "character": 34,
                                         "line": 28
                                       },
@@ -6392,12 +6392,12 @@
                                 "leading_trivia": [],
                                 "token": {
                                   "start_position": {
-                                    "bytes": 660,
+                                    "bytes": 658,
                                     "character": 34,
                                     "line": 28
                                   },
                                   "end_position": {
-                                    "bytes": 661,
+                                    "bytes": 659,
                                     "character": 35,
                                     "line": 28
                                   },
@@ -6409,12 +6409,12 @@
                                 "trailing_trivia": [
                                   {
                                     "start_position": {
-                                      "bytes": 661,
+                                      "bytes": 659,
                                       "character": 35,
                                       "line": 28
                                     },
                                     "end_position": {
-                                      "bytes": 662,
+                                      "bytes": 660,
                                       "character": 36,
                                       "line": 28
                                     },
@@ -6430,12 +6430,12 @@
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 662,
+                                      "bytes": 660,
                                       "character": 36,
                                       "line": 28
                                     },
                                     "end_position": {
-                                      "bytes": 665,
+                                      "bytes": 663,
                                       "character": 39,
                                       "line": 28
                                     },
@@ -6459,12 +6459,12 @@
                                   "leading_trivia": [
                                     {
                                       "start_position": {
-                                        "bytes": 665,
+                                        "bytes": 663,
                                         "character": 39,
                                         "line": 28
                                       },
                                       "end_position": {
-                                        "bytes": 667,
+                                        "bytes": 665,
                                         "character": 2,
                                         "line": 29
                                       },
@@ -6476,12 +6476,12 @@
                                   ],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 667,
+                                      "bytes": 665,
                                       "character": 2,
                                       "line": 29
                                     },
                                     "end_position": {
-                                      "bytes": 673,
+                                      "bytes": 671,
                                       "character": 8,
                                       "line": 29
                                     },
@@ -6493,12 +6493,12 @@
                                   "trailing_trivia": [
                                     {
                                       "start_position": {
-                                        "bytes": 673,
+                                        "bytes": 671,
                                         "character": 8,
                                         "line": 29
                                       },
                                       "end_position": {
-                                        "bytes": 674,
+                                        "bytes": 672,
                                         "character": 9,
                                         "line": 29
                                       },
@@ -6518,12 +6518,12 @@
                                             "leading_trivia": [],
                                             "token": {
                                               "start_position": {
-                                                "bytes": 674,
+                                                "bytes": 672,
                                                 "character": 9,
                                                 "line": 29
                                               },
                                               "end_position": {
-                                                "bytes": 675,
+                                                "bytes": 673,
                                                 "character": 10,
                                                 "line": 29
                                               },
@@ -6549,12 +6549,12 @@
                           "leading_trivia": [
                             {
                               "start_position": {
-                                "bytes": 675,
+                                "bytes": 673,
                                 "character": 10,
                                 "line": 29
                               },
                               "end_position": {
-                                "bytes": 676,
+                                "bytes": 674,
                                 "character": 10,
                                 "line": 29
                               },
@@ -6566,12 +6566,12 @@
                           ],
                           "token": {
                             "start_position": {
-                              "bytes": 676,
+                              "bytes": 674,
                               "character": 10,
                               "line": 29
                             },
                             "end_position": {
-                              "bytes": 679,
+                              "bytes": 677,
                               "character": 4,
                               "line": 30
                             },

--- a/tests/roblox_cases/pass/types/source.lua
+++ b/tests/roblox_cases/pass/types/source.lua
@@ -3,10 +3,10 @@ type Array<T> = { [string]: number }
 type Object = { x: number, y: number }
 type Typeof = typeof(2 + 2 + foo())
 
-type Callback1 = (string) => number
-type Callback2 = (string, string) => number
-type Callback3 = (string, string) => (string, string)
-type Callback4 = (string) => (string) => ()
+type Callback1 = (string) -> number
+type Callback2 = (string, string) -> number
+type Callback3 = (string, string) -> (string, string)
+type Callback4 = (string) -> (string) -> ()
 
 local foo: number = 3
 local foo: number?
@@ -18,13 +18,13 @@ local foo: string, bar: string
 local union: number | string
 local multiUnion: number | string | nil
 
-function foo(param: string) => string
+function foo(param: string): string
 	return param
 end
 
 function foo(a: string, b: string, ...)
 end
 
-local foo = function() => number | nil
+local foo = function(): number | nil
 	return 3
 end

--- a/tests/roblox_cases/pass/types/source.lua
+++ b/tests/roblox_cases/pass/types/source.lua
@@ -18,13 +18,13 @@ local foo: string, bar: string
 local union: number | string
 local multiUnion: number | string | nil
 
-function foo(param: string): string
+function foo(param: string) : string
 	return param
 end
 
 function foo(a: string, b: string, ...)
 end
 
-local foo = function(): number | nil
+local foo = function() : number | nil
 	return 3
 end

--- a/tests/roblox_cases/pass/types/tokens.json
+++ b/tests/roblox_cases/pass/types/tokens.json
@@ -4866,7 +4866,7 @@
   {
     "start_position": {
       "bytes": 663,
-      "character": 37,
+      "character": 38,
       "line": 28
     },
     "end_position": {

--- a/tests/roblox_cases/pass/types/tokens.json
+++ b/tests/roblox_cases/pass/types/tokens.json
@@ -1356,7 +1356,7 @@
     },
     "token_type": {
       "type": "Symbol",
-      "symbol": "=>"
+      "symbol": "->"
     }
   },
   {
@@ -1628,7 +1628,7 @@
     },
     "token_type": {
       "type": "Symbol",
-      "symbol": "=>"
+      "symbol": "->"
     }
   },
   {
@@ -1900,7 +1900,7 @@
     },
     "token_type": {
       "type": "Symbol",
-      "symbol": "=>"
+      "symbol": "->"
     }
   },
   {
@@ -2204,7 +2204,7 @@
     },
     "token_type": {
       "type": "Symbol",
-      "symbol": "=>"
+      "symbol": "->"
     }
   },
   {
@@ -2300,7 +2300,7 @@
     },
     "token_type": {
       "type": "Symbol",
-      "symbol": "=>"
+      "symbol": "->"
     }
   },
   {
@@ -4070,24 +4070,24 @@
       "line": 21
     },
     "end_position": {
-      "bytes": 555,
-      "character": 31,
+      "bytes": 554,
+      "character": 30,
       "line": 21
     },
     "token_type": {
       "type": "Symbol",
-      "symbol": "=>"
+      "symbol": ":"
     }
   },
   {
     "start_position": {
-      "bytes": 555,
-      "character": 31,
+      "bytes": 554,
+      "character": 30,
       "line": 21
     },
     "end_position": {
-      "bytes": 556,
-      "character": 32,
+      "bytes": 555,
+      "character": 31,
       "line": 21
     },
     "token_type": {
@@ -4097,13 +4097,13 @@
   },
   {
     "start_position": {
-      "bytes": 556,
-      "character": 32,
+      "bytes": 555,
+      "character": 31,
       "line": 21
     },
     "end_position": {
-      "bytes": 562,
-      "character": 38,
+      "bytes": 561,
+      "character": 37,
       "line": 21
     },
     "token_type": {
@@ -4113,12 +4113,12 @@
   },
   {
     "start_position": {
-      "bytes": 562,
-      "character": 38,
+      "bytes": 561,
+      "character": 37,
       "line": 21
     },
     "end_position": {
-      "bytes": 564,
+      "bytes": 563,
       "character": 2,
       "line": 22
     },
@@ -4129,12 +4129,12 @@
   },
   {
     "start_position": {
-      "bytes": 564,
+      "bytes": 563,
       "character": 2,
       "line": 22
     },
     "end_position": {
-      "bytes": 570,
+      "bytes": 569,
       "character": 8,
       "line": 22
     },
@@ -4145,12 +4145,12 @@
   },
   {
     "start_position": {
-      "bytes": 570,
+      "bytes": 569,
       "character": 8,
       "line": 22
     },
     "end_position": {
-      "bytes": 571,
+      "bytes": 570,
       "character": 9,
       "line": 22
     },
@@ -4161,12 +4161,12 @@
   },
   {
     "start_position": {
-      "bytes": 571,
+      "bytes": 570,
       "character": 9,
       "line": 22
     },
     "end_position": {
-      "bytes": 576,
+      "bytes": 575,
       "character": 14,
       "line": 22
     },
@@ -4177,12 +4177,12 @@
   },
   {
     "start_position": {
-      "bytes": 576,
+      "bytes": 575,
       "character": 14,
       "line": 22
     },
     "end_position": {
-      "bytes": 577,
+      "bytes": 576,
       "character": 14,
       "line": 22
     },
@@ -4193,12 +4193,12 @@
   },
   {
     "start_position": {
-      "bytes": 577,
+      "bytes": 576,
       "character": 14,
       "line": 22
     },
     "end_position": {
-      "bytes": 580,
+      "bytes": 579,
       "character": 4,
       "line": 23
     },
@@ -4209,14 +4209,30 @@
   },
   {
     "start_position": {
+      "bytes": 579,
+      "character": 4,
+      "line": 23
+    },
+    "end_position": {
+      "bytes": 580,
+      "character": 4,
+      "line": 23
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
       "bytes": 580,
       "character": 4,
       "line": 23
     },
     "end_position": {
       "bytes": 581,
-      "character": 4,
-      "line": 23
+      "character": 1,
+      "line": 24
     },
     "token_type": {
       "type": "Whitespace",
@@ -4226,27 +4242,11 @@
   {
     "start_position": {
       "bytes": 581,
-      "character": 4,
-      "line": 23
-    },
-    "end_position": {
-      "bytes": 582,
-      "character": 1,
-      "line": 24
-    },
-    "token_type": {
-      "type": "Whitespace",
-      "characters": "\n"
-    }
-  },
-  {
-    "start_position": {
-      "bytes": 582,
       "character": 1,
       "line": 24
     },
     "end_position": {
-      "bytes": 590,
+      "bytes": 589,
       "character": 9,
       "line": 25
     },
@@ -4257,12 +4257,12 @@
   },
   {
     "start_position": {
-      "bytes": 590,
+      "bytes": 589,
       "character": 9,
       "line": 25
     },
     "end_position": {
-      "bytes": 591,
+      "bytes": 590,
       "character": 10,
       "line": 25
     },
@@ -4273,12 +4273,12 @@
   },
   {
     "start_position": {
-      "bytes": 591,
+      "bytes": 590,
       "character": 10,
       "line": 25
     },
     "end_position": {
-      "bytes": 594,
+      "bytes": 593,
       "character": 13,
       "line": 25
     },
@@ -4289,12 +4289,12 @@
   },
   {
     "start_position": {
-      "bytes": 594,
+      "bytes": 593,
       "character": 13,
       "line": 25
     },
     "end_position": {
-      "bytes": 595,
+      "bytes": 594,
       "character": 14,
       "line": 25
     },
@@ -4305,12 +4305,12 @@
   },
   {
     "start_position": {
-      "bytes": 595,
+      "bytes": 594,
       "character": 14,
       "line": 25
     },
     "end_position": {
-      "bytes": 596,
+      "bytes": 595,
       "character": 15,
       "line": 25
     },
@@ -4321,12 +4321,12 @@
   },
   {
     "start_position": {
-      "bytes": 596,
+      "bytes": 595,
       "character": 15,
       "line": 25
     },
     "end_position": {
-      "bytes": 597,
+      "bytes": 596,
       "character": 16,
       "line": 25
     },
@@ -4337,12 +4337,12 @@
   },
   {
     "start_position": {
-      "bytes": 597,
+      "bytes": 596,
       "character": 16,
       "line": 25
     },
     "end_position": {
-      "bytes": 598,
+      "bytes": 597,
       "character": 17,
       "line": 25
     },
@@ -4353,12 +4353,12 @@
   },
   {
     "start_position": {
-      "bytes": 598,
+      "bytes": 597,
       "character": 17,
       "line": 25
     },
     "end_position": {
-      "bytes": 604,
+      "bytes": 603,
       "character": 23,
       "line": 25
     },
@@ -4369,12 +4369,12 @@
   },
   {
     "start_position": {
-      "bytes": 604,
+      "bytes": 603,
       "character": 23,
       "line": 25
     },
     "end_position": {
-      "bytes": 605,
+      "bytes": 604,
       "character": 24,
       "line": 25
     },
@@ -4385,12 +4385,12 @@
   },
   {
     "start_position": {
-      "bytes": 605,
+      "bytes": 604,
       "character": 24,
       "line": 25
     },
     "end_position": {
-      "bytes": 606,
+      "bytes": 605,
       "character": 25,
       "line": 25
     },
@@ -4401,12 +4401,12 @@
   },
   {
     "start_position": {
-      "bytes": 606,
+      "bytes": 605,
       "character": 25,
       "line": 25
     },
     "end_position": {
-      "bytes": 607,
+      "bytes": 606,
       "character": 26,
       "line": 25
     },
@@ -4417,12 +4417,12 @@
   },
   {
     "start_position": {
-      "bytes": 607,
+      "bytes": 606,
       "character": 26,
       "line": 25
     },
     "end_position": {
-      "bytes": 608,
+      "bytes": 607,
       "character": 27,
       "line": 25
     },
@@ -4433,12 +4433,12 @@
   },
   {
     "start_position": {
-      "bytes": 608,
+      "bytes": 607,
       "character": 27,
       "line": 25
     },
     "end_position": {
-      "bytes": 609,
+      "bytes": 608,
       "character": 28,
       "line": 25
     },
@@ -4449,12 +4449,12 @@
   },
   {
     "start_position": {
-      "bytes": 609,
+      "bytes": 608,
       "character": 28,
       "line": 25
     },
     "end_position": {
-      "bytes": 615,
+      "bytes": 614,
       "character": 34,
       "line": 25
     },
@@ -4465,12 +4465,12 @@
   },
   {
     "start_position": {
-      "bytes": 615,
+      "bytes": 614,
       "character": 34,
       "line": 25
     },
     "end_position": {
-      "bytes": 616,
+      "bytes": 615,
       "character": 35,
       "line": 25
     },
@@ -4481,12 +4481,12 @@
   },
   {
     "start_position": {
-      "bytes": 616,
+      "bytes": 615,
       "character": 35,
       "line": 25
     },
     "end_position": {
-      "bytes": 617,
+      "bytes": 616,
       "character": 36,
       "line": 25
     },
@@ -4497,12 +4497,12 @@
   },
   {
     "start_position": {
-      "bytes": 617,
+      "bytes": 616,
       "character": 36,
       "line": 25
     },
     "end_position": {
-      "bytes": 620,
+      "bytes": 619,
       "character": 39,
       "line": 25
     },
@@ -4513,12 +4513,12 @@
   },
   {
     "start_position": {
-      "bytes": 620,
+      "bytes": 619,
       "character": 39,
       "line": 25
     },
     "end_position": {
-      "bytes": 621,
+      "bytes": 620,
       "character": 40,
       "line": 25
     },
@@ -4529,12 +4529,12 @@
   },
   {
     "start_position": {
-      "bytes": 621,
+      "bytes": 620,
       "character": 40,
       "line": 25
     },
     "end_position": {
-      "bytes": 622,
+      "bytes": 621,
       "character": 40,
       "line": 25
     },
@@ -4545,12 +4545,12 @@
   },
   {
     "start_position": {
-      "bytes": 622,
+      "bytes": 621,
       "character": 40,
       "line": 25
     },
     "end_position": {
-      "bytes": 625,
+      "bytes": 624,
       "character": 4,
       "line": 26
     },
@@ -4561,14 +4561,30 @@
   },
   {
     "start_position": {
+      "bytes": 624,
+      "character": 4,
+      "line": 26
+    },
+    "end_position": {
+      "bytes": 625,
+      "character": 4,
+      "line": 26
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
       "bytes": 625,
       "character": 4,
       "line": 26
     },
     "end_position": {
       "bytes": 626,
-      "character": 4,
-      "line": 26
+      "character": 1,
+      "line": 27
     },
     "token_type": {
       "type": "Whitespace",
@@ -4578,27 +4594,11 @@
   {
     "start_position": {
       "bytes": 626,
-      "character": 4,
-      "line": 26
-    },
-    "end_position": {
-      "bytes": 627,
-      "character": 1,
-      "line": 27
-    },
-    "token_type": {
-      "type": "Whitespace",
-      "characters": "\n"
-    }
-  },
-  {
-    "start_position": {
-      "bytes": 627,
       "character": 1,
       "line": 27
     },
     "end_position": {
-      "bytes": 632,
+      "bytes": 631,
       "character": 6,
       "line": 28
     },
@@ -4609,12 +4609,12 @@
   },
   {
     "start_position": {
-      "bytes": 632,
+      "bytes": 631,
       "character": 6,
       "line": 28
     },
     "end_position": {
-      "bytes": 633,
+      "bytes": 632,
       "character": 7,
       "line": 28
     },
@@ -4625,12 +4625,12 @@
   },
   {
     "start_position": {
-      "bytes": 633,
+      "bytes": 632,
       "character": 7,
       "line": 28
     },
     "end_position": {
-      "bytes": 636,
+      "bytes": 635,
       "character": 10,
       "line": 28
     },
@@ -4641,12 +4641,12 @@
   },
   {
     "start_position": {
-      "bytes": 636,
+      "bytes": 635,
       "character": 10,
       "line": 28
     },
     "end_position": {
-      "bytes": 637,
+      "bytes": 636,
       "character": 11,
       "line": 28
     },
@@ -4657,12 +4657,12 @@
   },
   {
     "start_position": {
-      "bytes": 637,
+      "bytes": 636,
       "character": 11,
       "line": 28
     },
     "end_position": {
-      "bytes": 638,
+      "bytes": 637,
       "character": 12,
       "line": 28
     },
@@ -4673,12 +4673,12 @@
   },
   {
     "start_position": {
-      "bytes": 638,
+      "bytes": 637,
       "character": 12,
       "line": 28
     },
     "end_position": {
-      "bytes": 639,
+      "bytes": 638,
       "character": 13,
       "line": 28
     },
@@ -4689,12 +4689,12 @@
   },
   {
     "start_position": {
-      "bytes": 639,
+      "bytes": 638,
       "character": 13,
       "line": 28
     },
     "end_position": {
-      "bytes": 647,
+      "bytes": 646,
       "character": 21,
       "line": 28
     },
@@ -4705,12 +4705,12 @@
   },
   {
     "start_position": {
-      "bytes": 647,
+      "bytes": 646,
       "character": 21,
       "line": 28
     },
     "end_position": {
-      "bytes": 648,
+      "bytes": 647,
       "character": 22,
       "line": 28
     },
@@ -4721,12 +4721,12 @@
   },
   {
     "start_position": {
-      "bytes": 648,
+      "bytes": 647,
       "character": 22,
       "line": 28
     },
     "end_position": {
-      "bytes": 649,
+      "bytes": 648,
       "character": 23,
       "line": 28
     },
@@ -4737,12 +4737,12 @@
   },
   {
     "start_position": {
-      "bytes": 649,
+      "bytes": 648,
       "character": 23,
       "line": 28
     },
     "end_position": {
-      "bytes": 650,
+      "bytes": 649,
       "character": 24,
       "line": 28
     },
@@ -4753,29 +4753,29 @@
   },
   {
     "start_position": {
-      "bytes": 650,
+      "bytes": 649,
       "character": 24,
       "line": 28
     },
     "end_position": {
-      "bytes": 652,
-      "character": 26,
+      "bytes": 650,
+      "character": 25,
       "line": 28
     },
     "token_type": {
       "type": "Symbol",
-      "symbol": "=>"
+      "symbol": ":"
     }
   },
   {
     "start_position": {
-      "bytes": 652,
-      "character": 26,
+      "bytes": 650,
+      "character": 25,
       "line": 28
     },
     "end_position": {
-      "bytes": 653,
-      "character": 27,
+      "bytes": 651,
+      "character": 26,
       "line": 28
     },
     "token_type": {
@@ -4785,13 +4785,13 @@
   },
   {
     "start_position": {
-      "bytes": 653,
-      "character": 27,
+      "bytes": 651,
+      "character": 26,
       "line": 28
     },
     "end_position": {
-      "bytes": 659,
-      "character": 33,
+      "bytes": 657,
+      "character": 32,
       "line": 28
     },
     "token_type": {
@@ -4801,13 +4801,13 @@
   },
   {
     "start_position": {
-      "bytes": 659,
-      "character": 33,
+      "bytes": 657,
+      "character": 32,
       "line": 28
     },
     "end_position": {
-      "bytes": 660,
-      "character": 34,
+      "bytes": 658,
+      "character": 33,
       "line": 28
     },
     "token_type": {
@@ -4817,13 +4817,13 @@
   },
   {
     "start_position": {
-      "bytes": 660,
-      "character": 34,
+      "bytes": 658,
+      "character": 33,
       "line": 28
     },
     "end_position": {
-      "bytes": 661,
-      "character": 35,
+      "bytes": 659,
+      "character": 34,
       "line": 28
     },
     "token_type": {
@@ -4833,13 +4833,13 @@
   },
   {
     "start_position": {
-      "bytes": 661,
-      "character": 35,
+      "bytes": 659,
+      "character": 34,
       "line": 28
     },
     "end_position": {
-      "bytes": 662,
-      "character": 36,
+      "bytes": 660,
+      "character": 35,
       "line": 28
     },
     "token_type": {
@@ -4849,13 +4849,13 @@
   },
   {
     "start_position": {
-      "bytes": 662,
-      "character": 36,
+      "bytes": 660,
+      "character": 35,
       "line": 28
     },
     "end_position": {
-      "bytes": 665,
-      "character": 39,
+      "bytes": 663,
+      "character": 38,
       "line": 28
     },
     "token_type": {
@@ -4865,12 +4865,12 @@
   },
   {
     "start_position": {
-      "bytes": 665,
-      "character": 39,
+      "bytes": 663,
+      "character": 37,
       "line": 28
     },
     "end_position": {
-      "bytes": 667,
+      "bytes": 665,
       "character": 2,
       "line": 29
     },
@@ -4881,12 +4881,12 @@
   },
   {
     "start_position": {
-      "bytes": 667,
+      "bytes": 665,
       "character": 2,
       "line": 29
     },
     "end_position": {
-      "bytes": 673,
+      "bytes": 671,
       "character": 8,
       "line": 29
     },
@@ -4897,12 +4897,12 @@
   },
   {
     "start_position": {
-      "bytes": 673,
+      "bytes": 671,
       "character": 8,
       "line": 29
     },
     "end_position": {
-      "bytes": 674,
+      "bytes": 672,
       "character": 9,
       "line": 29
     },
@@ -4913,12 +4913,12 @@
   },
   {
     "start_position": {
-      "bytes": 674,
+      "bytes": 672,
       "character": 9,
       "line": 29
     },
     "end_position": {
-      "bytes": 675,
+      "bytes": 673,
       "character": 10,
       "line": 29
     },
@@ -4929,12 +4929,12 @@
   },
   {
     "start_position": {
-      "bytes": 675,
+      "bytes": 673,
       "character": 10,
       "line": 29
     },
     "end_position": {
-      "bytes": 676,
+      "bytes": 674,
       "character": 10,
       "line": 29
     },
@@ -4945,12 +4945,12 @@
   },
   {
     "start_position": {
-      "bytes": 676,
+      "bytes": 674,
       "character": 10,
       "line": 29
     },
     "end_position": {
-      "bytes": 679,
+      "bytes": 677,
       "character": 4,
       "line": 30
     },
@@ -4961,12 +4961,12 @@
   },
   {
     "start_position": {
-      "bytes": 679,
+      "bytes": 677,
       "character": 4,
       "line": 30
     },
     "end_position": {
-      "bytes": 680,
+      "bytes": 678,
       "character": 4,
       "line": 30
     },
@@ -4977,12 +4977,12 @@
   },
   {
     "start_position": {
-      "bytes": 680,
+      "bytes": 678,
       "character": 4,
       "line": 30
     },
     "end_position": {
-      "bytes": 680,
+      "bytes": 678,
       "character": 4,
       "line": 30
     },


### PR DESCRIPTION
Two syntax changes included to reflect the new typed lua syntax announced:

1. For function definitions, instead of using a “fat arrow” (=>), now use a colon (:) to delimit the return type
2. For function types, instead of using a “fat arrow” (=>), now use a “thin arrow” (->) to delimit the return type

Modifications shouldn't cause issues however the change was not tested due to complications.