### PR TITLE
Expose Punctuated parameters in FunctionBody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `with_XXX` methods to Roblox-related structs under the `roblox` feature flag
+- Added support for retrieving the `Punctuated` sequence of parameters in a `FunctionBody`
 
 ### Changed
 - Use intra doc links, remove unnecessary linking for some items in docs.
-- Added support for retrieving the `Punctuated` sequence of parameters in a `FunctionBody`
 - `FunctionBody::iter_parameters` is now deprecated in favour of `punctuated().iter` 
 
 ## [0.7.0] - 2020-11-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added support for retrieving the `Punctuated` sequence of parameters in a `FunctionBody`
+- `FunctionBody::iter_parameters` is now deprecated in favour of `punctuated().iter` 
 
 ### Changed
 - Use intra doc links, remove unnecessary linking for some items in docs.

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1263,8 +1263,15 @@ impl<'a> FunctionBody<'a> {
     }
 
     /// An iterator over the parameters for the function declaration
+    /// Deprecated in favor of [`Punctuated::iter`], which supports retrieving punctuation too
+    #[deprecated(note = "Please use parameters().iter instead")]
     pub fn iter_parameters(&self) -> impl Iterator<Item = &Parameter<'a>> {
         self.parameters.iter()
+    }
+
+    /// Returns the [`Punctuated`] sequence of the parameters for the function declaration
+    pub fn parameters(&self) -> &Punctuated<'a, Parameter<'a>> {
+        &self.parameters
     }
 
     /// The code of a function body


### PR DESCRIPTION
This PR adds a `.parameters()` method to `FunctionBody` in order to retrieve the Punctuated sequence of parameters
Closes #109