### PR TITLE
Expose Punctuated fields in TableConstructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Added support for retrieving the `Punctuated` sequence of fields in a `TableConstructor`
+
+### Changed
+- `TableConstructor::iter_fields` is now deprecated in favour of `parameters().iter`
+
 ## [0.8.0] - 2020-12-21
 ### Added
 - Added `with_XXX` methods to Roblox-related structs under the `roblox` feature flag

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -227,8 +227,14 @@ impl<'a> TableConstructor<'a> {
     }
 
     /// An iterator over the fields used to create the table
+    #[deprecated(note = "Please use fields().iter instead")]
     pub fn iter_fields(&self) -> impl Iterator<Item = &Field<'a>> {
         self.fields.iter()
+    }
+
+    /// Returns the [`Punctuated`] sequence of the fields used to create the table
+    pub fn fields(&self) -> &Punctuated<'a, Field<'a>> {
+        &self.fields
     }
 
     /// Returns a new TableConstructor with the given braces


### PR DESCRIPTION
This PR adds a `.fields()` method to FunctionBody in order to retrieve the Punctuated sequence of fields
Deprecates `FunctionBody::iter_fields`