### PR TITLE
Show luau-related docs

### DIFF
--- a/full-moon/Cargo.toml
+++ b/full-moon/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["parsing"]
 keywords = ["lua", "parser", "lua51"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+features = ["roblox"]
+
 [features]
 default = ["serde"]
 roblox = []


### PR DESCRIPTION
This PR makes docs.rs read through the crate with the `roblox` feature flag, so that it documents the luau related nodes