### PR TITLE
Use intra doc links and remove unnecessary links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Use intra doc links, remove unnecessary linking for some items in docs.
+
 ## [0.7.0] - 2020-11-06
 ### Added
 - Added support for exporting types (`export type Foo = { bar: number }`) under the `roblox` feature flag

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -57,13 +57,13 @@ impl<'a> Block<'a> {
         }
     }
 
-    /// An iterator over the [statements](enum.Stmt.html) in the block, such as `local foo = 1`
+    /// An iterator over the statements in the block, such as `local foo = 1`
     pub fn iter_stmts(&self) -> impl Iterator<Item = &Stmt<'a>> {
         self.stmts.iter().map(|(stmt, _)| stmt)
     }
 
     /// The last statement of the block if one exists, such as `return foo`
-    /// Deprecated in favor of [`Block::last_stmt`](#method.last_stmt),
+    /// Deprecated in favor of [`Block::last_stmt`],
     /// the plural in `last_stmts` was a typo
     #[deprecated(since = "0.5.0", note = "Use last_stmt instead")]
     pub fn last_stmts(&self) -> Option<&LastStmt<'a>> {
@@ -91,7 +91,7 @@ impl<'a> Block<'a> {
     }
 }
 
-/// The last statement of a [`Block`](struct.Block.html)
+/// The last statement of a [`Block`]
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum LastStmt<'a> {
@@ -153,7 +153,7 @@ impl Default for Return<'_> {
     }
 }
 
-/// Fields of a [`TableConstructor`](struct.TableConstructor.html)
+/// Fields of a [`TableConstructor`]
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Field<'a> {
@@ -226,7 +226,7 @@ impl<'a> TableConstructor<'a> {
         &self.braces
     }
 
-    /// An iterator over the [fields](enum.Field.html) used to create the table
+    /// An iterator over the fields used to create the table
     pub fn iter_fields(&self) -> impl Iterator<Item = &Field<'a>> {
         self.fields.iter()
     }
@@ -346,7 +346,7 @@ pub enum Expression<'a> {
     },
 }
 
-/// Values that cannot be used standalone, but as part of things such as [statements](enum.Stmt.html)
+/// Values that cannot be used standalone, but as part of things such as [`Stmt`]
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Value<'a> {
@@ -731,7 +731,7 @@ impl<'a> GenericFor<'a> {
         &self.for_token
     }
 
-    /// Returns the [`Punctuated`](punctuated/struct.Punctuated.html) sequence of names
+    /// Returns the punctuated sequence of names
     /// In `for index, value in pairs(list) do`, iterates over `index` and `value`
     pub fn names(&self) -> &Punctuated<'a, Cow<'a, TokenReference<'a>>> {
         &self.names
@@ -742,7 +742,7 @@ impl<'a> GenericFor<'a> {
         &self.in_token
     }
 
-    /// Returns the [`Punctuated`](punctuated/struct.Punctuated.html) sequence of the expressions looped over
+    /// Returns the punctuated sequence of the expressions looped over
     /// In `for index, value in pairs(list) do`, iterates over `pairs(list)`
     pub fn expr_list(&self) -> &Punctuated<'a, Expression<'a>> {
         &self.expr_list
@@ -924,7 +924,7 @@ impl<'a> If<'a> {
     }
 }
 
-/// An elseif block in a bigger [`If`](struct.If.html) statement
+/// An elseif block in a bigger [`If`] statement
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(fmt = "{}{}{}{}", "else_if_token", "condition", "then_token", "block")]
@@ -1395,7 +1395,7 @@ pub enum Suffix<'a> {
     Index(Index<'a>),
 }
 
-/// A complex expression used by [`Var`](enum.Var.html), consisting of both a prefix and suffixes
+/// A complex expression used by [`Var`], consisting of both a prefix and suffixes
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(fmt = "{}{}", "prefix", "join_vec(suffixes)")]
@@ -1435,7 +1435,7 @@ impl<'a> VarExpression<'a> {
     }
 }
 
-/// Used in [`Assignment`s](struct.Assignment.html) and [`Value`s](enum.Value.html)
+/// Used in [`Assignment`s](Assignment) and [`Value`s](Value)
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Var<'a> {
@@ -1448,7 +1448,7 @@ pub enum Var<'a> {
     Name(Cow<'a, TokenReference<'a>>),
 }
 
-/// An assignment, such as `x = y`. Not used for [`LocalAssignment`s](struct.LocalAssignment.html)
+/// An assignment, such as `x = y`. Not used for [`LocalAssignment`s](LocalAssignment)
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(fmt = "{}{}{}", "var_list", "equal_token", "expr_list")]
@@ -1472,7 +1472,7 @@ impl<'a> Assignment<'a> {
         }
     }
 
-    /// Returns the [`Punctuated`](punctuated/struct.Punctuated.html) sequence over the expressions being assigned.
+    /// Returns the punctuated sequence over the expressions being assigned.
     /// This is the the `1, 2` part of `x, y["a"] = 1, 2`
     pub fn expr_list(&self) -> &Punctuated<'a, Expression<'a>> {
         &self.expr_list
@@ -1483,7 +1483,7 @@ impl<'a> Assignment<'a> {
         &self.equal_token
     }
 
-    /// Returns the [`Punctuated`](punctuated/struct.Punctuated.html) sequence over the variables being assigned to.
+    /// Returns the punctuated sequence over the variables being assigned to.
     /// This is the `x, y["a"]` part of `x, y["a"] = 1, 2`
     pub fn var_list(&self) -> &Punctuated<'a, Var<'a>> {
         &self.var_list
@@ -1615,13 +1615,13 @@ impl<'a> LocalAssignment<'a> {
         self.equal_token.as_deref()
     }
 
-    /// Returns the [`Punctuated`](punctuated/struct.Punctuated.html) sequence of the expressions being assigned.
+    /// Returns the punctuated sequence of the expressions being assigned.
     /// This is the `1, 2` part of `local x, y = 1, 2`
     pub fn expr_list(&self) -> &Punctuated<'a, Expression<'a>> {
         &self.expr_list
     }
 
-    /// Returns the [`Punctuated`](punctuated/struct.Punctuated.html) sequence of names being assigned to.
+    /// Returns the punctuated sequence of names being assigned to.
     /// This is the `x, y` part of `local x, y = 1, 2`
     pub fn name_list(&self) -> &Punctuated<'a, Cow<'a, TokenReference<'a>>> {
         &self.name_list
@@ -1806,7 +1806,7 @@ impl<'a> FunctionCall<'a> {
     }
 }
 
-/// A function name when being [declared](struct.FunctionDeclaration.html)
+/// A function name when being declared as [`FunctionDeclaration`]
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(
@@ -1840,7 +1840,7 @@ impl<'a> FunctionName<'a> {
         Some(&self.colon_name.as_ref()?.1)
     }
 
-    /// Returns the [`Punctuated`](punctuated/struct.Punctuated.html) sequence over the names used when defining the function.
+    /// Returns the punctuated sequence over the names used when defining the function.
     /// This is the `x.y.z` part of `function x.y.z() end`
     pub fn names(&self) -> &Punctuated<'a, Cow<'a, TokenReference<'a>>> {
         &self.names
@@ -2001,7 +2001,7 @@ pub struct Ast<'a> {
 }
 
 impl<'a> Ast<'a> {
-    /// Create an Ast from the passed tokens. You probably want [`parse`](../fn.parse.html)
+    /// Create an Ast from the passed tokens. You probably want [`parse`](crate::parse)
     ///
     /// # Errors
     ///

--- a/full-moon/src/ast/owned.rs
+++ b/full-moon/src/ast/owned.rs
@@ -1,6 +1,6 @@
-//! Exposes the [`Owned`](trait.Owned.html) that nodes implement to produce an owned version of themselves.
+//! Exposes the [`Owned`] that nodes implement to produce an owned version of themselves.
 //! Owned versions are represented as the node with a lifetime of `'static`. For example, if you have
-//! an [`Ast<'a>`](../struct.Ast.html), calling `ast.owned()` on it will produce an owned `Ast<'static>`.
+//! an [`Ast<'a>`](crate::ast::Ast), calling `ast.owned()` on it will produce an owned `Ast<'static>`.
 use super::*;
 use crate::tokenizer::*;
 

--- a/full-moon/src/ast/punctuated.rs
+++ b/full-moon/src/ast/punctuated.rs
@@ -5,7 +5,7 @@
 //! - Names and definitions in a local assignment are `Punctuated<TokenReference>` and `Punctuated<Expression>` respectively
 //! - The values of a return statement are `Punctuated<Expression>`
 //!
-//! Everything with punctuation uses the [`Punctuated<T>`](struct.Punctuated.html) type with the following logic.
+//! Everything with punctuation uses the [`Punctuated<T>`](Punctuated) type with the following logic.
 //! ```rust
 //! # use full_moon::parse;
 //! # fn main() -> Result<(), Box<std::error::Error>> {
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt::Display, iter::FromIterator};
 
 /// A punctuated sequence of node `T` separated by
-/// [`TokenReference`](../../tokenizer/struct.TokenReference.html).
+/// [`TokenReference`](crate::tokenizer::TokenReference).
 /// Refer to the [module documentation](index.html) for more details.
 #[derive(Clone, Debug, Default, Display, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
@@ -99,7 +99,7 @@ impl<'a, T> Punctuated<'a, T> {
         self.into_iter()
     }
 
-    /// Returns an iterator over the [`Pair`](enum.Pair.html) sequences
+    /// Returns an iterator over pairs
     /// ```rust
     /// # use full_moon::ast::punctuated::{Pair, Punctuated};
     /// let mut punctuated = Punctuated::new();
@@ -112,7 +112,7 @@ impl<'a, T> Punctuated<'a, T> {
         self.pairs.into_iter()
     }
 
-    /// Returns the last [`Pair`](enum.Pair.html) in the sequence
+    /// Returns the last pair in the sequence
     /// ```rust
     /// # use full_moon::ast::punctuated::{Pair, Punctuated};
     /// let mut punctuated = Punctuated::new();
@@ -123,7 +123,7 @@ impl<'a, T> Punctuated<'a, T> {
         self.pairs.last()
     }
 
-    /// Returns an iterator over the [`Pair`](enum.Pair.html) sequences as references
+    /// Returns an iterator over pairs as references
     /// ```rust
     /// # use full_moon::ast::punctuated::{Pair, Punctuated};
     /// let mut punctuated = Punctuated::new();
@@ -136,7 +136,7 @@ impl<'a, T> Punctuated<'a, T> {
         self.pairs.iter()
     }
 
-    /// Returns an iterator over the [`Pair`](enum.Pair.html) sequences as mutable references
+    /// Returns an iterator over pairs as mutable references
     /// ```rust
     /// # use full_moon::ast::punctuated::{Pair, Punctuated};
     /// let mut punctuated = Punctuated::new();
@@ -150,7 +150,7 @@ impl<'a, T> Punctuated<'a, T> {
         self.pairs.iter_mut()
     }
 
-    /// Pops off the last [`Pair`](enum.Pair.html), if it isn't empty
+    /// Pops off the last pair if it isn't empty
     /// ```rust
     /// # use full_moon::ast::punctuated::{Pair, Punctuated};
     /// let mut punctuated = Punctuated::new();
@@ -161,7 +161,7 @@ impl<'a, T> Punctuated<'a, T> {
         self.pairs.pop()
     }
 
-    /// Pushes a new [`Pair`](enum.Pair.html) onto the sequence
+    /// Pushes a new pair onto the sequence
     /// ```rust
     /// # use full_moon::ast::punctuated::{Pair, Punctuated};
     /// let mut punctuated = Punctuated::new();
@@ -298,7 +298,8 @@ impl<'a, 'b, T> Iterator for IterMut<'a, 'b, T> {
     }
 }
 
-/// A node `T` followed by the possible trailing [`TokenReference`](../../tokenizer/struct.TokenReference.html).
+/// A node `T` followed by the possible trailing
+/// [`TokenReference`](crate::tokenizer::TokenReference).
 /// Refer to the [module documentation](index.html) for more details.
 #[derive(Clone, Debug, Display, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
@@ -307,7 +308,8 @@ pub enum Pair<'a, T> {
     #[display(fmt = "{}", "_0")]
     End(T),
 
-    /// A node `T` followed by punctuation (in the form of a [`TokenReference`](../../tokenizer/struct.TokenReference.html))
+    /// A node `T` followed by punctuation (in the form of a
+    /// [`TokenReference`](crate::tokenizer::TokenReference))
     #[display(fmt = "{}{}", "_0", "_1")]
     Punctuated(
         T,

--- a/full-moon/src/ast/types.rs
+++ b/full-moon/src/ast/types.rs
@@ -217,7 +217,7 @@ impl<'a> TypeField<'a> {
     }
 }
 
-/// A key in a [`TypeField`](struct.TypeField.html). Can either be a name or an index signature.
+/// A key in a [`TypeField`]. Can either be a name or an index signature.
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum TypeFieldKey<'a> {
@@ -312,7 +312,7 @@ impl<'a> TypeDeclaration<'a> {
     }
 }
 
-/// The generics used in a [type declaration](struct.TypeDeclaration.html).
+/// The generics used in a [`TypeDeclaration`].
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(fmt = "{}{}{}", "arrows.tokens().0", "generics", "arrows.tokens().1")]

--- a/full-moon/src/lib.rs
+++ b/full-moon/src/lib.rs
@@ -15,7 +15,7 @@ pub mod node;
 /// Useful for getting symbols and manually tokenizing without going using an AST.
 pub mod tokenizer;
 
-/// Used to create visitors that recurse through [`Ast`](ast/struct.Ast.html) nodes.
+/// Used to create visitors that recurse through [`Ast`](ast::Ast) nodes.
 pub mod visitors;
 
 mod private;
@@ -27,8 +27,8 @@ use std::fmt;
 #[cfg(all(test, not(feature = "serde")))]
 compile_error!("Serde feature must be enabled for tests");
 
-/// An error type that consists of both [`AstError`](ast/enum.AstError.html) and [`TokenizerError`](tokenizer/enum.TokenizerError.html)
-/// Used by [`parse`](fn.parse)
+/// An error type that consists of both [`AstError`](ast::AstError) and [`TokenizerError`](tokenizer::TokenizerError)
+/// Used by [`parse`]
 #[derive(Clone, Debug, PartialEq, Owned)]
 pub enum Error<'a> {
     /// Triggered if there's an issue creating an AST, but tokenizing must have succeeded
@@ -52,7 +52,7 @@ impl<'a> fmt::Display for Error<'a> {
 
 impl<'a> std::error::Error for Error<'a> {}
 
-/// Creates an [`Ast`](ast/struct.Ast.html) from Lua code
+/// Creates an [`Ast`](ast::Ast) from Lua code
 ///
 /// # Errors
 /// If the code passed cannot be tokenized, a TokenizerError will be returned.
@@ -68,7 +68,7 @@ pub fn parse(code: &str) -> Result<ast::Ast, Error> {
     ast::Ast::from_tokens(tokens).map_err(Error::AstError)
 }
 
-/// Prints back Lua code from an [Ast](ast/struct.Ast.html)
+/// Prints back Lua code from an [`Ast`](ast::Ast)
 pub fn print(ast: &ast::Ast) -> String {
     format!("{}{}", ast.nodes(), ast.eof())
 }

--- a/full-moon/src/node.rs
+++ b/full-moon/src/node.rs
@@ -70,7 +70,7 @@ impl fmt::Debug for TokenItem<'_, '_> {
 }
 
 /// An iterator that iterates over the tokens of a node
-/// Returned by [`Node::tokens`](trait.Node.html#method.tokens)
+/// Returned by [`Node::tokens`]
 #[derive(Default)]
 pub struct Tokens<'ast, 'b> {
     pub(crate) items: Vec<TokenItem<'ast, 'b>>,

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -92,7 +92,7 @@ pub enum TokenizerErrorType {
     /// An unexpected token was found
     UnexpectedToken(char),
     /// Symbol passed is not valid
-    /// Returned from [`TokenReference::symbol`](struct.TokenReference.html#method.symbol)
+    /// Returned from [`TokenReference::symbol`]
     InvalidSymbol(String),
 }
 
@@ -111,7 +111,7 @@ pub enum TokenType<'a> {
         identifier: Cow<'a, str>,
     },
 
-    /// A multi line comment in the format of --[[ comment ]]
+    /// A multi line comment in the format of `--[[ comment ]]`
     MultiLineComment {
         /// Number of equals signs, if any, for the multi line comment
         /// For example, `--[=[` would have a `blocks` value of `1`
@@ -150,14 +150,14 @@ pub enum TokenType<'a> {
         #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
         /// Number of equals signs used for a multi line string, if it is one
         /// For example, `[=[string]=]` would have a `multi_line` value of Some(1)
-        /// [[string]] would have a `multi_line` value of Some(0)
+        /// `[[string]]` would have a `multi_line` value of Some(0)
         /// A string such as `"string"` would have a `multi_line` value of None
         multi_line: Option<usize>,
         /// The type of quotation mark used to make the string
         quote_type: StringLiteralQuoteType,
     },
 
-    /// A [`Symbol`](enum.Symbol.html), such as `local` or `+`
+    /// A [`Symbol`], such as `local` or `+`
     Symbol {
         /// The symbol itself
         symbol: Symbol,
@@ -192,7 +192,7 @@ impl<'a> TokenType<'a> {
         }
     }
 
-    /// Returns the [`TokenKind`](enum.TokenKind.html) of the token type.
+    /// Returns the kind of the token type.
     ///
     /// ```rust
     /// use std::borrow::Cow;
@@ -241,7 +241,7 @@ pub enum TokenKind {
     Eof,
     /// An identifier, such as `foo`
     Identifier,
-    /// A multi line comment in the format of --[[ comment ]]
+    /// A multi line comment in the format of `--[[ comment ]]`
     MultiLineComment,
     /// A literal number, such as `3.3`
     Number,
@@ -251,13 +251,13 @@ pub enum TokenKind {
     SingleLineComment,
     /// A literal string, such as "Hello, world"
     StringLiteral,
-    /// A [`Symbol`](enum.Symbol.html), such as `local` or `+`
+    /// A [`Symbol`], such as `local` or `+`
     Symbol,
     /// Whitespace, such as tabs or new lines
     Whitespace,
 }
 
-/// A token such consisting of its [`Position`](struct.Position.html) and a [`TokenType`](enum.TokenType.html)
+/// A token such consisting of its [`Position`] and a [`TokenType`]
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Token<'a> {
@@ -287,14 +287,14 @@ impl<'a> Token<'a> {
         self.end_position
     }
 
-    /// The [type](enum.TokenType.html) of token as well as the data needed to represent it
-    /// If you don't need any other information, use [`token_kind`](#method.token_kind) instead.
+    /// The type of token as well as the data needed to represent it
+    /// If you don't need any other information, use [`token_kind`](Token::token_kind) instead.
     pub fn token_type(&self) -> &TokenType<'a> {
         &self.token_type
     }
 
-    /// The [kind](enum.TokenKind.html) of token with no additional data.
-    /// If you need any information such as idenitfier names, use [`token_type`](#method.token_type) instead.
+    /// The kind of token with no additional data.
+    /// If you need any information such as idenitfier names, use [`token_type`](Token::token_type) instead.
     pub fn token_kind(&self) -> TokenKind {
         self.token_type().kind()
     }
@@ -390,7 +390,7 @@ impl<'ast> VisitMut<'ast> for Token<'ast> {
 }
 
 /// A reference to a token used by Ast's.
-/// Dereferences to a [`Token`](struct.Token.html)
+/// Dereferences to a [`Token`]
 #[derive(Clone, Debug, Owned)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TokenReference<'a> {
@@ -476,7 +476,7 @@ impl<'a> TokenReference<'a> {
         })
     }
 
-    /// Returns the inner [`Token`](struct.Token.html)
+    /// Returns the inner token.
     pub fn token(&self) -> &Token<'a> {
         &self.token
     }
@@ -972,13 +972,13 @@ impl fmt::Display for TokenizerError {
 
 impl std::error::Error for TokenizerError {}
 
-/// Returns a list of [`Token`](struct.Token.html) structs.
-/// You probably want [`parse`](../fn.parse.html) instead.
+/// Returns a list of tokens.
+/// You probably want [`parse`](crate::parse) instead.
 ///
 /// # Errors
 ///
 /// If the code passed is malformed from normal Lua expectations,
-/// a [`TokenizerError`](struct.TokenizerError.html) will be returned.
+/// a [`TokenizerError`] will be returned.
 ///
 /// ```rust
 /// # use full_moon::tokenizer::tokens;

--- a/full-moon/src/visitors.rs
+++ b/full-moon/src/visitors.rs
@@ -19,7 +19,7 @@ macro_rules! create_visitor {
         $($visit_token:ident,)+
     }) => {
         /// A trait that implements functions to listen for specific nodes/tokens.
-        /// Unlike [`VisitorMut`](trait.VisitorMut.html), nodes/tokens passed are immutable.
+        /// Unlike [`VisitorMut`], nodes/tokens passed are immutable.
         ///
         /// ```rust
         /// # use full_moon::ast;
@@ -44,7 +44,7 @@ macro_rules! create_visitor {
         /// # }
         /// ```
         pub trait Visitor<'ast> {
-            /// Visit the nodes of an [`Ast`](../ast/struct.Ast.html)
+            /// Visit the nodes of an [`Ast`](crate::ast::Ast)
             fn visit_ast(&mut self, ast: &Ast<'ast>) where Self: Sized {
                 ast.nodes().visit(self);
                 ast.eof().visit(self);
@@ -77,9 +77,9 @@ macro_rules! create_visitor {
         }
 
         /// A trait that implements functions to listen for specific nodes/tokens.
-        /// Unlike [`Visitor`](trait.Visitor.html), nodes/tokens passed are mutable.
+        /// Unlike [`Visitor`], nodes/tokens passed are mutable.
         pub trait VisitorMut<'ast> {
-            /// Visit the nodes of an [`Ast`](../ast/struct.Ast.html)
+            /// Visit the nodes of an [`Ast`](crate::ast::Ast)
             fn visit_ast(&mut self, ast: Ast<'ast>) -> Ast<'ast> where Self: Sized {
                 // TODO: Visit tokens?
                 let eof = ast.eof().to_owned();


### PR DESCRIPTION
Use intra doc links feature of the latest `rustc 1.48.0`. I also removed some unnecessary linking to items, for example for methods/functions that return the item which is already linked in the docs. And fixed some warnings reported by `cargo doc` command. 

External `cargo deadlinks` command returns no results now 🥳 