### PR TITLE
TokenReference PartialEq now checks if leading_trivia and trailing_trivia are equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.
+- TokenReference equality now checks for leading and trailing trivia to be the same.
 
 ## [0.9.0] - 2020-12-21
 ### Added

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -536,6 +536,8 @@ impl<'a> fmt::Display for TokenReference<'a> {
 impl<'a> PartialEq<Self> for TokenReference<'a> {
     fn eq(&self, other: &Self) -> bool {
         (**self).eq(other)
+            && self.leading_trivia == other.leading_trivia
+            && self.trailing_trivia == other.trailing_trivia
     }
 }
 


### PR DESCRIPTION
This was causing tests to not fail when trivia was different.

Will be merged once it is confirmed selene did not rely on this in some way.