### PR TITLE
Fix parse error for positive exponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed parse error for exponents with an explicit positive sign (eg. `1e+5`)
 
 ### Changed
 - Use intra doc links, remove unnecessary linking for some items in docs.

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -729,7 +729,7 @@ fn parse_no_int_fractional_number(code: &str) -> IResult<&str, &str> {
         pair(
             pair(tag("."), parse_digit_with_seperator),
             opt(pair(
-                pair(tag_no_case("e"), opt(tag("-"))),
+                pair(tag_no_case("e"), opt(alt((tag("-"), tag("+"))))),
                 parse_digit_with_seperator,
             )),
         ),
@@ -742,7 +742,7 @@ fn parse_basic_number(code: &str) -> IResult<&str, &str> {
         pair(
             opt(pair(tag("."), parse_digit_with_seperator)),
             opt(pair(
-                pair(tag_no_case("e"), opt(tag("-"))),
+                pair(tag_no_case("e"), opt(alt((tag("-"), tag("+"))))),
                 parse_digit_with_seperator,
             )),
         ),

--- a/full-moon/tests/cases/pass/exponents/ast.json
+++ b/full-moon/tests/cases/pass/exponents/ast.json
@@ -326,6 +326,178 @@
         }
       },
       null
+    ],
+    [
+      {
+        "LocalAssignment": {
+          "local_token": {
+            "leading_trivia": [
+              {
+                "start_position": {
+                  "bytes": 33,
+                  "character": 18,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 34,
+                  "character": 18,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": "\n"
+                }
+              }
+            ],
+            "token": {
+              "start_position": {
+                "bytes": 34,
+                "character": 18,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 39,
+                "character": 6,
+                "line": 3
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "local"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 39,
+                  "character": 6,
+                  "line": 3
+                },
+                "end_position": {
+                  "bytes": 40,
+                  "character": 7,
+                  "line": 3
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "name_list": {
+            "pairs": [
+              {
+                "End": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 40,
+                      "character": 7,
+                      "line": 3
+                    },
+                    "end_position": {
+                      "bytes": 44,
+                      "character": 11,
+                      "line": 3
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "num3"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 44,
+                        "character": 11,
+                        "line": 3
+                      },
+                      "end_position": {
+                        "bytes": 45,
+                        "character": 12,
+                        "line": 3
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 45,
+                "character": 12,
+                "line": 3
+              },
+              "end_position": {
+                "bytes": 46,
+                "character": 13,
+                "line": 3
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 46,
+                  "character": 13,
+                  "line": 3
+                },
+                "end_position": {
+                  "bytes": 47,
+                  "character": 14,
+                  "line": 3
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "value": {
+                    "Number": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 47,
+                          "character": 14,
+                          "line": 3
+                        },
+                        "end_position": {
+                          "bytes": 51,
+                          "character": 18,
+                          "line": 3
+                        },
+                        "token_type": {
+                          "type": "Number",
+                          "text": "1e+5"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "binop": null
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
     ]
   ]
 }

--- a/full-moon/tests/cases/pass/exponents/source.lua
+++ b/full-moon/tests/cases/pass/exponents/source.lua
@@ -1,2 +1,3 @@
 local num = 1e5
 local num2 = 1e-5
+local num3 = 1e+5

--- a/full-moon/tests/cases/pass/exponents/tokens.json
+++ b/full-moon/tests/cases/pass/exponents/tokens.json
@@ -246,9 +246,137 @@
       "line": 2
     },
     "end_position": {
-      "bytes": 33,
+      "bytes": 34,
       "character": 18,
       "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 34,
+      "character": 18,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 39,
+      "character": 6,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "local"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 39,
+      "character": 6,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 40,
+      "character": 7,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 40,
+      "character": 7,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 44,
+      "character": 11,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "num3"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 44,
+      "character": 11,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 45,
+      "character": 12,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 45,
+      "character": 12,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 46,
+      "character": 13,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 46,
+      "character": 13,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 47,
+      "character": 14,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 47,
+      "character": 14,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 51,
+      "character": 18,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1e+5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 51,
+      "character": 18,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 51,
+      "character": 18,
+      "line": 3
     },
     "token_type": {
       "type": "Eof"


### PR DESCRIPTION
Fixes parse error for exponents with an explicit positive sign (eg. `1e+5`)
Fixes #108 