### PR TITLE
Fix leading_trivia with CRLF line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fixed old function return type syntax under `roblox` feature flag
+- Fixes `leading_trivia` not being populated correctly within `TokenReference`s inside `extract_token_references` due to CRLF line endings
 
 ## [0.5.0] - 2020-04-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fixed old function return type syntax under `roblox` feature flag
-- Fixes `leading_trivia` not being populated correctly within `TokenReference`s inside `extract_token_references` due to CRLF line endings
+- Fixed `leading_trivia` not being populated correctly within `TokenReference`s inside `extract_token_references` due to CRLF line endings
 
 ## [0.5.0] - 2020-04-21
 ### Added

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2131,7 +2131,8 @@ pub(crate) fn extract_token_references<'a>(mut tokens: Vec<Token<'a>>) -> Vec<To
             while let Some(token) = tokens.peek() {
                 if token.token_type().is_trivia() {
                     if let TokenType::Whitespace { ref characters } = &*token.token_type() {
-                        if characters.starts_with('\n') {
+                        // Use contains in order to tolerate \r\n line endings and mixed whitespace tokens
+                        if characters.contains('\n') {
                             break;
                         }
                     }


### PR DESCRIPTION
Fixes `leading_trivia` not being populated correctly within `TokenReference`s inside `extract_token_references` due to CRLF line endings



test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out