### PR TITLE
Add test cases for multi-line quoted string

### DIFF
--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -1264,6 +1264,18 @@ mod tests {
         );
 
         test_advancer!(
+            advance_quote("\"hello\\\nworld\""),
+            Ok(Some(TokenAdvancement {
+                advance: 14,
+                token_type: TokenType::StringLiteral {
+                    literal: Cow::from("hello\\\nworld"),
+                    multi_line: None,
+                    quote_type: StringLiteralQuoteType::Double,
+                },
+            }))
+        );
+
+        test_advancer!(
             advance_quote("\"hello"),
             Err(TokenizerErrorType::UnclosedString)
         );

--- a/full-moon/tests/cases/pass/multi-line-string-6/ast.json
+++ b/full-moon/tests/cases/pass/multi-line-string-6/ast.json
@@ -1,0 +1,160 @@
+{
+  "stmts": [
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 0,
+                "character": 1,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 5,
+                "character": 6,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 5,
+                  "character": 6,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 6,
+                  "character": 7,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 6,
+                      "character": 7,
+                      "line": 1
+                    },
+                    "end_position": {
+                      "bytes": 9,
+                      "character": 10,
+                      "line": 1
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "foo"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 9,
+                        "character": 10,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 10,
+                        "character": 11,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 10,
+                "character": 11,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 11,
+                "character": 12,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 11,
+                  "character": 12,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 12,
+                  "character": 13,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "String": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 12,
+                          "character": 13,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 22,
+                          "character": 5,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "StringLiteral",
+                          "literal": "bar\\\nbaz",
+                          "quote_type": "Double"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ]
+  ]
+}

--- a/full-moon/tests/cases/pass/multi-line-string-6/source.lua
+++ b/full-moon/tests/cases/pass/multi-line-string-6/source.lua
@@ -1,0 +1,2 @@
+local foo = "bar\
+baz"

--- a/full-moon/tests/cases/pass/multi-line-string-6/tokens.json
+++ b/full-moon/tests/cases/pass/multi-line-string-6/tokens.json
@@ -1,0 +1,146 @@
+[
+  {
+    "start_position": {
+      "bytes": 0,
+      "character": 1,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 6,
+      "character": 7,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "foo"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 9,
+      "character": 10,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 22,
+      "character": 5,
+      "line": 2
+    },
+    "token_type": {
+      "type": "StringLiteral",
+      "literal": "bar\\\nbaz",
+      "quote_type": "Double"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 22,
+      "character": 5,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 23,
+      "character": 5,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 23,
+      "character": 5,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 23,
+      "character": 5,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Eof"
+    }
+  }
+]


### PR DESCRIPTION
~~I want to tackle the #83. So far I've added test cases for that, they are failing right now.~~

~~My next step is to add code to remove hanging `\` at the end of a line in `advance_quote` function of `tokenizer.rs` and save a string in `Token::StringLiteral` as new `Cow::Owned`. What do you think?~~

Closes #83 