### PR TITLE
Improve parsing support for numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed old function return type syntax under `roblox` feature flag
 - Fixed `leading_trivia` not being populated correctly within `TokenReference`s inside `extract_token_references` due to CRLF line endings
+- Fixed parse error for numbers with negative exponents
+- Fixed parse error for fractional numbers with no integer part
 
 ## [0.5.0] - 2020-04-21
 ### Added

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -688,14 +688,8 @@ fn parse_no_int_fractional_number(code: &str) -> IResult<&str, &str> {
         opt(digit1),
         pair(
             pair(tag("."), digit1),
-            opt(pair(
-                pair(
-                    tag_no_case("e"),
-                    opt(tag("-"))
-                ),
-                digit1
-            ))
-        )
+            opt(pair(pair(tag_no_case("e"), opt(tag("-"))), digit1)),
+        ),
     ))(code)
 }
 
@@ -704,13 +698,7 @@ fn parse_basic_number(code: &str) -> IResult<&str, &str> {
         digit1,
         pair(
             opt(pair(tag("."), digit1)),
-            opt(pair(
-                pair(
-                    tag_no_case("e"),
-                    opt(tag("-"))
-                ),
-                digit1
-            )),
+            opt(pair(pair(tag_no_case("e"), opt(tag("-"))), digit1)),
         ),
     ))(code)
 }
@@ -732,7 +720,12 @@ fn parse_roblox_number(code: &str) -> IResult<&str, &str> {
 }
 
 fn parse_number(code: &str) -> IResult<&str, &str> {
-    alt((parse_roblox_number, parse_hex_number, parse_basic_number, parse_no_int_fractional_number))(code)
+    alt((
+        parse_roblox_number,
+        parse_hex_number,
+        parse_basic_number,
+        parse_no_int_fractional_number,
+    ))(code)
 }
 
 fn advance_number(code: &str) -> Advancement {

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -688,7 +688,13 @@ fn parse_basic_number(code: &str) -> IResult<&str, &str> {
         digit1,
         pair(
             opt(pair(tag("."), digit1)),
-            opt(pair(tag_no_case("e"), digit1)),
+            opt(pair(
+                pair(
+                    tag_no_case("e"),
+                    opt(tag("-"))
+                ),
+                digit1
+            )),
         ),
     ))(code)
 }

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -683,6 +683,22 @@ fn parse_hex_number(code: &str) -> IResult<&str, &str> {
     ))(code)
 }
 
+fn parse_no_int_fractional_number(code: &str) -> IResult<&str, &str> {
+    recognize(pair(
+        opt(digit1),
+        pair(
+            pair(tag("."), digit1),
+            opt(pair(
+                pair(
+                    tag_no_case("e"),
+                    opt(tag("-"))
+                ),
+                digit1
+            ))
+        )
+    ))(code)
+}
+
 fn parse_basic_number(code: &str) -> IResult<&str, &str> {
     recognize(pair(
         digit1,
@@ -716,7 +732,7 @@ fn parse_roblox_number(code: &str) -> IResult<&str, &str> {
 }
 
 fn parse_number(code: &str) -> IResult<&str, &str> {
-    alt((parse_roblox_number, parse_hex_number, parse_basic_number))(code)
+    alt((parse_roblox_number, parse_hex_number, parse_basic_number, parse_no_int_fractional_number))(code)
 }
 
 fn advance_number(code: &str) -> Advancement {

--- a/full-moon/tests/cases/pass/exponents/ast.json
+++ b/full-moon/tests/cases/pass/exponents/ast.json
@@ -1,0 +1,331 @@
+{
+  "stmts": [
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 0,
+                "character": 1,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 5,
+                "character": 6,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 5,
+                  "character": 6,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 6,
+                  "character": 7,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 6,
+                      "character": 7,
+                      "line": 1
+                    },
+                    "end_position": {
+                      "bytes": 9,
+                      "character": 10,
+                      "line": 1
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "num"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 9,
+                        "character": 10,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 10,
+                        "character": 11,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 10,
+                "character": 11,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 11,
+                "character": 12,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 11,
+                  "character": 12,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 12,
+                  "character": 13,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Number": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 12,
+                          "character": 13,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 15,
+                          "character": 16,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": "1e5"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [
+              {
+                "start_position": {
+                  "bytes": 15,
+                  "character": 16,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 17,
+                  "character": 17,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": "\r\n"
+                }
+              }
+            ],
+            "token": {
+              "start_position": {
+                "bytes": 17,
+                "character": 17,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 22,
+                "character": 6,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 22,
+                  "character": 6,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 23,
+                  "character": 7,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 23,
+                      "character": 7,
+                      "line": 2
+                    },
+                    "end_position": {
+                      "bytes": 27,
+                      "character": 11,
+                      "line": 2
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "num2"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 27,
+                        "character": 11,
+                        "line": 2
+                      },
+                      "end_position": {
+                        "bytes": 28,
+                        "character": 12,
+                        "line": 2
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 28,
+                "character": 12,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 29,
+                "character": 13,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 29,
+                  "character": 13,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 30,
+                  "character": 14,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Number": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 30,
+                          "character": 14,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 34,
+                          "character": 18,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": "1e-5"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ]
+  ]
+}

--- a/full-moon/tests/cases/pass/exponents/source.lua
+++ b/full-moon/tests/cases/pass/exponents/source.lua
@@ -1,0 +1,2 @@
+local num = 1e5
+local num2 = 1e-5

--- a/full-moon/tests/cases/pass/exponents/tokens.json
+++ b/full-moon/tests/cases/pass/exponents/tokens.json
@@ -1,0 +1,257 @@
+[
+  {
+    "start_position": {
+      "bytes": 0,
+      "character": 1,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "num"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1e5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 17,
+      "character": 17,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\r\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 17,
+      "character": 17,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 22,
+      "character": 6,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 22,
+      "character": 6,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 23,
+      "character": 7,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 23,
+      "character": 7,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 27,
+      "character": 11,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "num2"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 27,
+      "character": 11,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 28,
+      "character": 12,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 28,
+      "character": 12,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 29,
+      "character": 13,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 29,
+      "character": 13,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 30,
+      "character": 14,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 30,
+      "character": 14,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 34,
+      "character": 18,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1e-5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 34,
+      "character": 18,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 34,
+      "character": 18,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Eof"
+    }
+  }
+]

--- a/full-moon/tests/cases/pass/fractional-numbers/ast.json
+++ b/full-moon/tests/cases/pass/fractional-numbers/ast.json
@@ -1,0 +1,675 @@
+{
+  "stmts": [
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 0,
+                "character": 1,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 5,
+                "character": 6,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 5,
+                  "character": 6,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 6,
+                  "character": 7,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 6,
+                      "character": 7,
+                      "line": 1
+                    },
+                    "end_position": {
+                      "bytes": 9,
+                      "character": 10,
+                      "line": 1
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "num"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 9,
+                        "character": 10,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 10,
+                        "character": 11,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 10,
+                "character": 11,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 11,
+                "character": 12,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 11,
+                  "character": 12,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 12,
+                  "character": 13,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Number": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 12,
+                          "character": 13,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 15,
+                          "character": 16,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": "0.5"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [
+              {
+                "start_position": {
+                  "bytes": 15,
+                  "character": 16,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 17,
+                  "character": 17,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": "\r\n"
+                }
+              }
+            ],
+            "token": {
+              "start_position": {
+                "bytes": 17,
+                "character": 17,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 22,
+                "character": 6,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 22,
+                  "character": 6,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 23,
+                  "character": 7,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 23,
+                      "character": 7,
+                      "line": 2
+                    },
+                    "end_position": {
+                      "bytes": 27,
+                      "character": 11,
+                      "line": 2
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "num2"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 27,
+                        "character": 11,
+                        "line": 2
+                      },
+                      "end_position": {
+                        "bytes": 28,
+                        "character": 12,
+                        "line": 2
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 28,
+                "character": 12,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 29,
+                "character": 13,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 29,
+                  "character": 13,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 30,
+                  "character": 14,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Number": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 30,
+                          "character": 14,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 35,
+                          "character": 19,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": "0.5e5"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [
+              {
+                "start_position": {
+                  "bytes": 35,
+                  "character": 19,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 37,
+                  "character": 20,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": "\r\n"
+                }
+              }
+            ],
+            "token": {
+              "start_position": {
+                "bytes": 37,
+                "character": 20,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 42,
+                "character": 6,
+                "line": 3
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 42,
+                  "character": 6,
+                  "line": 3
+                },
+                "end_position": {
+                  "bytes": 43,
+                  "character": 7,
+                  "line": 3
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 43,
+                      "character": 7,
+                      "line": 3
+                    },
+                    "end_position": {
+                      "bytes": 47,
+                      "character": 11,
+                      "line": 3
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "num3"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 47,
+                        "character": 11,
+                        "line": 3
+                      },
+                      "end_position": {
+                        "bytes": 48,
+                        "character": 12,
+                        "line": 3
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 48,
+                "character": 12,
+                "line": 3
+              },
+              "end_position": {
+                "bytes": 49,
+                "character": 13,
+                "line": 3
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 49,
+                  "character": 13,
+                  "line": 3
+                },
+                "end_position": {
+                  "bytes": 50,
+                  "character": 14,
+                  "line": 3
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Number": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 50,
+                          "character": 14,
+                          "line": 3
+                        },
+                        "end_position": {
+                          "bytes": 52,
+                          "character": 16,
+                          "line": 3
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": ".5"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [
+              {
+                "start_position": {
+                  "bytes": 52,
+                  "character": 16,
+                  "line": 3
+                },
+                "end_position": {
+                  "bytes": 54,
+                  "character": 17,
+                  "line": 3
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": "\r\n"
+                }
+              }
+            ],
+            "token": {
+              "start_position": {
+                "bytes": 54,
+                "character": 17,
+                "line": 3
+              },
+              "end_position": {
+                "bytes": 59,
+                "character": 6,
+                "line": 4
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 59,
+                  "character": 6,
+                  "line": 4
+                },
+                "end_position": {
+                  "bytes": 60,
+                  "character": 7,
+                  "line": 4
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 60,
+                      "character": 7,
+                      "line": 4
+                    },
+                    "end_position": {
+                      "bytes": 64,
+                      "character": 11,
+                      "line": 4
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "num4"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 64,
+                        "character": 11,
+                        "line": 4
+                      },
+                      "end_position": {
+                        "bytes": 65,
+                        "character": 12,
+                        "line": 4
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 65,
+                "character": 12,
+                "line": 4
+              },
+              "end_position": {
+                "bytes": 66,
+                "character": 13,
+                "line": 4
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 66,
+                  "character": 13,
+                  "line": 4
+                },
+                "end_position": {
+                  "bytes": 67,
+                  "character": 14,
+                  "line": 4
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Number": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 67,
+                          "character": 14,
+                          "line": 4
+                        },
+                        "end_position": {
+                          "bytes": 71,
+                          "character": 18,
+                          "line": 4
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": ".5e5"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ]
+  ]
+}

--- a/full-moon/tests/cases/pass/fractional-numbers/source.lua
+++ b/full-moon/tests/cases/pass/fractional-numbers/source.lua
@@ -1,0 +1,4 @@
+local num = 0.5
+local num2 = 0.5e5
+local num3 = .5
+local num4 = .5e5

--- a/full-moon/tests/cases/pass/fractional-numbers/tokens.json
+++ b/full-moon/tests/cases/pass/fractional-numbers/tokens.json
@@ -1,0 +1,513 @@
+[
+  {
+    "start_position": {
+      "bytes": 0,
+      "character": 1,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "num"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "0.5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 17,
+      "character": 17,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\r\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 17,
+      "character": 17,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 22,
+      "character": 6,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 22,
+      "character": 6,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 23,
+      "character": 7,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 23,
+      "character": 7,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 27,
+      "character": 11,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "num2"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 27,
+      "character": 11,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 28,
+      "character": 12,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 28,
+      "character": 12,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 29,
+      "character": 13,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 29,
+      "character": 13,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 30,
+      "character": 14,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 30,
+      "character": 14,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 35,
+      "character": 19,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "0.5e5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 35,
+      "character": 19,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 37,
+      "character": 20,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\r\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 37,
+      "character": 20,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 42,
+      "character": 6,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 42,
+      "character": 6,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 43,
+      "character": 7,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 43,
+      "character": 7,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 47,
+      "character": 11,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "num3"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 47,
+      "character": 11,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 48,
+      "character": 12,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 48,
+      "character": 12,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 49,
+      "character": 13,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 49,
+      "character": 13,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 50,
+      "character": 14,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 50,
+      "character": 14,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 52,
+      "character": 16,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": ".5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 52,
+      "character": 16,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 54,
+      "character": 17,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\r\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 54,
+      "character": 17,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 59,
+      "character": 6,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 59,
+      "character": 6,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 60,
+      "character": 7,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 60,
+      "character": 7,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 64,
+      "character": 11,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "num4"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 64,
+      "character": 11,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 65,
+      "character": 12,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 65,
+      "character": 12,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 66,
+      "character": 13,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 66,
+      "character": 13,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 67,
+      "character": 14,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 67,
+      "character": 14,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 71,
+      "character": 18,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Number",
+      "text": ".5e5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 71,
+      "character": 18,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 71,
+      "character": 18,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Eof"
+    }
+  }
+]


### PR DESCRIPTION
This PR will:
- Add support for negative exponents (eg. `1e-5`) - Closes #57 
- Add support for fractional numbers with no integer part (eg. `.5`) - Closes #58, Closes #63 (Duplicate?)

With tests for both