### PR TITLE
Implement ignoring shebang on a tokenizer level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for exporting types (`export type Foo = { bar: number }`) under the `roblox` feature flag
 - Added support for using types from other modules (`local x: module.Foo`) under the `roblox` feature flag
+- Added ability to ignore shebang
 
 ### Fixed
 - Fixed type declaration of objects not supporting trailing commas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for exporting types (`export type Foo = { bar: number }`) under the `roblox` feature flag
 - Added support for using types from other modules (`local x: module.Foo`) under the `roblox` feature flag
-- Added ability to ignore shebang
+- Added support for parsing a shebang
 
 ### Fixed
 - Fixed type declaration of objects not supporting trailing commas

--- a/full-moon/src/ast/owned.rs
+++ b/full-moon/src/ast/owned.rs
@@ -98,6 +98,9 @@ impl Owned for TokenType<'_> {
             TokenType::Number { text } => TokenType::Number {
                 text: Cow::Owned(text.clone().into_owned()),
             },
+            TokenType::Shebang { line } => TokenType::Shebang {
+                line: Cow::Owned(line.clone().into_owned()),
+            },
             TokenType::SingleLineComment { comment } => TokenType::SingleLineComment {
                 comment: Cow::Owned(comment.clone().into_owned()),
             },

--- a/full-moon/tests/cases/fail/tokenizer/wrong-place-shebang/error.json
+++ b/full-moon/tests/cases/fail/tokenizer/wrong-place-shebang/error.json
@@ -1,0 +1,10 @@
+{
+  "error": {
+    "UnexpectedToken": "#"
+  },
+  "position": {
+    "bytes": 2,
+    "character": 2,
+    "line": 2
+  }
+}

--- a/full-moon/tests/cases/fail/tokenizer/wrong-place-shebang/source.lua
+++ b/full-moon/tests/cases/fail/tokenizer/wrong-place-shebang/source.lua
@@ -1,0 +1,4 @@
+
+#!/usr/bin/env luajit
+
+print("hello");

--- a/full-moon/tests/cases/pass/shebang/ast.json
+++ b/full-moon/tests/cases/pass/shebang/ast.json
@@ -1,0 +1,171 @@
+{
+  "stmts": [
+    [
+      {
+        "FunctionCall": {
+          "prefix": {
+            "Name": {
+              "leading_trivia": [
+                {
+                  "start_position": {
+                    "bytes": 0,
+                    "character": 1,
+                    "line": 1
+                  },
+                  "end_position": {
+                    "bytes": 19,
+                    "character": 19,
+                    "line": 1
+                  },
+                  "token_type": {
+                    "type": "Shebang",
+                    "line": "#!/usr/bin/env lua\n"
+                  }
+                },
+                {
+                  "start_position": {
+                    "bytes": 19,
+                    "character": 19,
+                    "line": 1
+                  },
+                  "end_position": {
+                    "bytes": 20,
+                    "character": 1,
+                    "line": 2
+                  },
+                  "token_type": {
+                    "type": "Whitespace",
+                    "characters": "\n"
+                  }
+                }
+              ],
+              "token": {
+                "start_position": {
+                  "bytes": 20,
+                  "character": 1,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 25,
+                  "character": 6,
+                  "line": 3
+                },
+                "token_type": {
+                  "type": "Identifier",
+                  "identifier": "print"
+                }
+              },
+              "trailing_trivia": []
+            }
+          },
+          "suffixes": [
+            {
+              "Call": {
+                "AnonymousCall": {
+                  "Parentheses": {
+                    "parentheses": {
+                      "tokens": [
+                        {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 25,
+                              "character": 6,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 26,
+                              "character": 7,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Symbol",
+                              "symbol": "("
+                            }
+                          },
+                          "trailing_trivia": []
+                        },
+                        {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 39,
+                              "character": 20,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 40,
+                              "character": 21,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Symbol",
+                              "symbol": ")"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      ]
+                    },
+                    "arguments": {
+                      "pairs": [
+                        {
+                          "End": {
+                            "value": {
+                              "String": {
+                                "leading_trivia": [],
+                                "token": {
+                                  "start_position": {
+                                    "bytes": 26,
+                                    "character": 7,
+                                    "line": 3
+                                  },
+                                  "end_position": {
+                                    "bytes": 39,
+                                    "character": 20,
+                                    "line": 3
+                                  },
+                                  "token_type": {
+                                    "type": "StringLiteral",
+                                    "literal": "Hello world",
+                                    "quote_type": "Double"
+                                  }
+                                },
+                                "trailing_trivia": []
+                              }
+                            },
+                            "binop": null
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      {
+        "leading_trivia": [],
+        "token": {
+          "start_position": {
+            "bytes": 40,
+            "character": 21,
+            "line": 3
+          },
+          "end_position": {
+            "bytes": 41,
+            "character": 22,
+            "line": 3
+          },
+          "token_type": {
+            "type": "Symbol",
+            "symbol": ";"
+          }
+        },
+        "trailing_trivia": []
+      }
+    ]
+  ]
+}

--- a/full-moon/tests/cases/pass/shebang/source.lua
+++ b/full-moon/tests/cases/pass/shebang/source.lua
@@ -1,0 +1,3 @@
+#!/usr/bin/env lua
+
+print("Hello world");

--- a/full-moon/tests/cases/pass/shebang/tokens.json
+++ b/full-moon/tests/cases/pass/shebang/tokens.json
@@ -1,0 +1,146 @@
+[
+  {
+    "start_position": {
+      "bytes": 0,
+      "character": 1,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 19,
+      "character": 19,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Shebang",
+      "line": "#!/usr/bin/env lua\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 19,
+      "character": 19,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 20,
+      "character": 1,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 20,
+      "character": 1,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 25,
+      "character": 6,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "print"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 25,
+      "character": 6,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 26,
+      "character": 7,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "("
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 26,
+      "character": 7,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 39,
+      "character": 20,
+      "line": 3
+    },
+    "token_type": {
+      "type": "StringLiteral",
+      "literal": "Hello world",
+      "quote_type": "Double"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 39,
+      "character": 20,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 40,
+      "character": 21,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": ")"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 40,
+      "character": 21,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 41,
+      "character": 22,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": ";"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 41,
+      "character": 22,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 42,
+      "character": 22,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 42,
+      "character": 22,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 42,
+      "character": 22,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Eof"
+    }
+  }
+]


### PR DESCRIPTION
Since the crate builds only with roblox feature, I've placed a test case in `roblox_cases`. It should be probably moved in general tests.

Closes #81 