### PR TITLE
Add support for shorthand array type notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added support for shorthand array type notation (`type Foo = { number }`) under the `roblox` feature flag
 
 ### Changed
 - Use intra doc links, remove unnecessary linking for some items in docs.

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -1369,26 +1369,43 @@ cfg_if::cfg_if! {
                     )
                 }
             } else if let Ok((state, start_brace)) = ParseSymbol(Symbol::LeftBrace).parse(state) {
-                let (state, fields) = expect!(
-                    state,
-                    ZeroOrMoreDelimited(ParseTypeField, ParseSymbol(Symbol::Comma), true)
-                        .parse(state),
-                    "expected fields in between braces"
-                );
+                if let Ok((state, fields)) = ZeroOrMoreDelimited(ParseTypeField, ParseSymbol(Symbol::Comma), true)
+                        .parse(state)
+                {
+                    let (state, end_brace) = expect!(
+                        state,
+                        ParseSymbol(Symbol::RightBrace).parse(state),
+                        "expected `}` to match `{`"
+                    );
 
-                let (state, end_brace) = expect!(
-                    state,
-                    ParseSymbol(Symbol::RightBrace).parse(state),
-                    "expected `}` to match `{`"
-                );
+                    (
+                        state,
+                        TypeInfo::Table {
+                            braces: ContainedSpan::new(start_brace, end_brace),
+                            fields,
+                        },
+                    )
+                } else {
+                    let (state, type_info) = expect!(
+                        state,
+                        ParseTypeInfo.parse(state),
+                        "expected type in array"
+                    );
 
-                (
-                    state,
-                    TypeInfo::Table {
-                        braces: ContainedSpan::new(start_brace, end_brace),
-                        fields,
-                    },
-                )
+                    let (state, end_brace) = expect!(
+                        state,
+                        ParseSymbol(Symbol::RightBrace).parse(state),
+                        "expected `}` to match `{`"
+                    );
+
+                    (
+                        state,
+                        TypeInfo::Array {
+                            braces: ContainedSpan::new(start_brace, end_brace),
+                            type_info: Box::new(type_info)
+                        },
+                    )
+                }
             } else {
                 return Err(InternalAstError::NoMatch);
             };

--- a/full-moon/src/ast/type_visitors.rs
+++ b/full-moon/src/ast/type_visitors.rs
@@ -12,6 +12,11 @@ impl<'a> Visit<'a> for TypeInfo<'a> {
     fn visit<V: Visitor<'a>>(&self, visitor: &mut V) {
         visitor.visit_type_info(self);
         match self {
+            TypeInfo::Array { braces, type_info } => {
+                braces.tokens.0.visit(visitor);
+                type_info.visit(visitor);
+                braces.tokens.1.visit(visitor);
+            }
             TypeInfo::Basic(__self_0) => {
                 __self_0.visit(visitor);
             }
@@ -96,6 +101,16 @@ impl<'a> VisitMut<'a> for TypeInfo<'a> {
     fn visit_mut<V: VisitorMut<'a>>(mut self, visitor: &mut V) -> Self {
         self = visitor.visit_type_info(self);
         self = match self {
+            TypeInfo::Array {
+                mut braces,
+                mut type_info,
+            } => {
+                braces.tokens.0 = braces.tokens.0.visit_mut(visitor);
+                type_info = type_info.visit_mut(visitor);
+                braces.tokens.1 = braces.tokens.1.visit_mut(visitor);
+
+                TypeInfo::Array { braces, type_info }
+            }
             TypeInfo::Basic(__self_0) => TypeInfo::Basic(__self_0.visit_mut(visitor)),
             TypeInfo::Callback {
                 mut parentheses,

--- a/full-moon/src/ast/types.rs
+++ b/full-moon/src/ast/types.rs
@@ -8,6 +8,17 @@ use derive_more::Display;
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum TypeInfo<'a> {
+    /// A shorthand type annotating the structure of an array: { number }
+    #[display(fmt = "{}{}{}", "braces.tokens().0", "type_info", "braces.tokens().1")]
+    Array {
+        /// The braces (`{}`) containing the type info.
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        braces: ContainedSpan<'a>,
+        /// The type info for the values in the Array
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        type_info: Box<TypeInfo<'a>>,
+    },
+
     /// A standalone type, such as `string` or `Foo`.
     #[display(fmt = "{}", "_0")]
     Basic(#[cfg_attr(feature = "serde", serde(borrow))] Cow<'a, TokenReference<'a>>),

--- a/full-moon/tests/roblox_cases/pass/shorthand_array_type/ast.json
+++ b/full-moon/tests/roblox_cases/pass/shorthand_array_type/ast.json
@@ -1,0 +1,724 @@
+{
+  "stmts": [
+    [
+      {
+        "TypeDeclaration": {
+          "type_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 0,
+                "character": 1,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 4,
+                "character": 5,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Identifier",
+                "identifier": "type"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 4,
+                  "character": 5,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 5,
+                  "character": 6,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "base": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 5,
+                "character": 6,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 10,
+                "character": 11,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Identifier",
+                "identifier": "Array"
+              }
+            },
+            "trailing_trivia": []
+          },
+          "generics": {
+            "arrows": {
+              "tokens": [
+                {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 10,
+                      "character": 11,
+                      "line": 1
+                    },
+                    "end_position": {
+                      "bytes": 11,
+                      "character": 12,
+                      "line": 1
+                    },
+                    "token_type": {
+                      "type": "Symbol",
+                      "symbol": "<"
+                    }
+                  },
+                  "trailing_trivia": []
+                },
+                {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 12,
+                      "character": 13,
+                      "line": 1
+                    },
+                    "end_position": {
+                      "bytes": 13,
+                      "character": 14,
+                      "line": 1
+                    },
+                    "token_type": {
+                      "type": "Symbol",
+                      "symbol": ">"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 13,
+                        "character": 14,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 14,
+                        "character": 15,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "generics": {
+              "pairs": [
+                {
+                  "End": {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 11,
+                        "character": 12,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 12,
+                        "character": 13,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "T"
+                      }
+                    },
+                    "trailing_trivia": []
+                  }
+                }
+              ]
+            }
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 14,
+                "character": 15,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 15,
+                "character": 16,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 15,
+                  "character": 16,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 16,
+                  "character": 17,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "declare_as": {
+            "Array": {
+              "braces": {
+                "tokens": [
+                  {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 16,
+                        "character": 17,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 17,
+                        "character": 18,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Symbol",
+                        "symbol": "{"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 17,
+                          "character": 18,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 18,
+                          "character": 19,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 20,
+                        "character": 21,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 21,
+                        "character": 22,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Symbol",
+                        "symbol": "}"
+                      }
+                    },
+                    "trailing_trivia": []
+                  }
+                ]
+              },
+              "type_info": {
+                "Basic": {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 18,
+                      "character": 19,
+                      "line": 1
+                    },
+                    "end_position": {
+                      "bytes": 19,
+                      "character": 20,
+                      "line": 1
+                    },
+                    "token_type": {
+                      "type": "Identifier",
+                      "identifier": "T"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 19,
+                        "character": 20,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 20,
+                        "character": 21,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "TypeDeclaration": {
+          "type_token": {
+            "leading_trivia": [
+              {
+                "start_position": {
+                  "bytes": 21,
+                  "character": 22,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 22,
+                  "character": 22,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": "\n"
+                }
+              }
+            ],
+            "token": {
+              "start_position": {
+                "bytes": 22,
+                "character": 22,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 26,
+                "character": 5,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Identifier",
+                "identifier": "type"
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 26,
+                  "character": 5,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 27,
+                  "character": 6,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "base": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 27,
+                "character": 6,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 32,
+                "character": 11,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Identifier",
+                "identifier": "Array"
+              }
+            },
+            "trailing_trivia": []
+          },
+          "generics": {
+            "arrows": {
+              "tokens": [
+                {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 32,
+                      "character": 11,
+                      "line": 2
+                    },
+                    "end_position": {
+                      "bytes": 33,
+                      "character": 12,
+                      "line": 2
+                    },
+                    "token_type": {
+                      "type": "Symbol",
+                      "symbol": "<"
+                    }
+                  },
+                  "trailing_trivia": []
+                },
+                {
+                  "leading_trivia": [],
+                  "token": {
+                    "start_position": {
+                      "bytes": 34,
+                      "character": 13,
+                      "line": 2
+                    },
+                    "end_position": {
+                      "bytes": 35,
+                      "character": 14,
+                      "line": 2
+                    },
+                    "token_type": {
+                      "type": "Symbol",
+                      "symbol": ">"
+                    }
+                  },
+                  "trailing_trivia": [
+                    {
+                      "start_position": {
+                        "bytes": 35,
+                        "character": 14,
+                        "line": 2
+                      },
+                      "end_position": {
+                        "bytes": 36,
+                        "character": 15,
+                        "line": 2
+                      },
+                      "token_type": {
+                        "type": "Whitespace",
+                        "characters": " "
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "generics": {
+              "pairs": [
+                {
+                  "End": {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 33,
+                        "character": 12,
+                        "line": 2
+                      },
+                      "end_position": {
+                        "bytes": 34,
+                        "character": 13,
+                        "line": 2
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "T"
+                      }
+                    },
+                    "trailing_trivia": []
+                  }
+                }
+              ]
+            }
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 36,
+                "character": 15,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 37,
+                "character": 16,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 37,
+                  "character": 16,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 38,
+                  "character": 17,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "declare_as": {
+            "Table": {
+              "braces": {
+                "tokens": [
+                  {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 38,
+                        "character": 17,
+                        "line": 2
+                      },
+                      "end_position": {
+                        "bytes": 39,
+                        "character": 18,
+                        "line": 2
+                      },
+                      "token_type": {
+                        "type": "Symbol",
+                        "symbol": "{"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 39,
+                          "character": 18,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 40,
+                          "character": 19,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 52,
+                        "character": 31,
+                        "line": 2
+                      },
+                      "end_position": {
+                        "bytes": 53,
+                        "character": 32,
+                        "line": 2
+                      },
+                      "token_type": {
+                        "type": "Symbol",
+                        "symbol": "}"
+                      }
+                    },
+                    "trailing_trivia": []
+                  }
+                ]
+              },
+              "fields": {
+                "pairs": [
+                  {
+                    "End": {
+                      "key": {
+                        "IndexSignature": {
+                          "brackets": {
+                            "tokens": [
+                              {
+                                "leading_trivia": [],
+                                "token": {
+                                  "start_position": {
+                                    "bytes": 40,
+                                    "character": 19,
+                                    "line": 2
+                                  },
+                                  "end_position": {
+                                    "bytes": 41,
+                                    "character": 20,
+                                    "line": 2
+                                  },
+                                  "token_type": {
+                                    "type": "Symbol",
+                                    "symbol": "["
+                                  }
+                                },
+                                "trailing_trivia": []
+                              },
+                              {
+                                "leading_trivia": [],
+                                "token": {
+                                  "start_position": {
+                                    "bytes": 47,
+                                    "character": 26,
+                                    "line": 2
+                                  },
+                                  "end_position": {
+                                    "bytes": 48,
+                                    "character": 27,
+                                    "line": 2
+                                  },
+                                  "token_type": {
+                                    "type": "Symbol",
+                                    "symbol": "]"
+                                  }
+                                },
+                                "trailing_trivia": []
+                              }
+                            ]
+                          },
+                          "inner": {
+                            "Basic": {
+                              "leading_trivia": [],
+                              "token": {
+                                "start_position": {
+                                  "bytes": 41,
+                                  "character": 20,
+                                  "line": 2
+                                },
+                                "end_position": {
+                                  "bytes": 47,
+                                  "character": 26,
+                                  "line": 2
+                                },
+                                "token_type": {
+                                  "type": "Identifier",
+                                  "identifier": "number"
+                                }
+                              },
+                              "trailing_trivia": []
+                            }
+                          }
+                        }
+                      },
+                      "colon": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 48,
+                            "character": 27,
+                            "line": 2
+                          },
+                          "end_position": {
+                            "bytes": 49,
+                            "character": 28,
+                            "line": 2
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": ":"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 49,
+                              "character": 28,
+                              "line": 2
+                            },
+                            "end_position": {
+                              "bytes": 50,
+                              "character": 29,
+                              "line": 2
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      },
+                      "value": {
+                        "Basic": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 50,
+                              "character": 29,
+                              "line": 2
+                            },
+                            "end_position": {
+                              "bytes": 51,
+                              "character": 30,
+                              "line": 2
+                            },
+                            "token_type": {
+                              "type": "Identifier",
+                              "identifier": "T"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 51,
+                                "character": 30,
+                                "line": 2
+                              },
+                              "end_position": {
+                                "bytes": 52,
+                                "character": 31,
+                                "line": 2
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      null
+    ]
+  ]
+}

--- a/full-moon/tests/roblox_cases/pass/shorthand_array_type/source.lua
+++ b/full-moon/tests/roblox_cases/pass/shorthand_array_type/source.lua
@@ -1,0 +1,2 @@
+type Array<T> = { T }
+type Array<T> = { [number]: T }

--- a/full-moon/tests/roblox_cases/pass/shorthand_array_type/tokens.json
+++ b/full-moon/tests/roblox_cases/pass/shorthand_array_type/tokens.json
@@ -1,0 +1,561 @@
+[
+  {
+    "start_position": {
+      "bytes": 0,
+      "character": 1,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 4,
+      "character": 5,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "type"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 4,
+      "character": 5,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 5,
+      "character": 6,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "Array"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 10,
+      "character": 11,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "<"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "T"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 13,
+      "character": 14,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": ">"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 13,
+      "character": 14,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 14,
+      "character": 15,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 14,
+      "character": 15,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 16,
+      "character": 17,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 16,
+      "character": 17,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 17,
+      "character": 18,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "{"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 17,
+      "character": 18,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 18,
+      "character": 19,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 18,
+      "character": 19,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 19,
+      "character": 20,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "T"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 19,
+      "character": 20,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 20,
+      "character": 21,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 20,
+      "character": 21,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 21,
+      "character": 22,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "}"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 21,
+      "character": 22,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 22,
+      "character": 22,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 22,
+      "character": 22,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 26,
+      "character": 5,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "type"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 26,
+      "character": 5,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 27,
+      "character": 6,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 27,
+      "character": 6,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 32,
+      "character": 11,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "Array"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 32,
+      "character": 11,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 33,
+      "character": 12,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "<"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 33,
+      "character": 12,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 34,
+      "character": 13,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "T"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 34,
+      "character": 13,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 35,
+      "character": 14,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": ">"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 35,
+      "character": 14,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 36,
+      "character": 15,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 36,
+      "character": 15,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 37,
+      "character": 16,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 37,
+      "character": 16,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 38,
+      "character": 17,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 38,
+      "character": 17,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 39,
+      "character": 18,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "{"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 39,
+      "character": 18,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 40,
+      "character": 19,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 40,
+      "character": 19,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 41,
+      "character": 20,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "["
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 41,
+      "character": 20,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 47,
+      "character": 26,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "number"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 47,
+      "character": 26,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 48,
+      "character": 27,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "]"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 48,
+      "character": 27,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 49,
+      "character": 28,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": ":"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 49,
+      "character": 28,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 50,
+      "character": 29,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 50,
+      "character": 29,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 51,
+      "character": 30,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "T"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 51,
+      "character": 30,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 52,
+      "character": 31,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 52,
+      "character": 31,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 53,
+      "character": 32,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "}"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 53,
+      "character": 32,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 53,
+      "character": 32,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Eof"
+    }
+  }
+]


### PR DESCRIPTION
Adds support for shorthand array type notation under the `roblox` feature flag
e.g. `type Foo = { number }`
Fixes #106 