### PR TITLE
Implement new binary operator AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `block.iter_stmts_with_semicolon()` which returns an iterator over tuples containing the statement and an optional semicolon.
+- Added `Expression::BinaryOperator{ lhs, binop, rhs }` which now handles binary operation expressions, with support for precedence.
+- Added `operator.precedence()` to `BinOp` and `UnOp`. This returns the precedence value from a scale of 1-8 for the operator, where 8 is highest precedence.
+- Added `binop.is_right_associative()` to `BinOp`. This returns whether the binary operator is right associative.
 
 ### Changed
 - Updated dependency cfg_if to v1.0
+- **[BREAKING CHANGE]** Moved binary operations to `Expression::BinaryOperator`. `binop` has been removed from `Expression::Value`
+- Removed `BinOpRhs`. This is now part of `Expression::BinaryOperator`.
+- Removed `visit_bin_op` and related visitors. Binary operations should be handled in the expression visitor
+- Removed `Value::ParseExpression`. This should now be handled by the `lhs` of `Expression::BinaryOperator`
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[BREAKING CHANGE]** Moved binary operations to `Expression::BinaryOperator`. `binop` has been removed from `Expression::Value`
 - Removed `BinOpRhs`. This is now part of `Expression::BinaryOperator`.
 - Removed `visit_bin_op` and related visitors. Binary operations should be handled in the expression visitor
-- Renamed `Value::ParseExpression` to `Value::ParenthesesExpression`
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[BREAKING CHANGE]** Moved binary operations to `Expression::BinaryOperator`. `binop` has been removed from `Expression::Value`
 - Removed `BinOpRhs`. This is now part of `Expression::BinaryOperator`.
 - Removed `visit_bin_op` and related visitors. Binary operations should be handled in the expression visitor
-- Removed `Value::ParseExpression`. This should now be handled by the `lhs` of `Expression::BinaryOperator`
+- Renamed `Value::ParseExpression` to `Value::ParenthesesExpression`
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -262,49 +262,23 @@ impl Default for TableConstructor<'_> {
     }
 }
 
-/// A binary operation, such as (`+ 3`)
-#[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[display(fmt = "{}{}", bin_op, rhs)]
-#[visit(visit_as = "bin_op")]
-pub struct BinOpRhs<'a> {
-    #[cfg_attr(feature = "serde", serde(borrow))]
-    bin_op: BinOp<'a>,
-    rhs: Box<Expression<'a>>,
-}
-
-impl<'a> BinOpRhs<'a> {
-    /// Creates a new BinOpRhs from the given binary operator and right hand side
-    pub fn new(bin_op: BinOp<'a>, rhs: Box<Expression<'a>>) -> Self {
-        Self { bin_op, rhs }
-    }
-
-    /// The binary operation used, the `+` part of `+ 3`
-    pub fn bin_op(&self) -> &BinOp<'a> {
-        &self.bin_op
-    }
-
-    /// The right hand side of the binary operation, the `3` part of `+ 3`
-    pub fn rhs(&self) -> &Expression<'a> {
-        self.rhs.as_ref()
-    }
-
-    /// Returns a new BinOpRhs with the given binary operator token
-    pub fn with_bin_op(self, bin_op: BinOp<'a>) -> Self {
-        Self { bin_op, ..self }
-    }
-
-    /// Returns a new BinOpRhs with the given right hand side
-    pub fn with_rhs(self, rhs: Box<Expression<'a>>) -> Self {
-        Self { rhs, ..self }
-    }
-}
-
 /// An expression, mostly useful for getting values
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
 pub enum Expression<'a> {
+    /// A binary operation, such as `1 + 3`
+    #[display(fmt = "{}{}{}", "lhs", "binop", "rhs")]
+    BinaryOperator {
+        /// The left hand side of the binary operation, the `1` part of `1 + 3`
+        lhs: Box<Expression<'a>>,
+        /// The binary operation used, the `+` part of `1 + 3`
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        binop: BinOp<'a>,
+        /// The right hand side of the binary operation, the `3` part of `1 + 3`
+        rhs: Box<Expression<'a>>,
+    },
+
     /// A statement in parentheses, such as `(#list)`
     #[display(
         fmt = "{}{}{}",
@@ -332,25 +306,15 @@ pub enum Expression<'a> {
     },
 
     /// A value, such as "strings"
-    #[cfg_attr(
-        not(feature = "roblox"),
-        display(fmt = "{}{}", value, "display_option(binop)")
-    )]
+    #[cfg_attr(not(feature = "roblox"), display(fmt = "{}", value))]
     #[cfg_attr(
         feature = "roblox",
-        display(
-            fmt = "{}{}{}",
-            value,
-            "display_option(binop)",
-            "display_option(as_assertion)"
-        )
+        display(fmt = "{}{}", value, "display_option(as_assertion)")
     )]
     Value {
         /// The value itself
         #[cfg_attr(feature = "serde", serde(borrow))]
         value: Box<Value<'a>>,
-        /// The binary operation being done, if one exists (the `+ 3` part of `2 + 3`)
-        binop: Option<BinOpRhs<'a>>,
         /// What the value is being asserted as using `as`.
         /// Only available when the "roblox" feature flag is enabled.
         #[cfg(feature = "roblox")]
@@ -377,9 +341,6 @@ pub enum Value<'a> {
     /// A number token, such as `3.3`
     #[display(fmt = "{}", "_0")]
     Number(Cow<'a, TokenReference<'a>>),
-    /// An expression between parentheses, such as `(3 + 2)`
-    #[display(fmt = "{}", "_0")]
-    ParseExpression(Expression<'a>),
     /// A string token, such as `"hello"`
     #[display(fmt = "{}", "_0")]
     String(Cow<'a, TokenReference<'a>>),
@@ -2060,6 +2021,33 @@ make_op!(BinOp,
     }
 );
 
+impl BinOp<'_> {
+    /// The precedence of the operator, from a scale of 1 to 8. The larger the number, the higher the precedence.
+    /// See more at http://www.lua.org/manual/5.1/manual.html#2.5.6
+    pub fn precedence(&self) -> u8 {
+        match *self {
+            BinOp::Caret(_) => 8,
+            BinOp::Star(_) | BinOp::Slash(_) | BinOp::Percent(_) => 6,
+            BinOp::Plus(_) | BinOp::Minus(_) => 5,
+            BinOp::TwoDots(_) => 4,
+            BinOp::GreaterThan(_)
+            | BinOp::LessThan(_)
+            | BinOp::GreaterThanEqual(_)
+            | BinOp::LessThanEqual(_)
+            | BinOp::TildeEqual(_)
+            | BinOp::TwoEqual(_) => 3,
+            BinOp::And(_) => 2,
+            BinOp::Or(_) => 1,
+        }
+    }
+
+    /// Whether the operator is right associative. If not, it is left associative
+    /// See more at https://www.lua.org/pil/3.5.html
+    pub fn is_right_associative(&self) -> bool {
+        matches!(*self, BinOp::Caret(_) | BinOp::TwoDots(_))
+    }
+}
+
 make_op!(UnOp,
     #[doc = "Operators that require just one operand, such as #X"]
     {
@@ -2068,6 +2056,14 @@ make_op!(UnOp,
         Hash,
     }
 );
+
+impl UnOp<'_> {
+    /// The precedence of the operator, from a scale of 1 to 8. The larger the number, the higher the precedence.
+    /// See more at http://www.lua.org/manual/5.1/manual.html#2.5.6
+    pub fn precedence(&self) -> u8 {
+        7
+    }
+}
 
 /// An error that occurs when creating the ast *after* tokenizing
 #[derive(Clone, Debug, PartialEq)]
@@ -2350,7 +2346,6 @@ mod tests {
 
         let expression = Expression::Value {
             value: Box::new(Value::Var(Var::Name(token.clone()))),
-            binop: None,
             #[cfg(feature = "roblox")]
             as_assertion: None,
         };

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -343,7 +343,7 @@ pub enum Value<'a> {
     Number(Cow<'a, TokenReference<'a>>),
     /// An expression between parentheses, such as `(3 + 2)`
     #[display(fmt = "{}", "_0")]
-    ParenthesesExpression(Expression<'a>),
+    ParseExpression(Expression<'a>),
     /// A string token, such as `"hello"`
     #[display(fmt = "{}", "_0")]
     String(Cow<'a, TokenReference<'a>>),

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2044,7 +2044,7 @@ impl BinOp<'_> {
         }
     }
 
-    /// Whether the operator is right associative. If not, it is left associative
+    /// Whether the operator is right associative. If not, it is left associative.
     /// See more at https://www.lua.org/pil/3.5.html
     pub fn is_right_associative(&self) -> bool {
         matches!(*self, BinOp::Caret(_) | BinOp::TwoDots(_))

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -341,6 +341,9 @@ pub enum Value<'a> {
     /// A number token, such as `3.3`
     #[display(fmt = "{}", "_0")]
     Number(Cow<'a, TokenReference<'a>>),
+    /// An expression between parentheses, such as `(3 + 2)`
+    #[display(fmt = "{}", "_0")]
+    ParenthesesExpression(Expression<'a>),
     /// A string token, such as `"hello"`
     #[display(fmt = "{}", "_0")]
     String(Cow<'a, TokenReference<'a>>),

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -300,8 +300,6 @@ define_parser!(ParsePartExpression, Expression<'a>, |_,
 >| {
     if let Ok((state, expression)) = keep_going!(ParseUnaryExpression.parse(state)) {
         Ok((state, expression))
-    } else if let Ok((state, expression)) = keep_going!(ParseParenExpression.parse(state)) {
-        Ok((state, expression))
     } else if let Ok((state, expression)) = keep_going!(ParseValueExpression.parse(state)) {
         Ok((state, expression))
     } else {
@@ -401,6 +399,7 @@ define_parser!(
         ParseTableConstructor => Value::TableConstructor,
         ParseFunctionCall => Value::FunctionCall,
         ParseVar => Value::Var,
+        ParseParenExpression => Value::ParenthesesExpression,
     })
 );
 

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -221,11 +221,57 @@ define_parser!(
 );
 
 #[derive(Clone, Debug, PartialEq)]
-struct ParseExpression;
+struct ParseUnaryExpression;
 define_parser!(
-    ParseExpression,
+    ParseUnaryExpression,
     Expression<'a>,
-    |_, state: ParserState<'a>| if let Ok((state, value)) = keep_going!(ParseValue.parse(state)) {
+    |_, state: ParserState<'a>| {
+        let (state, unop) = keep_going!(ParseUnOp.parse(state))?;
+        let (state, expression) = expect!(
+            state,
+            ParseExpressionAtPrecedence(unop.precedence()).parse(state),
+            "expected expression"
+        );
+        let expression = Box::new(expression);
+
+        Ok((state, Expression::UnaryOperator { unop, expression }))
+    }
+);
+
+#[derive(Clone, Debug, PartialEq)]
+struct ParseParenExpression;
+define_parser!(
+    ParseParenExpression,
+    Expression<'a>,
+    |_, state: ParserState<'a>| {
+        let (state, left_paren) = ParseSymbol(Symbol::LeftParen).parse(state)?;
+        let (state, expression) =
+            expect!(state, ParseExpression.parse(state), "expected expression");
+
+        let (state, right_paren) = expect!(
+            state,
+            ParseSymbol(Symbol::RightParen).parse(state),
+            "expected ')'"
+        );
+
+        Ok((
+            state,
+            Expression::Parentheses {
+                contained: ContainedSpan::new(left_paren, right_paren),
+                expression: Box::new(expression),
+            },
+        ))
+    }
+);
+
+#[derive(Clone, Debug, PartialEq)]
+struct ParseValueExpression;
+define_parser!(
+    ParseValueExpression,
+    Expression<'a>,
+    |_, state: ParserState<'a>| {
+        let (state, value) = keep_going!(ParseValue.parse(state))?;
+        #[cfg(feature = "roblox")]
         let (state, as_assertion) =
             if let Ok((state, as_assertion)) = keep_going!(ParseAsAssertion.parse(state)) {
                 (state, Some(as_assertion))
@@ -233,46 +279,80 @@ define_parser!(
                 (state, None)
             };
 
-        let (state, binop) = if as_assertion.is_none() {
-            if let Ok((state, bin_op)) = ParseBinOp.parse(state) {
-                let (state, rhs) =
-                    expect!(state, ParseExpression.parse(state), "expected expression");
-
-                (
-                    state,
-                    Some(BinOpRhs {
-                        bin_op,
-                        rhs: Box::new(rhs),
-                    }),
-                )
-            } else {
-                (state, None)
-            }
-        } else {
-            (state, None)
-        };
-
         let value = Box::new(value);
 
         Ok((
             state,
             Expression::Value {
                 value,
-                binop,
                 #[cfg(feature = "roblox")]
                 as_assertion,
             },
         ))
-    } else if let Ok((state, unop)) = keep_going!(ParseUnOp.parse(state)) {
-        let (state, expression) =
-            expect!(state, ParseExpression.parse(state), "expected expression");
+    }
+);
 
-        let expression = Box::new(expression);
-
-        Ok((state, Expression::UnaryOperator { unop, expression }))
+#[derive(Clone, Debug, PartialEq)]
+struct ParsePartExpression;
+define_parser!(ParsePartExpression, Expression<'a>, |_,
+                                                     state: ParserState<
+    'a,
+>| {
+    if let Ok((state, expression)) = keep_going!(ParseUnaryExpression.parse(state)) {
+        Ok((state, expression))
+    } else if let Ok((state, expression)) = keep_going!(ParseParenExpression.parse(state)) {
+        Ok((state, expression))
+    } else if let Ok((state, expression)) = keep_going!(ParseValueExpression.parse(state)) {
+        Ok((state, expression))
     } else {
         Err(InternalAstError::NoMatch)
     }
+});
+
+#[derive(Clone, Debug, PartialEq)]
+struct ParseExpressionAtPrecedence(u8);
+define_parser!(
+    ParseExpressionAtPrecedence,
+    Expression<'a>,
+    |this: &ParseExpressionAtPrecedence, state: ParserState<'a>| {
+        let min_precedence = this.0;
+        let (mut state, mut current_expr) = ParsePartExpression.parse(state)?;
+
+        // See if we can find a Binary Operator
+        while let Ok((next_state, operator)) = ParseBinOp.parse(state) {
+            if operator.precedence() < min_precedence {
+                break;
+            }
+
+            let next_min_precedence = if operator.is_right_associative() {
+                operator.precedence()
+            } else {
+                operator.precedence() + 1
+            };
+
+            let (next_state, rhs) = expect!(
+                next_state,
+                ParseExpressionAtPrecedence(next_min_precedence).parse(next_state),
+                "expected expression"
+            );
+            state = next_state;
+            current_expr = Expression::BinaryOperator {
+                lhs: Box::new(current_expr),
+                binop: operator,
+                rhs: Box::new(rhs),
+            };
+        }
+
+        Ok((state, current_expr))
+    }
+);
+
+#[derive(Clone, Debug, PartialEq)]
+struct ParseExpression;
+define_parser!(
+    ParseExpression,
+    Expression<'a>,
+    |_, state: ParserState<'a>| { ParseExpressionAtPrecedence(1).parse(state) }
 );
 
 #[derive(Clone, Debug, PartialEq)]
@@ -306,35 +386,6 @@ define_roblox_parser!(
 );
 
 #[derive(Clone, Debug, PartialEq)]
-struct ParseParenExpression;
-define_parser!(
-    ParseParenExpression,
-    Expression<'a>,
-    |_, state: ParserState<'a>| if let Ok((state, left_paren)) =
-        ParseSymbol(Symbol::LeftParen).parse(state)
-    {
-        let (state, expression) =
-            expect!(state, ParseExpression.parse(state), "expected expression");
-
-        let (state, right_paren) = expect!(
-            state,
-            ParseSymbol(Symbol::RightParen).parse(state),
-            "expected ')'"
-        );
-
-        Ok((
-            state,
-            Expression::Parentheses {
-                contained: ContainedSpan::new(left_paren, right_paren),
-                expression: Box::new(expression),
-            },
-        ))
-    } else {
-        Err(InternalAstError::NoMatch)
-    }
-);
-
-#[derive(Clone, Debug, PartialEq)]
 struct ParseValue;
 define_parser!(
     ParseValue,
@@ -350,7 +401,6 @@ define_parser!(
         ParseTableConstructor => Value::TableConstructor,
         ParseFunctionCall => Value::FunctionCall,
         ParseVar => Value::Var,
-        ParseParenExpression => Value::ParseExpression,
     })
 );
 

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -399,7 +399,7 @@ define_parser!(
         ParseTableConstructor => Value::TableConstructor,
         ParseFunctionCall => Value::FunctionCall,
         ParseVar => Value::Var,
-        ParseParenExpression => Value::ParenthesesExpression,
+        ParseParenExpression => Value::ParseExpression,
     })
 );
 

--- a/full-moon/src/ast/visitors.rs
+++ b/full-moon/src/ast/visitors.rs
@@ -82,6 +82,12 @@ impl<'a> Visit<'a> for Expression<'a> {
     fn visit<V: Visitor<'a>>(&self, visitor: &mut V) {
         visitor.visit_expression(self);
         match self {
+            Expression::BinaryOperator { lhs, binop, rhs } => {
+                lhs.visit(visitor);
+                binop.visit(visitor);
+                rhs.visit(visitor);
+            }
+
             Expression::Parentheses {
                 contained,
                 expression,
@@ -96,12 +102,10 @@ impl<'a> Visit<'a> for Expression<'a> {
             }
             Expression::Value {
                 value,
-                binop,
                 #[cfg(feature = "roblox")]
                 as_assertion,
             } => {
                 value.visit(visitor);
-                binop.visit(visitor);
                 #[cfg(feature = "roblox")]
                 as_assertion.visit(visitor);
             }
@@ -115,6 +119,12 @@ impl<'a> VisitMut<'a> for Expression<'a> {
     fn visit_mut<V: VisitorMut<'a>>(mut self, visitor: &mut V) -> Self {
         self = visitor.visit_expression(self);
         self = match self {
+            Expression::BinaryOperator { lhs, binop, rhs } => Expression::BinaryOperator {
+                lhs: lhs.visit_mut(visitor),
+                binop: binop.visit_mut(visitor),
+                rhs: rhs.visit_mut(visitor),
+            },
+
             Expression::Parentheses {
                 mut contained,
                 mut expression,
@@ -136,12 +146,10 @@ impl<'a> VisitMut<'a> for Expression<'a> {
 
             Expression::Value {
                 value,
-                binop,
                 #[cfg(feature = "roblox")]
                 as_assertion,
             } => Expression::Value {
                 value: value.visit_mut(visitor),
-                binop: binop.visit_mut(visitor),
                 #[cfg(feature = "roblox")]
                 as_assertion: as_assertion.visit_mut(visitor),
             },

--- a/full-moon/src/visitors.rs
+++ b/full-moon/src/visitors.rs
@@ -230,7 +230,6 @@ impl<'ast, T: VisitMut<'ast>> VisitMut<'ast> for Box<T> {
 create_visitor!(ast: {
     visit_anonymous_call => FunctionArgs,
     visit_assignment => Assignment,
-    visit_bin_op => BinOpRhs,
     visit_block => Block,
     visit_call => Call,
     visit_contained_span => ContainedSpan,

--- a/full-moon/tests/cases/pass/binops/ast.json
+++ b/full-moon/tests/cases/pass/binops/ast.json
@@ -1,0 +1,2773 @@
+{
+  "stmts": [
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 0,
+                        "character": 1,
+                        "line": 1
+                      },
+                      "end_position": {
+                        "bytes": 1,
+                        "character": 2,
+                        "line": 1
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "a"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 1,
+                          "character": 2,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 2,
+                          "character": 3,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 2,
+                "character": 3,
+                "line": 1
+              },
+              "end_position": {
+                "bytes": 3,
+                "character": 4,
+                "line": 1
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 3,
+                  "character": 4,
+                  "line": 1
+                },
+                "end_position": {
+                  "bytes": 4,
+                  "character": 5,
+                  "line": 1
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "lhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 4,
+                              "character": 5,
+                              "line": 1
+                            },
+                            "end_position": {
+                              "bytes": 7,
+                              "character": 8,
+                              "line": 1
+                            },
+                            "token_type": {
+                              "type": "Identifier",
+                              "identifier": "foo"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 7,
+                                "character": 8,
+                                "line": 1
+                              },
+                              "end_position": {
+                                "bytes": 8,
+                                "character": 9,
+                                "line": 1
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "And": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 8,
+                          "character": 9,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 11,
+                          "character": 12,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "and"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
+                          "start_position": {
+                            "bytes": 11,
+                            "character": 12,
+                            "line": 1
+                          },
+                          "end_position": {
+                            "bytes": 12,
+                            "character": 13,
+                            "line": 1
+                          },
+                          "token_type": {
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 12,
+                              "character": 13,
+                              "line": 1
+                            },
+                            "end_position": {
+                              "bytes": 15,
+                              "character": 16,
+                              "line": 1
+                            },
+                            "token_type": {
+                              "type": "Identifier",
+                              "identifier": "bar"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 15,
+                          "character": 16,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 16,
+                          "character": 16,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": "\n"
+                        }
+                      }
+                    ],
+                    "token": {
+                      "start_position": {
+                        "bytes": 16,
+                        "character": 1,
+                        "line": 2
+                      },
+                      "end_position": {
+                        "bytes": 17,
+                        "character": 2,
+                        "line": 2
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "b"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 17,
+                          "character": 2,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 18,
+                          "character": 3,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 18,
+                "character": 3,
+                "line": 2
+              },
+              "end_position": {
+                "bytes": 19,
+                "character": 4,
+                "line": 2
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 19,
+                  "character": 4,
+                  "line": 2
+                },
+                "end_position": {
+                  "bytes": 20,
+                  "character": 5,
+                  "line": 2
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "lhs": {
+                    "lhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 20,
+                                "character": 5,
+                                "line": 2
+                              },
+                              "end_position": {
+                                "bytes": 23,
+                                "character": 8,
+                                "line": 2
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "foo"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 23,
+                                  "character": 8,
+                                  "line": 2
+                                },
+                                "end_position": {
+                                  "bytes": 24,
+                                  "character": 9,
+                                  "line": 2
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "And": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 24,
+                            "character": 9,
+                            "line": 2
+                          },
+                          "end_position": {
+                            "bytes": 27,
+                            "character": 12,
+                            "line": 2
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "and"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 27,
+                              "character": 12,
+                              "line": 2
+                            },
+                            "end_position": {
+                              "bytes": 28,
+                              "character": 13,
+                              "line": 2
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 28,
+                                "character": 13,
+                                "line": 2
+                              },
+                              "end_position": {
+                                "bytes": 31,
+                                "character": 16,
+                                "line": 2
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "bar"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 31,
+                                  "character": 16,
+                                  "line": 2
+                                },
+                                "end_position": {
+                                  "bytes": 32,
+                                  "character": 17,
+                                  "line": 2
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "Or": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 32,
+                          "character": 17,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 34,
+                          "character": 19,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "or"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
+                          "start_position": {
+                            "bytes": 34,
+                            "character": 19,
+                            "line": 2
+                          },
+                          "end_position": {
+                            "bytes": 35,
+                            "character": 20,
+                            "line": 2
+                          },
+                          "token_type": {
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 35,
+                              "character": 20,
+                              "line": 2
+                            },
+                            "end_position": {
+                              "bytes": 38,
+                              "character": 23,
+                              "line": 2
+                            },
+                            "token_type": {
+                              "type": "Identifier",
+                              "identifier": "baz"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 38,
+                          "character": 23,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 39,
+                          "character": 23,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": "\n"
+                        }
+                      }
+                    ],
+                    "token": {
+                      "start_position": {
+                        "bytes": 39,
+                        "character": 1,
+                        "line": 3
+                      },
+                      "end_position": {
+                        "bytes": 40,
+                        "character": 2,
+                        "line": 3
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "c"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 40,
+                          "character": 2,
+                          "line": 3
+                        },
+                        "end_position": {
+                          "bytes": 41,
+                          "character": 3,
+                          "line": 3
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 41,
+                "character": 3,
+                "line": 3
+              },
+              "end_position": {
+                "bytes": 42,
+                "character": 4,
+                "line": 3
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 42,
+                  "character": 4,
+                  "line": 3
+                },
+                "end_position": {
+                  "bytes": 43,
+                  "character": 5,
+                  "line": 3
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "lhs": {
+                    "lhs": {
+                      "value": {
+                        "Number": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 43,
+                              "character": 5,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 44,
+                              "character": 6,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Number",
+                              "text": "1"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 44,
+                                "character": 6,
+                                "line": 3
+                              },
+                              "end_position": {
+                                "bytes": 45,
+                                "character": 7,
+                                "line": 3
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "binop": {
+                      "Plus": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 45,
+                            "character": 7,
+                            "line": 3
+                          },
+                          "end_position": {
+                            "bytes": 46,
+                            "character": 8,
+                            "line": 3
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "+"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 46,
+                              "character": 8,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 47,
+                              "character": 9,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "lhs": {
+                        "value": {
+                          "Number": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 47,
+                                "character": 9,
+                                "line": 3
+                              },
+                              "end_position": {
+                                "bytes": 48,
+                                "character": 10,
+                                "line": 3
+                              },
+                              "token_type": {
+                                "type": "Number",
+                                "text": "2"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 48,
+                                  "character": 10,
+                                  "line": 3
+                                },
+                                "end_position": {
+                                  "bytes": 49,
+                                  "character": 11,
+                                  "line": 3
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "binop": {
+                        "Star": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 49,
+                              "character": 11,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 50,
+                              "character": 12,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Symbol",
+                              "symbol": "*"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 50,
+                                "character": 12,
+                                "line": 3
+                              },
+                              "end_position": {
+                                "bytes": 51,
+                                "character": 13,
+                                "line": 3
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "rhs": {
+                        "value": {
+                          "Number": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 51,
+                                "character": 13,
+                                "line": 3
+                              },
+                              "end_position": {
+                                "bytes": 52,
+                                "character": 14,
+                                "line": 3
+                              },
+                              "token_type": {
+                                "type": "Number",
+                                "text": "3"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 52,
+                                  "character": 14,
+                                  "line": 3
+                                },
+                                "end_position": {
+                                  "bytes": 53,
+                                  "character": 15,
+                                  "line": 3
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "Minus": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 53,
+                          "character": 15,
+                          "line": 3
+                        },
+                        "end_position": {
+                          "bytes": 54,
+                          "character": 16,
+                          "line": 3
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "-"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
+                          "start_position": {
+                            "bytes": 54,
+                            "character": 16,
+                            "line": 3
+                          },
+                          "end_position": {
+                            "bytes": 55,
+                            "character": 17,
+                            "line": 3
+                          },
+                          "token_type": {
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "lhs": {
+                      "value": {
+                        "Number": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 55,
+                              "character": 17,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 56,
+                              "character": 18,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Number",
+                              "text": "4"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 56,
+                                "character": 18,
+                                "line": 3
+                              },
+                              "end_position": {
+                                "bytes": 57,
+                                "character": 19,
+                                "line": 3
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "binop": {
+                      "Caret": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 57,
+                            "character": 19,
+                            "line": 3
+                          },
+                          "end_position": {
+                            "bytes": 58,
+                            "character": 20,
+                            "line": 3
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "^"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 58,
+                              "character": 20,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 59,
+                              "character": 21,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Number": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 59,
+                              "character": 21,
+                              "line": 3
+                            },
+                            "end_position": {
+                              "bytes": 60,
+                              "character": 22,
+                              "line": 3
+                            },
+                            "token_type": {
+                              "type": "Number",
+                              "text": "2"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 60,
+                          "character": 22,
+                          "line": 3
+                        },
+                        "end_position": {
+                          "bytes": 61,
+                          "character": 22,
+                          "line": 3
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": "\n"
+                        }
+                      }
+                    ],
+                    "token": {
+                      "start_position": {
+                        "bytes": 61,
+                        "character": 1,
+                        "line": 4
+                      },
+                      "end_position": {
+                        "bytes": 62,
+                        "character": 2,
+                        "line": 4
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "d"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 62,
+                          "character": 2,
+                          "line": 4
+                        },
+                        "end_position": {
+                          "bytes": 63,
+                          "character": 3,
+                          "line": 4
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 63,
+                "character": 3,
+                "line": 4
+              },
+              "end_position": {
+                "bytes": 64,
+                "character": 4,
+                "line": 4
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 64,
+                  "character": 4,
+                  "line": 4
+                },
+                "end_position": {
+                  "bytes": 65,
+                  "character": 5,
+                  "line": 4
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "lhs": {
+                    "lhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 65,
+                                "character": 5,
+                                "line": 4
+                              },
+                              "end_position": {
+                                "bytes": 66,
+                                "character": 6,
+                                "line": 4
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "a"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 66,
+                                  "character": 6,
+                                  "line": 4
+                                },
+                                "end_position": {
+                                  "bytes": 67,
+                                  "character": 7,
+                                  "line": 4
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "Plus": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 67,
+                            "character": 7,
+                            "line": 4
+                          },
+                          "end_position": {
+                            "bytes": 68,
+                            "character": 8,
+                            "line": 4
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "+"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 68,
+                              "character": 8,
+                              "line": 4
+                            },
+                            "end_position": {
+                              "bytes": 69,
+                              "character": 9,
+                              "line": 4
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 69,
+                                "character": 9,
+                                "line": 4
+                              },
+                              "end_position": {
+                                "bytes": 70,
+                                "character": 10,
+                                "line": 4
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "i"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 70,
+                                  "character": 10,
+                                  "line": 4
+                                },
+                                "end_position": {
+                                  "bytes": 71,
+                                  "character": 11,
+                                  "line": 4
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "LessThan": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 71,
+                          "character": 11,
+                          "line": 4
+                        },
+                        "end_position": {
+                          "bytes": 72,
+                          "character": 12,
+                          "line": 4
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "<"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
+                          "start_position": {
+                            "bytes": 72,
+                            "character": 12,
+                            "line": 4
+                          },
+                          "end_position": {
+                            "bytes": 73,
+                            "character": 13,
+                            "line": 4
+                          },
+                          "token_type": {
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "lhs": {
+                      "lhs": {
+                        "value": {
+                          "Var": {
+                            "Name": {
+                              "leading_trivia": [],
+                              "token": {
+                                "start_position": {
+                                  "bytes": 73,
+                                  "character": 13,
+                                  "line": 4
+                                },
+                                "end_position": {
+                                  "bytes": 74,
+                                  "character": 14,
+                                  "line": 4
+                                },
+                                "token_type": {
+                                  "type": "Identifier",
+                                  "identifier": "b"
+                                }
+                              },
+                              "trailing_trivia": [
+                                {
+                                  "start_position": {
+                                    "bytes": 74,
+                                    "character": 14,
+                                    "line": 4
+                                  },
+                                  "end_position": {
+                                    "bytes": 75,
+                                    "character": 15,
+                                    "line": 4
+                                  },
+                                  "token_type": {
+                                    "type": "Whitespace",
+                                    "characters": " "
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "binop": {
+                        "Slash": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 75,
+                              "character": 15,
+                              "line": 4
+                            },
+                            "end_position": {
+                              "bytes": 76,
+                              "character": 16,
+                              "line": 4
+                            },
+                            "token_type": {
+                              "type": "Symbol",
+                              "symbol": "/"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 76,
+                                "character": 16,
+                                "line": 4
+                              },
+                              "end_position": {
+                                "bytes": 77,
+                                "character": 17,
+                                "line": 4
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "rhs": {
+                        "value": {
+                          "Number": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 77,
+                                "character": 17,
+                                "line": 4
+                              },
+                              "end_position": {
+                                "bytes": 78,
+                                "character": 18,
+                                "line": 4
+                              },
+                              "token_type": {
+                                "type": "Number",
+                                "text": "2"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 78,
+                                  "character": 18,
+                                  "line": 4
+                                },
+                                "end_position": {
+                                  "bytes": 79,
+                                  "character": 19,
+                                  "line": 4
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "Plus": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 79,
+                            "character": 19,
+                            "line": 4
+                          },
+                          "end_position": {
+                            "bytes": 80,
+                            "character": 20,
+                            "line": 4
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "+"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 80,
+                              "character": 20,
+                              "line": 4
+                            },
+                            "end_position": {
+                              "bytes": 81,
+                              "character": 21,
+                              "line": 4
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Number": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 81,
+                              "character": 21,
+                              "line": 4
+                            },
+                            "end_position": {
+                              "bytes": 82,
+                              "character": 22,
+                              "line": 4
+                            },
+                            "token_type": {
+                              "type": "Number",
+                              "text": "1"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 82,
+                          "character": 22,
+                          "line": 4
+                        },
+                        "end_position": {
+                          "bytes": 83,
+                          "character": 22,
+                          "line": 4
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": "\n"
+                        }
+                      }
+                    ],
+                    "token": {
+                      "start_position": {
+                        "bytes": 83,
+                        "character": 1,
+                        "line": 5
+                      },
+                      "end_position": {
+                        "bytes": 84,
+                        "character": 2,
+                        "line": 5
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "e"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 84,
+                          "character": 2,
+                          "line": 5
+                        },
+                        "end_position": {
+                          "bytes": 85,
+                          "character": 3,
+                          "line": 5
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 85,
+                "character": 3,
+                "line": 5
+              },
+              "end_position": {
+                "bytes": 86,
+                "character": 4,
+                "line": 5
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 86,
+                  "character": 4,
+                  "line": 5
+                },
+                "end_position": {
+                  "bytes": 87,
+                  "character": 5,
+                  "line": 5
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "lhs": {
+                    "value": {
+                      "Number": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 87,
+                            "character": 5,
+                            "line": 5
+                          },
+                          "end_position": {
+                            "bytes": 88,
+                            "character": 6,
+                            "line": 5
+                          },
+                          "token_type": {
+                            "type": "Number",
+                            "text": "5"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 88,
+                              "character": 6,
+                              "line": 5
+                            },
+                            "end_position": {
+                              "bytes": 89,
+                              "character": 7,
+                              "line": 5
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "binop": {
+                    "Plus": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 89,
+                          "character": 7,
+                          "line": 5
+                        },
+                        "end_position": {
+                          "bytes": 90,
+                          "character": 8,
+                          "line": 5
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "+"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
+                          "start_position": {
+                            "bytes": 90,
+                            "character": 8,
+                            "line": 5
+                          },
+                          "end_position": {
+                            "bytes": 91,
+                            "character": 9,
+                            "line": 5
+                          },
+                          "token_type": {
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "lhs": {
+                      "lhs": {
+                        "value": {
+                          "Var": {
+                            "Name": {
+                              "leading_trivia": [],
+                              "token": {
+                                "start_position": {
+                                  "bytes": 91,
+                                  "character": 9,
+                                  "line": 5
+                                },
+                                "end_position": {
+                                  "bytes": 92,
+                                  "character": 10,
+                                  "line": 5
+                                },
+                                "token_type": {
+                                  "type": "Identifier",
+                                  "identifier": "x"
+                                }
+                              },
+                              "trailing_trivia": [
+                                {
+                                  "start_position": {
+                                    "bytes": 92,
+                                    "character": 10,
+                                    "line": 5
+                                  },
+                                  "end_position": {
+                                    "bytes": 93,
+                                    "character": 11,
+                                    "line": 5
+                                  },
+                                  "token_type": {
+                                    "type": "Whitespace",
+                                    "characters": " "
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "binop": {
+                        "Caret": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 93,
+                              "character": 11,
+                              "line": 5
+                            },
+                            "end_position": {
+                              "bytes": 94,
+                              "character": 12,
+                              "line": 5
+                            },
+                            "token_type": {
+                              "type": "Symbol",
+                              "symbol": "^"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 94,
+                                "character": 12,
+                                "line": 5
+                              },
+                              "end_position": {
+                                "bytes": 95,
+                                "character": 13,
+                                "line": 5
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "rhs": {
+                        "value": {
+                          "Number": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 95,
+                                "character": 13,
+                                "line": 5
+                              },
+                              "end_position": {
+                                "bytes": 96,
+                                "character": 14,
+                                "line": 5
+                              },
+                              "token_type": {
+                                "type": "Number",
+                                "text": "2"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 96,
+                                  "character": 14,
+                                  "line": 5
+                                },
+                                "end_position": {
+                                  "bytes": 97,
+                                  "character": 15,
+                                  "line": 5
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "Star": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 97,
+                            "character": 15,
+                            "line": 5
+                          },
+                          "end_position": {
+                            "bytes": 98,
+                            "character": 16,
+                            "line": 5
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "*"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 98,
+                              "character": 16,
+                              "line": 5
+                            },
+                            "end_position": {
+                              "bytes": 99,
+                              "character": 17,
+                              "line": 5
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Number": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 99,
+                              "character": 17,
+                              "line": 5
+                            },
+                            "end_position": {
+                              "bytes": 100,
+                              "character": 18,
+                              "line": 5
+                            },
+                            "token_type": {
+                              "type": "Number",
+                              "text": "8"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 100,
+                          "character": 18,
+                          "line": 5
+                        },
+                        "end_position": {
+                          "bytes": 101,
+                          "character": 18,
+                          "line": 5
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": "\n"
+                        }
+                      }
+                    ],
+                    "token": {
+                      "start_position": {
+                        "bytes": 101,
+                        "character": 1,
+                        "line": 6
+                      },
+                      "end_position": {
+                        "bytes": 102,
+                        "character": 2,
+                        "line": 6
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "f"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 102,
+                          "character": 2,
+                          "line": 6
+                        },
+                        "end_position": {
+                          "bytes": 103,
+                          "character": 3,
+                          "line": 6
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 103,
+                "character": 3,
+                "line": 6
+              },
+              "end_position": {
+                "bytes": 104,
+                "character": 4,
+                "line": 6
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 104,
+                  "character": 4,
+                  "line": 6
+                },
+                "end_position": {
+                  "bytes": 105,
+                  "character": 5,
+                  "line": 6
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "lhs": {
+                    "lhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 105,
+                                "character": 5,
+                                "line": 6
+                              },
+                              "end_position": {
+                                "bytes": 106,
+                                "character": 6,
+                                "line": 6
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "a"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 106,
+                                  "character": 6,
+                                  "line": 6
+                                },
+                                "end_position": {
+                                  "bytes": 107,
+                                  "character": 7,
+                                  "line": 6
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "LessThan": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 107,
+                            "character": 7,
+                            "line": 6
+                          },
+                          "end_position": {
+                            "bytes": 108,
+                            "character": 8,
+                            "line": 6
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "<"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 108,
+                              "character": 8,
+                              "line": 6
+                            },
+                            "end_position": {
+                              "bytes": 109,
+                              "character": 9,
+                              "line": 6
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 109,
+                                "character": 9,
+                                "line": 6
+                              },
+                              "end_position": {
+                                "bytes": 110,
+                                "character": 10,
+                                "line": 6
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "y"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 110,
+                                  "character": 10,
+                                  "line": 6
+                                },
+                                "end_position": {
+                                  "bytes": 111,
+                                  "character": 11,
+                                  "line": 6
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "And": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 111,
+                          "character": 11,
+                          "line": 6
+                        },
+                        "end_position": {
+                          "bytes": 114,
+                          "character": 14,
+                          "line": 6
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "and"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
+                          "start_position": {
+                            "bytes": 114,
+                            "character": 14,
+                            "line": 6
+                          },
+                          "end_position": {
+                            "bytes": 115,
+                            "character": 15,
+                            "line": 6
+                          },
+                          "token_type": {
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "lhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 115,
+                                "character": 15,
+                                "line": 6
+                              },
+                              "end_position": {
+                                "bytes": 116,
+                                "character": 16,
+                                "line": 6
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "y"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 116,
+                                  "character": 16,
+                                  "line": 6
+                                },
+                                "end_position": {
+                                  "bytes": 117,
+                                  "character": 17,
+                                  "line": 6
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "LessThanEqual": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 117,
+                            "character": 17,
+                            "line": 6
+                          },
+                          "end_position": {
+                            "bytes": 119,
+                            "character": 19,
+                            "line": 6
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "<="
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 119,
+                              "character": 19,
+                              "line": 6
+                            },
+                            "end_position": {
+                              "bytes": 120,
+                              "character": 20,
+                              "line": 6
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 120,
+                                "character": 20,
+                                "line": 6
+                              },
+                              "end_position": {
+                                "bytes": 121,
+                                "character": 21,
+                                "line": 6
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "z"
+                              }
+                            },
+                            "trailing_trivia": []
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 121,
+                          "character": 21,
+                          "line": 6
+                        },
+                        "end_position": {
+                          "bytes": 122,
+                          "character": 21,
+                          "line": 6
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": "\n"
+                        }
+                      }
+                    ],
+                    "token": {
+                      "start_position": {
+                        "bytes": 122,
+                        "character": 1,
+                        "line": 7
+                      },
+                      "end_position": {
+                        "bytes": 123,
+                        "character": 2,
+                        "line": 7
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "g"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 123,
+                          "character": 2,
+                          "line": 7
+                        },
+                        "end_position": {
+                          "bytes": 124,
+                          "character": 3,
+                          "line": 7
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 124,
+                "character": 3,
+                "line": 7
+              },
+              "end_position": {
+                "bytes": 125,
+                "character": 4,
+                "line": 7
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 125,
+                  "character": 4,
+                  "line": 7
+                },
+                "end_position": {
+                  "bytes": 126,
+                  "character": 5,
+                  "line": 7
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "unop": {
+                    "Minus": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 126,
+                          "character": 5,
+                          "line": 7
+                        },
+                        "end_position": {
+                          "bytes": 127,
+                          "character": 6,
+                          "line": 7
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "-"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "expression": {
+                    "lhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 127,
+                                "character": 6,
+                                "line": 7
+                              },
+                              "end_position": {
+                                "bytes": 128,
+                                "character": 7,
+                                "line": 7
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "x"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 128,
+                                  "character": 7,
+                                  "line": 7
+                                },
+                                "end_position": {
+                                  "bytes": 129,
+                                  "character": 8,
+                                  "line": 7
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "Caret": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 129,
+                            "character": 8,
+                            "line": 7
+                          },
+                          "end_position": {
+                            "bytes": 130,
+                            "character": 9,
+                            "line": 7
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "^"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 130,
+                              "character": 9,
+                              "line": 7
+                            },
+                            "end_position": {
+                              "bytes": 131,
+                              "character": 10,
+                              "line": 7
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Number": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 131,
+                              "character": 10,
+                              "line": 7
+                            },
+                            "end_position": {
+                              "bytes": 132,
+                              "character": 11,
+                              "line": 7
+                            },
+                            "token_type": {
+                              "type": "Number",
+                              "text": "2"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ],
+    [
+      {
+        "Assignment": {
+          "var_list": {
+            "pairs": [
+              {
+                "End": {
+                  "Name": {
+                    "leading_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 132,
+                          "character": 11,
+                          "line": 7
+                        },
+                        "end_position": {
+                          "bytes": 133,
+                          "character": 11,
+                          "line": 7
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": "\n"
+                        }
+                      }
+                    ],
+                    "token": {
+                      "start_position": {
+                        "bytes": 133,
+                        "character": 1,
+                        "line": 8
+                      },
+                      "end_position": {
+                        "bytes": 134,
+                        "character": 2,
+                        "line": 8
+                      },
+                      "token_type": {
+                        "type": "Identifier",
+                        "identifier": "h"
+                      }
+                    },
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 134,
+                          "character": 2,
+                          "line": 8
+                        },
+                        "end_position": {
+                          "bytes": 135,
+                          "character": 3,
+                          "line": 8
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          },
+          "equal_token": {
+            "leading_trivia": [],
+            "token": {
+              "start_position": {
+                "bytes": 135,
+                "character": 3,
+                "line": 8
+              },
+              "end_position": {
+                "bytes": 136,
+                "character": 4,
+                "line": 8
+              },
+              "token_type": {
+                "type": "Symbol",
+                "symbol": "="
+              }
+            },
+            "trailing_trivia": [
+              {
+                "start_position": {
+                  "bytes": 136,
+                  "character": 4,
+                  "line": 8
+                },
+                "end_position": {
+                  "bytes": 137,
+                  "character": 5,
+                  "line": 8
+                },
+                "token_type": {
+                  "type": "Whitespace",
+                  "characters": " "
+                }
+              }
+            ]
+          },
+          "expr_list": {
+            "pairs": [
+              {
+                "End": {
+                  "lhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 137,
+                              "character": 5,
+                              "line": 8
+                            },
+                            "end_position": {
+                              "bytes": 138,
+                              "character": 6,
+                              "line": 8
+                            },
+                            "token_type": {
+                              "type": "Identifier",
+                              "identifier": "x"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 138,
+                                "character": 6,
+                                "line": 8
+                              },
+                              "end_position": {
+                                "bytes": 139,
+                                "character": 7,
+                                "line": 8
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "Caret": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 139,
+                          "character": 7,
+                          "line": 8
+                        },
+                        "end_position": {
+                          "bytes": 140,
+                          "character": 8,
+                          "line": 8
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "^"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
+                          "start_position": {
+                            "bytes": 140,
+                            "character": 8,
+                            "line": 8
+                          },
+                          "end_position": {
+                            "bytes": 141,
+                            "character": 9,
+                            "line": 8
+                          },
+                          "token_type": {
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "lhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 141,
+                                "character": 9,
+                                "line": 8
+                              },
+                              "end_position": {
+                                "bytes": 142,
+                                "character": 10,
+                                "line": 8
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "y"
+                              }
+                            },
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 142,
+                                  "character": 10,
+                                  "line": 8
+                                },
+                                "end_position": {
+                                  "bytes": 143,
+                                  "character": 11,
+                                  "line": 8
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "binop": {
+                      "Caret": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 143,
+                            "character": 11,
+                            "line": 8
+                          },
+                          "end_position": {
+                            "bytes": 144,
+                            "character": 12,
+                            "line": 8
+                          },
+                          "token_type": {
+                            "type": "Symbol",
+                            "symbol": "^"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 144,
+                              "character": 12,
+                              "line": 8
+                            },
+                            "end_position": {
+                              "bytes": 145,
+                              "character": 13,
+                              "line": 8
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "rhs": {
+                      "value": {
+                        "Var": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 145,
+                                "character": 13,
+                                "line": 8
+                              },
+                              "end_position": {
+                                "bytes": 146,
+                                "character": 14,
+                                "line": 8
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "z"
+                              }
+                            },
+                            "trailing_trivia": []
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      null
+    ]
+  ]
+}

--- a/full-moon/tests/cases/pass/binops/source.lua
+++ b/full-moon/tests/cases/pass/binops/source.lua
@@ -1,0 +1,8 @@
+a = foo and bar
+b = foo and bar or baz
+c = 1 + 2 * 3 - 4 ^ 2
+d = a + i < b / 2 + 1
+e = 5 + x ^ 2 * 8
+f = a < y and y <= z
+g = -x ^ 2
+h = x ^ y ^ z

--- a/full-moon/tests/cases/pass/binops/tokens.json
+++ b/full-moon/tests/cases/pass/binops/tokens.json
@@ -1,0 +1,2065 @@
+[
+  {
+    "start_position": {
+      "bytes": 0,
+      "character": 1,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 1,
+      "character": 2,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "a"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 1,
+      "character": 2,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 2,
+      "character": 3,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 2,
+      "character": 3,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 3,
+      "character": 4,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 3,
+      "character": 4,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 4,
+      "character": 5,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 4,
+      "character": 5,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 7,
+      "character": 8,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "foo"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 7,
+      "character": 8,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 8,
+      "character": 9,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 8,
+      "character": 9,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "and"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 11,
+      "character": 12,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 12,
+      "character": 13,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "bar"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 15,
+      "character": 16,
+      "line": 1
+    },
+    "end_position": {
+      "bytes": 16,
+      "character": 16,
+      "line": 1
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 16,
+      "character": 1,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 17,
+      "character": 2,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "b"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 17,
+      "character": 2,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 18,
+      "character": 3,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 18,
+      "character": 3,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 19,
+      "character": 4,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 19,
+      "character": 4,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 20,
+      "character": 5,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 20,
+      "character": 5,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 23,
+      "character": 8,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "foo"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 23,
+      "character": 8,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 24,
+      "character": 9,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 24,
+      "character": 9,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 27,
+      "character": 12,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "and"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 27,
+      "character": 12,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 28,
+      "character": 13,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 28,
+      "character": 13,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 31,
+      "character": 16,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "bar"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 31,
+      "character": 16,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 32,
+      "character": 17,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 32,
+      "character": 17,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 34,
+      "character": 19,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "or"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 34,
+      "character": 19,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 35,
+      "character": 20,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 35,
+      "character": 20,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 38,
+      "character": 23,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "baz"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 38,
+      "character": 23,
+      "line": 2
+    },
+    "end_position": {
+      "bytes": 39,
+      "character": 23,
+      "line": 2
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 39,
+      "character": 1,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 40,
+      "character": 2,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "c"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 40,
+      "character": 2,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 41,
+      "character": 3,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 41,
+      "character": 3,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 42,
+      "character": 4,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 42,
+      "character": 4,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 43,
+      "character": 5,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 43,
+      "character": 5,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 44,
+      "character": 6,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 44,
+      "character": 6,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 45,
+      "character": 7,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 45,
+      "character": 7,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 46,
+      "character": 8,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "+"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 46,
+      "character": 8,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 47,
+      "character": 9,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 47,
+      "character": 9,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 48,
+      "character": 10,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "2"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 48,
+      "character": 10,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 49,
+      "character": 11,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 49,
+      "character": 11,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 50,
+      "character": 12,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "*"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 50,
+      "character": 12,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 51,
+      "character": 13,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 51,
+      "character": 13,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 52,
+      "character": 14,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "3"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 52,
+      "character": 14,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 53,
+      "character": 15,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 53,
+      "character": 15,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 54,
+      "character": 16,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "-"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 54,
+      "character": 16,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 55,
+      "character": 17,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 55,
+      "character": 17,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 56,
+      "character": 18,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "4"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 56,
+      "character": 18,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 57,
+      "character": 19,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 57,
+      "character": 19,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 58,
+      "character": 20,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "^"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 58,
+      "character": 20,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 59,
+      "character": 21,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 59,
+      "character": 21,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 60,
+      "character": 22,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "2"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 60,
+      "character": 22,
+      "line": 3
+    },
+    "end_position": {
+      "bytes": 61,
+      "character": 22,
+      "line": 3
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 61,
+      "character": 1,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 62,
+      "character": 2,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "d"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 62,
+      "character": 2,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 63,
+      "character": 3,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 63,
+      "character": 3,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 64,
+      "character": 4,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 64,
+      "character": 4,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 65,
+      "character": 5,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 65,
+      "character": 5,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 66,
+      "character": 6,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "a"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 66,
+      "character": 6,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 67,
+      "character": 7,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 67,
+      "character": 7,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 68,
+      "character": 8,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "+"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 68,
+      "character": 8,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 69,
+      "character": 9,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 69,
+      "character": 9,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 70,
+      "character": 10,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "i"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 70,
+      "character": 10,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 71,
+      "character": 11,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 71,
+      "character": 11,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 72,
+      "character": 12,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "<"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 72,
+      "character": 12,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 73,
+      "character": 13,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 73,
+      "character": 13,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 74,
+      "character": 14,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "b"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 74,
+      "character": 14,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 75,
+      "character": 15,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 75,
+      "character": 15,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 76,
+      "character": 16,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "/"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 76,
+      "character": 16,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 77,
+      "character": 17,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 77,
+      "character": 17,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 78,
+      "character": 18,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "2"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 78,
+      "character": 18,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 79,
+      "character": 19,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 79,
+      "character": 19,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 80,
+      "character": 20,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "+"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 80,
+      "character": 20,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 81,
+      "character": 21,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 81,
+      "character": 21,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 82,
+      "character": 22,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "1"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 82,
+      "character": 22,
+      "line": 4
+    },
+    "end_position": {
+      "bytes": 83,
+      "character": 22,
+      "line": 4
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 83,
+      "character": 1,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 84,
+      "character": 2,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "e"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 84,
+      "character": 2,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 85,
+      "character": 3,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 85,
+      "character": 3,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 86,
+      "character": 4,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 86,
+      "character": 4,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 87,
+      "character": 5,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 87,
+      "character": 5,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 88,
+      "character": 6,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "5"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 88,
+      "character": 6,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 89,
+      "character": 7,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 89,
+      "character": 7,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 90,
+      "character": 8,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "+"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 90,
+      "character": 8,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 91,
+      "character": 9,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 91,
+      "character": 9,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 92,
+      "character": 10,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "x"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 92,
+      "character": 10,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 93,
+      "character": 11,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 93,
+      "character": 11,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 94,
+      "character": 12,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "^"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 94,
+      "character": 12,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 95,
+      "character": 13,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 95,
+      "character": 13,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 96,
+      "character": 14,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "2"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 96,
+      "character": 14,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 97,
+      "character": 15,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 97,
+      "character": 15,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 98,
+      "character": 16,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "*"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 98,
+      "character": 16,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 99,
+      "character": 17,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 99,
+      "character": 17,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 100,
+      "character": 18,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "8"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 100,
+      "character": 18,
+      "line": 5
+    },
+    "end_position": {
+      "bytes": 101,
+      "character": 18,
+      "line": 5
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 101,
+      "character": 1,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 102,
+      "character": 2,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "f"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 102,
+      "character": 2,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 103,
+      "character": 3,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 103,
+      "character": 3,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 104,
+      "character": 4,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 104,
+      "character": 4,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 105,
+      "character": 5,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 105,
+      "character": 5,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 106,
+      "character": 6,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "a"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 106,
+      "character": 6,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 107,
+      "character": 7,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 107,
+      "character": 7,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 108,
+      "character": 8,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "<"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 108,
+      "character": 8,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 109,
+      "character": 9,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 109,
+      "character": 9,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 110,
+      "character": 10,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "y"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 110,
+      "character": 10,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 111,
+      "character": 11,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 111,
+      "character": 11,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 114,
+      "character": 14,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "and"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 114,
+      "character": 14,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 115,
+      "character": 15,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 115,
+      "character": 15,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 116,
+      "character": 16,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "y"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 116,
+      "character": 16,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 117,
+      "character": 17,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 117,
+      "character": 17,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 119,
+      "character": 19,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "<="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 119,
+      "character": 19,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 120,
+      "character": 20,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 120,
+      "character": 20,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 121,
+      "character": 21,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "z"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 121,
+      "character": 21,
+      "line": 6
+    },
+    "end_position": {
+      "bytes": 122,
+      "character": 21,
+      "line": 6
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 122,
+      "character": 1,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 123,
+      "character": 2,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "g"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 123,
+      "character": 2,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 124,
+      "character": 3,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 124,
+      "character": 3,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 125,
+      "character": 4,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 125,
+      "character": 4,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 126,
+      "character": 5,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 126,
+      "character": 5,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 127,
+      "character": 6,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "-"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 127,
+      "character": 6,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 128,
+      "character": 7,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "x"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 128,
+      "character": 7,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 129,
+      "character": 8,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 129,
+      "character": 8,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 130,
+      "character": 9,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "^"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 130,
+      "character": 9,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 131,
+      "character": 10,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 131,
+      "character": 10,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 132,
+      "character": 11,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Number",
+      "text": "2"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 132,
+      "character": 11,
+      "line": 7
+    },
+    "end_position": {
+      "bytes": 133,
+      "character": 11,
+      "line": 7
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": "\n"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 133,
+      "character": 1,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 134,
+      "character": 2,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "h"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 134,
+      "character": 2,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 135,
+      "character": 3,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 135,
+      "character": 3,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 136,
+      "character": 4,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "="
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 136,
+      "character": 4,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 137,
+      "character": 5,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 137,
+      "character": 5,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 138,
+      "character": 6,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "x"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 138,
+      "character": 6,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 139,
+      "character": 7,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 139,
+      "character": 7,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 140,
+      "character": 8,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "^"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 140,
+      "character": 8,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 141,
+      "character": 9,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 141,
+      "character": 9,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 142,
+      "character": 10,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "y"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 142,
+      "character": 10,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 143,
+      "character": 11,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 143,
+      "character": 11,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 144,
+      "character": 12,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Symbol",
+      "symbol": "^"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 144,
+      "character": 12,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 145,
+      "character": 13,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Whitespace",
+      "characters": " "
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 145,
+      "character": 13,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 146,
+      "character": 14,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Identifier",
+      "identifier": "z"
+    }
+  },
+  {
+    "start_position": {
+      "bytes": 146,
+      "character": 14,
+      "line": 8
+    },
+    "end_position": {
+      "bytes": 146,
+      "character": 14,
+      "line": 8
+    },
+    "token_type": {
+      "type": "Eof"
+    }
+  }
+]

--- a/full-moon/tests/cases/pass/gt-lt/ast.json
+++ b/full-moon/tests/cases/pass/gt-lt/ast.json
@@ -78,35 +78,76 @@
                       "pairs": [
                         {
                           "End": {
-                            "value": {
-                              "Number": {
+                            "lhs": {
+                              "value": {
+                                "Number": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 5,
+                                      "character": 6,
+                                      "line": 1
+                                    },
+                                    "end_position": {
+                                      "bytes": 6,
+                                      "character": 7,
+                                      "line": 1
+                                    },
+                                    "token_type": {
+                                      "type": "Number",
+                                      "text": "1"
+                                    }
+                                  },
+                                  "trailing_trivia": [
+                                    {
+                                      "start_position": {
+                                        "bytes": 6,
+                                        "character": 7,
+                                        "line": 1
+                                      },
+                                      "end_position": {
+                                        "bytes": 7,
+                                        "character": 8,
+                                        "line": 1
+                                      },
+                                      "token_type": {
+                                        "type": "Whitespace",
+                                        "characters": " "
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "binop": {
+                              "LessThan": {
                                 "leading_trivia": [],
                                 "token": {
                                   "start_position": {
-                                    "bytes": 5,
-                                    "character": 6,
+                                    "bytes": 7,
+                                    "character": 8,
                                     "line": 1
                                   },
                                   "end_position": {
-                                    "bytes": 6,
-                                    "character": 7,
+                                    "bytes": 8,
+                                    "character": 9,
                                     "line": 1
                                   },
                                   "token_type": {
-                                    "type": "Number",
-                                    "text": "1"
+                                    "type": "Symbol",
+                                    "symbol": "<"
                                   }
                                 },
                                 "trailing_trivia": [
                                   {
                                     "start_position": {
-                                      "bytes": 6,
-                                      "character": 7,
+                                      "bytes": 8,
+                                      "character": 9,
                                       "line": 1
                                     },
                                     "end_position": {
-                                      "bytes": 7,
-                                      "character": 8,
+                                      "bytes": 9,
+                                      "character": 10,
                                       "line": 1
                                     },
                                     "token_type": {
@@ -117,70 +158,28 @@
                                 ]
                               }
                             },
-                            "binop": {
-                              "bin_op": {
-                                "LessThan": {
+                            "rhs": {
+                              "value": {
+                                "Number": {
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 7,
-                                      "character": 8,
+                                      "bytes": 9,
+                                      "character": 10,
                                       "line": 1
                                     },
                                     "end_position": {
-                                      "bytes": 8,
-                                      "character": 9,
+                                      "bytes": 10,
+                                      "character": 11,
                                       "line": 1
                                     },
                                     "token_type": {
-                                      "type": "Symbol",
-                                      "symbol": "<"
+                                      "type": "Number",
+                                      "text": "2"
                                     }
                                   },
-                                  "trailing_trivia": [
-                                    {
-                                      "start_position": {
-                                        "bytes": 8,
-                                        "character": 9,
-                                        "line": 1
-                                      },
-                                      "end_position": {
-                                        "bytes": 9,
-                                        "character": 10,
-                                        "line": 1
-                                      },
-                                      "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
-                                      }
-                                    }
-                                  ]
+                                  "trailing_trivia": []
                                 }
-                              },
-                              "rhs": {
-                                "value": {
-                                  "Number": {
-                                    "leading_trivia": [],
-                                    "token": {
-                                      "start_position": {
-                                        "bytes": 9,
-                                        "character": 10,
-                                        "line": 1
-                                      },
-                                      "end_position": {
-                                        "bytes": 10,
-                                        "character": 11,
-                                        "line": 1
-                                      },
-                                      "token_type": {
-                                        "type": "Number",
-                                        "text": "2"
-                                      }
-                                    },
-                                    "trailing_trivia": []
-                                  }
-                                },
-                                "binop": null
                               }
                             }
                           }
@@ -291,35 +290,76 @@
                       "pairs": [
                         {
                           "End": {
-                            "value": {
-                              "Number": {
+                            "lhs": {
+                              "value": {
+                                "Number": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 17,
+                                      "character": 6,
+                                      "line": 2
+                                    },
+                                    "end_position": {
+                                      "bytes": 18,
+                                      "character": 7,
+                                      "line": 2
+                                    },
+                                    "token_type": {
+                                      "type": "Number",
+                                      "text": "1"
+                                    }
+                                  },
+                                  "trailing_trivia": [
+                                    {
+                                      "start_position": {
+                                        "bytes": 18,
+                                        "character": 7,
+                                        "line": 2
+                                      },
+                                      "end_position": {
+                                        "bytes": 19,
+                                        "character": 8,
+                                        "line": 2
+                                      },
+                                      "token_type": {
+                                        "type": "Whitespace",
+                                        "characters": " "
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "binop": {
+                              "LessThanEqual": {
                                 "leading_trivia": [],
                                 "token": {
                                   "start_position": {
-                                    "bytes": 17,
-                                    "character": 6,
+                                    "bytes": 19,
+                                    "character": 8,
                                     "line": 2
                                   },
                                   "end_position": {
-                                    "bytes": 18,
-                                    "character": 7,
+                                    "bytes": 21,
+                                    "character": 10,
                                     "line": 2
                                   },
                                   "token_type": {
-                                    "type": "Number",
-                                    "text": "1"
+                                    "type": "Symbol",
+                                    "symbol": "<="
                                   }
                                 },
                                 "trailing_trivia": [
                                   {
                                     "start_position": {
-                                      "bytes": 18,
-                                      "character": 7,
+                                      "bytes": 21,
+                                      "character": 10,
                                       "line": 2
                                     },
                                     "end_position": {
-                                      "bytes": 19,
-                                      "character": 8,
+                                      "bytes": 22,
+                                      "character": 11,
                                       "line": 2
                                     },
                                     "token_type": {
@@ -330,70 +370,28 @@
                                 ]
                               }
                             },
-                            "binop": {
-                              "bin_op": {
-                                "LessThanEqual": {
+                            "rhs": {
+                              "value": {
+                                "Number": {
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 19,
-                                      "character": 8,
+                                      "bytes": 22,
+                                      "character": 11,
                                       "line": 2
                                     },
                                     "end_position": {
-                                      "bytes": 21,
-                                      "character": 10,
+                                      "bytes": 23,
+                                      "character": 12,
                                       "line": 2
                                     },
                                     "token_type": {
-                                      "type": "Symbol",
-                                      "symbol": "<="
+                                      "type": "Number",
+                                      "text": "2"
                                     }
                                   },
-                                  "trailing_trivia": [
-                                    {
-                                      "start_position": {
-                                        "bytes": 21,
-                                        "character": 10,
-                                        "line": 2
-                                      },
-                                      "end_position": {
-                                        "bytes": 22,
-                                        "character": 11,
-                                        "line": 2
-                                      },
-                                      "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
-                                      }
-                                    }
-                                  ]
+                                  "trailing_trivia": []
                                 }
-                              },
-                              "rhs": {
-                                "value": {
-                                  "Number": {
-                                    "leading_trivia": [],
-                                    "token": {
-                                      "start_position": {
-                                        "bytes": 22,
-                                        "character": 11,
-                                        "line": 2
-                                      },
-                                      "end_position": {
-                                        "bytes": 23,
-                                        "character": 12,
-                                        "line": 2
-                                      },
-                                      "token_type": {
-                                        "type": "Number",
-                                        "text": "2"
-                                      }
-                                    },
-                                    "trailing_trivia": []
-                                  }
-                                },
-                                "binop": null
                               }
                             }
                           }
@@ -504,35 +502,76 @@
                       "pairs": [
                         {
                           "End": {
-                            "value": {
-                              "Number": {
+                            "lhs": {
+                              "value": {
+                                "Number": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 30,
+                                      "character": 6,
+                                      "line": 3
+                                    },
+                                    "end_position": {
+                                      "bytes": 31,
+                                      "character": 7,
+                                      "line": 3
+                                    },
+                                    "token_type": {
+                                      "type": "Number",
+                                      "text": "2"
+                                    }
+                                  },
+                                  "trailing_trivia": [
+                                    {
+                                      "start_position": {
+                                        "bytes": 31,
+                                        "character": 7,
+                                        "line": 3
+                                      },
+                                      "end_position": {
+                                        "bytes": 32,
+                                        "character": 8,
+                                        "line": 3
+                                      },
+                                      "token_type": {
+                                        "type": "Whitespace",
+                                        "characters": " "
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "binop": {
+                              "GreaterThan": {
                                 "leading_trivia": [],
                                 "token": {
                                   "start_position": {
-                                    "bytes": 30,
-                                    "character": 6,
+                                    "bytes": 32,
+                                    "character": 8,
                                     "line": 3
                                   },
                                   "end_position": {
-                                    "bytes": 31,
-                                    "character": 7,
+                                    "bytes": 33,
+                                    "character": 9,
                                     "line": 3
                                   },
                                   "token_type": {
-                                    "type": "Number",
-                                    "text": "2"
+                                    "type": "Symbol",
+                                    "symbol": ">"
                                   }
                                 },
                                 "trailing_trivia": [
                                   {
                                     "start_position": {
-                                      "bytes": 31,
-                                      "character": 7,
+                                      "bytes": 33,
+                                      "character": 9,
                                       "line": 3
                                     },
                                     "end_position": {
-                                      "bytes": 32,
-                                      "character": 8,
+                                      "bytes": 34,
+                                      "character": 10,
                                       "line": 3
                                     },
                                     "token_type": {
@@ -543,70 +582,28 @@
                                 ]
                               }
                             },
-                            "binop": {
-                              "bin_op": {
-                                "GreaterThan": {
+                            "rhs": {
+                              "value": {
+                                "Number": {
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 32,
-                                      "character": 8,
+                                      "bytes": 34,
+                                      "character": 10,
                                       "line": 3
                                     },
                                     "end_position": {
-                                      "bytes": 33,
-                                      "character": 9,
+                                      "bytes": 35,
+                                      "character": 11,
                                       "line": 3
                                     },
                                     "token_type": {
-                                      "type": "Symbol",
-                                      "symbol": ">"
+                                      "type": "Number",
+                                      "text": "1"
                                     }
                                   },
-                                  "trailing_trivia": [
-                                    {
-                                      "start_position": {
-                                        "bytes": 33,
-                                        "character": 9,
-                                        "line": 3
-                                      },
-                                      "end_position": {
-                                        "bytes": 34,
-                                        "character": 10,
-                                        "line": 3
-                                      },
-                                      "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
-                                      }
-                                    }
-                                  ]
+                                  "trailing_trivia": []
                                 }
-                              },
-                              "rhs": {
-                                "value": {
-                                  "Number": {
-                                    "leading_trivia": [],
-                                    "token": {
-                                      "start_position": {
-                                        "bytes": 34,
-                                        "character": 10,
-                                        "line": 3
-                                      },
-                                      "end_position": {
-                                        "bytes": 35,
-                                        "character": 11,
-                                        "line": 3
-                                      },
-                                      "token_type": {
-                                        "type": "Number",
-                                        "text": "1"
-                                      }
-                                    },
-                                    "trailing_trivia": []
-                                  }
-                                },
-                                "binop": null
                               }
                             }
                           }
@@ -717,35 +714,76 @@
                       "pairs": [
                         {
                           "End": {
-                            "value": {
-                              "Number": {
+                            "lhs": {
+                              "value": {
+                                "Number": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 42,
+                                      "character": 6,
+                                      "line": 4
+                                    },
+                                    "end_position": {
+                                      "bytes": 43,
+                                      "character": 7,
+                                      "line": 4
+                                    },
+                                    "token_type": {
+                                      "type": "Number",
+                                      "text": "2"
+                                    }
+                                  },
+                                  "trailing_trivia": [
+                                    {
+                                      "start_position": {
+                                        "bytes": 43,
+                                        "character": 7,
+                                        "line": 4
+                                      },
+                                      "end_position": {
+                                        "bytes": 44,
+                                        "character": 8,
+                                        "line": 4
+                                      },
+                                      "token_type": {
+                                        "type": "Whitespace",
+                                        "characters": " "
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "binop": {
+                              "GreaterThanEqual": {
                                 "leading_trivia": [],
                                 "token": {
                                   "start_position": {
-                                    "bytes": 42,
-                                    "character": 6,
+                                    "bytes": 44,
+                                    "character": 8,
                                     "line": 4
                                   },
                                   "end_position": {
-                                    "bytes": 43,
-                                    "character": 7,
+                                    "bytes": 46,
+                                    "character": 10,
                                     "line": 4
                                   },
                                   "token_type": {
-                                    "type": "Number",
-                                    "text": "2"
+                                    "type": "Symbol",
+                                    "symbol": ">="
                                   }
                                 },
                                 "trailing_trivia": [
                                   {
                                     "start_position": {
-                                      "bytes": 43,
-                                      "character": 7,
+                                      "bytes": 46,
+                                      "character": 10,
                                       "line": 4
                                     },
                                     "end_position": {
-                                      "bytes": 44,
-                                      "character": 8,
+                                      "bytes": 47,
+                                      "character": 11,
                                       "line": 4
                                     },
                                     "token_type": {
@@ -756,70 +794,28 @@
                                 ]
                               }
                             },
-                            "binop": {
-                              "bin_op": {
-                                "GreaterThanEqual": {
+                            "rhs": {
+                              "value": {
+                                "Number": {
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 44,
-                                      "character": 8,
+                                      "bytes": 47,
+                                      "character": 11,
                                       "line": 4
                                     },
                                     "end_position": {
-                                      "bytes": 46,
-                                      "character": 10,
+                                      "bytes": 48,
+                                      "character": 12,
                                       "line": 4
                                     },
                                     "token_type": {
-                                      "type": "Symbol",
-                                      "symbol": ">="
+                                      "type": "Number",
+                                      "text": "1"
                                     }
                                   },
-                                  "trailing_trivia": [
-                                    {
-                                      "start_position": {
-                                        "bytes": 46,
-                                        "character": 10,
-                                        "line": 4
-                                      },
-                                      "end_position": {
-                                        "bytes": 47,
-                                        "character": 11,
-                                        "line": 4
-                                      },
-                                      "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
-                                      }
-                                    }
-                                  ]
+                                  "trailing_trivia": []
                                 }
-                              },
-                              "rhs": {
-                                "value": {
-                                  "Number": {
-                                    "leading_trivia": [],
-                                    "token": {
-                                      "start_position": {
-                                        "bytes": 47,
-                                        "character": 11,
-                                        "line": 4
-                                      },
-                                      "end_position": {
-                                        "bytes": 48,
-                                        "character": 12,
-                                        "line": 4
-                                      },
-                                      "token_type": {
-                                        "type": "Number",
-                                        "text": "1"
-                                      }
-                                    },
-                                    "trailing_trivia": []
-                                  }
-                                },
-                                "binop": null
                               }
                             }
                           }
@@ -930,113 +926,112 @@
                       "pairs": [
                         {
                           "End": {
-                            "value": {
-                              "Var": {
-                                "Name": {
-                                  "leading_trivia": [],
-                                  "token": {
-                                    "start_position": {
-                                      "bytes": 55,
-                                      "character": 6,
-                                      "line": 5
-                                    },
-                                    "end_position": {
-                                      "bytes": 56,
-                                      "character": 7,
-                                      "line": 5
-                                    },
-                                    "token_type": {
-                                      "type": "Identifier",
-                                      "identifier": "x"
-                                    }
-                                  },
-                                  "trailing_trivia": [
-                                    {
+                            "lhs": {
+                              "value": {
+                                "Var": {
+                                  "Name": {
+                                    "leading_trivia": [],
+                                    "token": {
                                       "start_position": {
+                                        "bytes": 55,
+                                        "character": 6,
+                                        "line": 5
+                                      },
+                                      "end_position": {
                                         "bytes": 56,
                                         "character": 7,
                                         "line": 5
                                       },
-                                      "end_position": {
-                                        "bytes": 57,
-                                        "character": 8,
-                                        "line": 5
-                                      },
                                       "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
+                                        "type": "Identifier",
+                                        "identifier": "x"
                                       }
-                                    }
-                                  ]
+                                    },
+                                    "trailing_trivia": [
+                                      {
+                                        "start_position": {
+                                          "bytes": 56,
+                                          "character": 7,
+                                          "line": 5
+                                        },
+                                        "end_position": {
+                                          "bytes": 57,
+                                          "character": 8,
+                                          "line": 5
+                                        },
+                                        "token_type": {
+                                          "type": "Whitespace",
+                                          "characters": " "
+                                        }
+                                      }
+                                    ]
+                                  }
                                 }
                               }
                             },
                             "binop": {
-                              "bin_op": {
-                                "GreaterThanEqual": {
-                                  "leading_trivia": [],
-                                  "token": {
+                              "GreaterThanEqual": {
+                                "leading_trivia": [],
+                                "token": {
+                                  "start_position": {
+                                    "bytes": 57,
+                                    "character": 8,
+                                    "line": 5
+                                  },
+                                  "end_position": {
+                                    "bytes": 59,
+                                    "character": 10,
+                                    "line": 5
+                                  },
+                                  "token_type": {
+                                    "type": "Symbol",
+                                    "symbol": ">="
+                                  }
+                                },
+                                "trailing_trivia": [
+                                  {
                                     "start_position": {
-                                      "bytes": 57,
-                                      "character": 8,
-                                      "line": 5
-                                    },
-                                    "end_position": {
                                       "bytes": 59,
                                       "character": 10,
                                       "line": 5
                                     },
+                                    "end_position": {
+                                      "bytes": 60,
+                                      "character": 11,
+                                      "line": 5
+                                    },
                                     "token_type": {
-                                      "type": "Symbol",
-                                      "symbol": ">="
+                                      "type": "Whitespace",
+                                      "characters": " "
                                     }
-                                  },
-                                  "trailing_trivia": [
-                                    {
+                                  }
+                                ]
+                              }
+                            },
+                            "rhs": {
+                              "value": {
+                                "Var": {
+                                  "Name": {
+                                    "leading_trivia": [],
+                                    "token": {
                                       "start_position": {
-                                        "bytes": 59,
-                                        "character": 10,
-                                        "line": 5
-                                      },
-                                      "end_position": {
                                         "bytes": 60,
                                         "character": 11,
                                         "line": 5
                                       },
-                                      "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "rhs": {
-                                "value": {
-                                  "Var": {
-                                    "Name": {
-                                      "leading_trivia": [],
-                                      "token": {
-                                        "start_position": {
-                                          "bytes": 60,
-                                          "character": 11,
-                                          "line": 5
-                                        },
-                                        "end_position": {
-                                          "bytes": 61,
-                                          "character": 12,
-                                          "line": 5
-                                        },
-                                        "token_type": {
-                                          "type": "Identifier",
-                                          "identifier": "y"
-                                        }
+                                      "end_position": {
+                                        "bytes": 61,
+                                        "character": 12,
+                                        "line": 5
                                       },
-                                      "trailing_trivia": []
-                                    }
+                                      "token_type": {
+                                        "type": "Identifier",
+                                        "identifier": "y"
+                                      }
+                                    },
+                                    "trailing_trivia": []
                                   }
-                                },
-                                "binop": null
+                                }
                               }
                             }
                           }

--- a/full-moon/tests/cases/pass/negative-numbers/ast.json
+++ b/full-moon/tests/cases/pass/negative-numbers/ast.json
@@ -124,77 +124,76 @@
             "pairs": [
               {
                 "End": {
-                  "value": {
-                    "Var": {
-                      "Name": {
-                        "leading_trivia": [],
-                        "token": {
-                          "start_position": {
-                            "bytes": 12,
-                            "character": 13,
-                            "line": 1
-                          },
-                          "end_position": {
-                            "bytes": 13,
-                            "character": 14,
-                            "line": 1
-                          },
-                          "token_type": {
-                            "type": "Identifier",
-                            "identifier": "x"
-                          }
-                        },
-                        "trailing_trivia": []
-                      }
-                    }
-                  },
-                  "binop": {
-                    "bin_op": {
-                      "Minus": {
-                        "leading_trivia": [],
-                        "token": {
-                          "start_position": {
-                            "bytes": 13,
-                            "character": 14,
-                            "line": 1
-                          },
-                          "end_position": {
-                            "bytes": 14,
-                            "character": 15,
-                            "line": 1
-                          },
-                          "token_type": {
-                            "type": "Symbol",
-                            "symbol": "-"
-                          }
-                        },
-                        "trailing_trivia": []
-                      }
-                    },
-                    "rhs": {
-                      "value": {
-                        "Number": {
+                  "lhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
                           "leading_trivia": [],
                           "token": {
                             "start_position": {
-                              "bytes": 14,
-                              "character": 15,
+                              "bytes": 12,
+                              "character": 13,
                               "line": 1
                             },
                             "end_position": {
-                              "bytes": 15,
-                              "character": 16,
+                              "bytes": 13,
+                              "character": 14,
                               "line": 1
                             },
                             "token_type": {
-                              "type": "Number",
-                              "text": "1"
+                              "type": "Identifier",
+                              "identifier": "x"
                             }
                           },
                           "trailing_trivia": []
                         }
+                      }
+                    }
+                  },
+                  "binop": {
+                    "Minus": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 13,
+                          "character": 14,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 14,
+                          "character": 15,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "-"
+                        }
                       },
-                      "binop": null
+                      "trailing_trivia": []
+                    }
+                  },
+                  "rhs": {
+                    "value": {
+                      "Number": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 14,
+                            "character": 15,
+                            "line": 1
+                          },
+                          "end_position": {
+                            "bytes": 15,
+                            "character": 16,
+                            "line": 1
+                          },
+                          "token_type": {
+                            "type": "Number",
+                            "text": "1"
+                          }
+                        },
+                        "trailing_trivia": []
+                      }
                     }
                   }
                 }
@@ -346,94 +345,93 @@
             "pairs": [
               {
                 "End": {
-                  "value": {
-                    "Var": {
-                      "Name": {
-                        "leading_trivia": [],
-                        "token": {
-                          "start_position": {
-                            "bytes": 28,
-                            "character": 13,
-                            "line": 2
-                          },
-                          "end_position": {
-                            "bytes": 29,
-                            "character": 14,
-                            "line": 2
-                          },
-                          "token_type": {
-                            "type": "Identifier",
-                            "identifier": "x"
-                          }
-                        },
-                        "trailing_trivia": [
-                          {
+                  "lhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
+                          "leading_trivia": [],
+                          "token": {
                             "start_position": {
+                              "bytes": 28,
+                              "character": 13,
+                              "line": 2
+                            },
+                            "end_position": {
                               "bytes": 29,
                               "character": 14,
                               "line": 2
                             },
-                            "end_position": {
-                              "bytes": 30,
-                              "character": 15,
-                              "line": 2
-                            },
                             "token_type": {
-                              "type": "Whitespace",
-                              "characters": " "
+                              "type": "Identifier",
+                              "identifier": "x"
                             }
-                          }
-                        ]
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 29,
+                                "character": 14,
+                                "line": 2
+                              },
+                              "end_position": {
+                                "bytes": 30,
+                                "character": 15,
+                                "line": 2
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
                       }
                     }
                   },
                   "binop": {
-                    "bin_op": {
-                      "Minus": {
+                    "Minus": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 30,
+                          "character": 15,
+                          "line": 2
+                        },
+                        "end_position": {
+                          "bytes": 31,
+                          "character": 16,
+                          "line": 2
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "-"
+                        }
+                      },
+                      "trailing_trivia": []
+                    }
+                  },
+                  "rhs": {
+                    "value": {
+                      "Number": {
                         "leading_trivia": [],
                         "token": {
                           "start_position": {
-                            "bytes": 30,
-                            "character": 15,
-                            "line": 2
-                          },
-                          "end_position": {
                             "bytes": 31,
                             "character": 16,
                             "line": 2
                           },
+                          "end_position": {
+                            "bytes": 32,
+                            "character": 17,
+                            "line": 2
+                          },
                           "token_type": {
-                            "type": "Symbol",
-                            "symbol": "-"
+                            "type": "Number",
+                            "text": "1"
                           }
                         },
                         "trailing_trivia": []
                       }
-                    },
-                    "rhs": {
-                      "value": {
-                        "Number": {
-                          "leading_trivia": [],
-                          "token": {
-                            "start_position": {
-                              "bytes": 31,
-                              "character": 16,
-                              "line": 2
-                            },
-                            "end_position": {
-                              "bytes": 32,
-                              "character": 17,
-                              "line": 2
-                            },
-                            "token_type": {
-                              "type": "Number",
-                              "text": "1"
-                            }
-                          },
-                          "trailing_trivia": []
-                        }
-                      },
-                      "binop": null
                     }
                   }
                 }
@@ -539,98 +537,97 @@
                       "pairs": [
                         {
                           "End": {
-                            "value": {
-                              "Number": {
+                            "lhs": {
+                              "value": {
+                                "Number": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 39,
+                                      "character": 7,
+                                      "line": 3
+                                    },
+                                    "end_position": {
+                                      "bytes": 40,
+                                      "character": 8,
+                                      "line": 3
+                                    },
+                                    "token_type": {
+                                      "type": "Number",
+                                      "text": "1"
+                                    }
+                                  },
+                                  "trailing_trivia": []
+                                }
+                              }
+                            },
+                            "binop": {
+                              "Plus": {
                                 "leading_trivia": [],
                                 "token": {
                                   "start_position": {
-                                    "bytes": 39,
-                                    "character": 7,
-                                    "line": 3
-                                  },
-                                  "end_position": {
                                     "bytes": 40,
                                     "character": 8,
                                     "line": 3
                                   },
+                                  "end_position": {
+                                    "bytes": 41,
+                                    "character": 9,
+                                    "line": 3
+                                  },
                                   "token_type": {
-                                    "type": "Number",
-                                    "text": "1"
+                                    "type": "Symbol",
+                                    "symbol": "+"
                                   }
                                 },
                                 "trailing_trivia": []
                               }
                             },
-                            "binop": {
-                              "bin_op": {
-                                "Plus": {
+                            "rhs": {
+                              "unop": {
+                                "Minus": {
                                   "leading_trivia": [],
                                   "token": {
                                     "start_position": {
-                                      "bytes": 40,
-                                      "character": 8,
-                                      "line": 3
-                                    },
-                                    "end_position": {
                                       "bytes": 41,
                                       "character": 9,
                                       "line": 3
                                     },
+                                    "end_position": {
+                                      "bytes": 42,
+                                      "character": 10,
+                                      "line": 3
+                                    },
                                     "token_type": {
                                       "type": "Symbol",
-                                      "symbol": "+"
+                                      "symbol": "-"
                                     }
                                   },
                                   "trailing_trivia": []
                                 }
                               },
-                              "rhs": {
-                                "unop": {
-                                  "Minus": {
+                              "expression": {
+                                "value": {
+                                  "Number": {
                                     "leading_trivia": [],
                                     "token": {
                                       "start_position": {
-                                        "bytes": 41,
-                                        "character": 9,
-                                        "line": 3
-                                      },
-                                      "end_position": {
                                         "bytes": 42,
                                         "character": 10,
                                         "line": 3
                                       },
+                                      "end_position": {
+                                        "bytes": 43,
+                                        "character": 11,
+                                        "line": 3
+                                      },
                                       "token_type": {
-                                        "type": "Symbol",
-                                        "symbol": "-"
+                                        "type": "Number",
+                                        "text": "3"
                                       }
                                     },
                                     "trailing_trivia": []
                                   }
-                                },
-                                "expression": {
-                                  "value": {
-                                    "Number": {
-                                      "leading_trivia": [],
-                                      "token": {
-                                        "start_position": {
-                                          "bytes": 42,
-                                          "character": 10,
-                                          "line": 3
-                                        },
-                                        "end_position": {
-                                          "bytes": 43,
-                                          "character": 11,
-                                          "line": 3
-                                        },
-                                        "token_type": {
-                                          "type": "Number",
-                                          "text": "3"
-                                        }
-                                      },
-                                      "trailing_trivia": []
-                                    }
-                                  },
-                                  "binop": null
                                 }
                               }
                             }

--- a/full-moon/tests/cases/pass/paren-expressions/ast.json
+++ b/full-moon/tests/cases/pass/paren-expressions/ast.json
@@ -206,7 +206,7 @@
                   },
                   "rhs": {
                     "value": {
-                      "ParenthesesExpression": {
+                      "ParseExpression": {
                         "contained": {
                           "tokens": [
                             {

--- a/full-moon/tests/cases/pass/paren-expressions/ast.json
+++ b/full-moon/tests/cases/pass/paren-expressions/ast.json
@@ -124,35 +124,76 @@
             "pairs": [
               {
                 "End": {
-                  "value": {
-                    "Number": {
+                  "lhs": {
+                    "value": {
+                      "Number": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 10,
+                            "character": 11,
+                            "line": 1
+                          },
+                          "end_position": {
+                            "bytes": 11,
+                            "character": 12,
+                            "line": 1
+                          },
+                          "token_type": {
+                            "type": "Number",
+                            "text": "1"
+                          }
+                        },
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 11,
+                              "character": 12,
+                              "line": 1
+                            },
+                            "end_position": {
+                              "bytes": 12,
+                              "character": 13,
+                              "line": 1
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  },
+                  "binop": {
+                    "Plus": {
                       "leading_trivia": [],
                       "token": {
                         "start_position": {
-                          "bytes": 10,
-                          "character": 11,
+                          "bytes": 12,
+                          "character": 13,
                           "line": 1
                         },
                         "end_position": {
-                          "bytes": 11,
-                          "character": 12,
+                          "bytes": 13,
+                          "character": 14,
                           "line": 1
                         },
                         "token_type": {
-                          "type": "Number",
-                          "text": "1"
+                          "type": "Symbol",
+                          "symbol": "+"
                         }
                       },
                       "trailing_trivia": [
                         {
                           "start_position": {
-                            "bytes": 11,
-                            "character": 12,
+                            "bytes": 13,
+                            "character": 14,
                             "line": 1
                           },
                           "end_position": {
-                            "bytes": 12,
-                            "character": 13,
+                            "bytes": 14,
+                            "character": 15,
                             "line": 1
                           },
                           "token_type": {
@@ -163,203 +204,156 @@
                       ]
                     }
                   },
-                  "binop": {
-                    "bin_op": {
-                      "Plus": {
-                        "leading_trivia": [],
-                        "token": {
-                          "start_position": {
-                            "bytes": 12,
-                            "character": 13,
-                            "line": 1
-                          },
-                          "end_position": {
-                            "bytes": 13,
-                            "character": 14,
-                            "line": 1
-                          },
-                          "token_type": {
-                            "type": "Symbol",
-                            "symbol": "+"
-                          }
-                        },
-                        "trailing_trivia": [
-                          {
+                  "rhs": {
+                    "contained": {
+                      "tokens": [
+                        {
+                          "leading_trivia": [],
+                          "token": {
                             "start_position": {
-                              "bytes": 13,
-                              "character": 14,
-                              "line": 1
-                            },
-                            "end_position": {
                               "bytes": 14,
                               "character": 15,
                               "line": 1
                             },
+                            "end_position": {
+                              "bytes": 15,
+                              "character": 16,
+                              "line": 1
+                            },
                             "token_type": {
-                              "type": "Whitespace",
-                              "characters": " "
+                              "type": "Symbol",
+                              "symbol": "("
                             }
-                          }
-                        ]
-                      }
-                    },
-                    "rhs": {
-                      "value": {
-                        "ParseExpression": {
-                          "contained": {
-                            "tokens": [
-                              {
-                                "leading_trivia": [],
-                                "token": {
-                                  "start_position": {
-                                    "bytes": 14,
-                                    "character": 15,
-                                    "line": 1
-                                  },
-                                  "end_position": {
-                                    "bytes": 15,
-                                    "character": 16,
-                                    "line": 1
-                                  },
-                                  "token_type": {
-                                    "type": "Symbol",
-                                    "symbol": "("
-                                  }
-                                },
-                                "trailing_trivia": []
-                              },
-                              {
-                                "leading_trivia": [],
-                                "token": {
-                                  "start_position": {
-                                    "bytes": 20,
-                                    "character": 21,
-                                    "line": 1
-                                  },
-                                  "end_position": {
-                                    "bytes": 21,
-                                    "character": 22,
-                                    "line": 1
-                                  },
-                                  "token_type": {
-                                    "type": "Symbol",
-                                    "symbol": ")"
-                                  }
-                                },
-                                "trailing_trivia": []
-                              }
-                            ]
                           },
-                          "expression": {
-                            "value": {
-                              "Number": {
-                                "leading_trivia": [],
-                                "token": {
-                                  "start_position": {
-                                    "bytes": 15,
-                                    "character": 16,
-                                    "line": 1
-                                  },
-                                  "end_position": {
-                                    "bytes": 16,
-                                    "character": 17,
-                                    "line": 1
-                                  },
-                                  "token_type": {
-                                    "type": "Number",
-                                    "text": "2"
-                                  }
-                                },
-                                "trailing_trivia": [
-                                  {
-                                    "start_position": {
-                                      "bytes": 16,
-                                      "character": 17,
-                                      "line": 1
-                                    },
-                                    "end_position": {
-                                      "bytes": 17,
-                                      "character": 18,
-                                      "line": 1
-                                    },
-                                    "token_type": {
-                                      "type": "Whitespace",
-                                      "characters": " "
-                                    }
-                                  }
-                                ]
+                          "trailing_trivia": []
+                        },
+                        {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 20,
+                              "character": 21,
+                              "line": 1
+                            },
+                            "end_position": {
+                              "bytes": 21,
+                              "character": 22,
+                              "line": 1
+                            },
+                            "token_type": {
+                              "type": "Symbol",
+                              "symbol": ")"
+                            }
+                          },
+                          "trailing_trivia": []
+                        }
+                      ]
+                    },
+                    "expression": {
+                      "lhs": {
+                        "value": {
+                          "Number": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 15,
+                                "character": 16,
+                                "line": 1
+                              },
+                              "end_position": {
+                                "bytes": 16,
+                                "character": 17,
+                                "line": 1
+                              },
+                              "token_type": {
+                                "type": "Number",
+                                "text": "2"
                               }
                             },
-                            "binop": {
-                              "bin_op": {
-                                "Minus": {
-                                  "leading_trivia": [],
-                                  "token": {
-                                    "start_position": {
-                                      "bytes": 17,
-                                      "character": 18,
-                                      "line": 1
-                                    },
-                                    "end_position": {
-                                      "bytes": 18,
-                                      "character": 19,
-                                      "line": 1
-                                    },
-                                    "token_type": {
-                                      "type": "Symbol",
-                                      "symbol": "-"
-                                    }
-                                  },
-                                  "trailing_trivia": [
-                                    {
-                                      "start_position": {
-                                        "bytes": 18,
-                                        "character": 19,
-                                        "line": 1
-                                      },
-                                      "end_position": {
-                                        "bytes": 19,
-                                        "character": 20,
-                                        "line": 1
-                                      },
-                                      "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "rhs": {
-                                "value": {
-                                  "Number": {
-                                    "leading_trivia": [],
-                                    "token": {
-                                      "start_position": {
-                                        "bytes": 19,
-                                        "character": 20,
-                                        "line": 1
-                                      },
-                                      "end_position": {
-                                        "bytes": 20,
-                                        "character": 21,
-                                        "line": 1
-                                      },
-                                      "token_type": {
-                                        "type": "Number",
-                                        "text": "3"
-                                      }
-                                    },
-                                    "trailing_trivia": []
-                                  }
+                            "trailing_trivia": [
+                              {
+                                "start_position": {
+                                  "bytes": 16,
+                                  "character": 17,
+                                  "line": 1
                                 },
-                                "binop": null
+                                "end_position": {
+                                  "bytes": 17,
+                                  "character": 18,
+                                  "line": 1
+                                },
+                                "token_type": {
+                                  "type": "Whitespace",
+                                  "characters": " "
+                                }
                               }
-                            }
+                            ]
                           }
                         }
                       },
-                      "binop": null
+                      "binop": {
+                        "Minus": {
+                          "leading_trivia": [],
+                          "token": {
+                            "start_position": {
+                              "bytes": 17,
+                              "character": 18,
+                              "line": 1
+                            },
+                            "end_position": {
+                              "bytes": 18,
+                              "character": 19,
+                              "line": 1
+                            },
+                            "token_type": {
+                              "type": "Symbol",
+                              "symbol": "-"
+                            }
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 18,
+                                "character": 19,
+                                "line": 1
+                              },
+                              "end_position": {
+                                "bytes": 19,
+                                "character": 20,
+                                "line": 1
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      "rhs": {
+                        "value": {
+                          "Number": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 19,
+                                "character": 20,
+                                "line": 1
+                              },
+                              "end_position": {
+                                "bytes": 20,
+                                "character": 21,
+                                "line": 1
+                              },
+                              "token_type": {
+                                "type": "Number",
+                                "text": "3"
+                              }
+                            },
+                            "trailing_trivia": []
+                          }
+                        }
+                      }
                     }
                   }
                 }

--- a/full-moon/tests/cases/pass/paren-expressions/ast.json
+++ b/full-moon/tests/cases/pass/paren-expressions/ast.json
@@ -205,152 +205,156 @@
                     }
                   },
                   "rhs": {
-                    "contained": {
-                      "tokens": [
-                        {
-                          "leading_trivia": [],
-                          "token": {
-                            "start_position": {
-                              "bytes": 14,
-                              "character": 15,
-                              "line": 1
-                            },
-                            "end_position": {
-                              "bytes": 15,
-                              "character": 16,
-                              "line": 1
-                            },
-                            "token_type": {
-                              "type": "Symbol",
-                              "symbol": "("
-                            }
-                          },
-                          "trailing_trivia": []
-                        },
-                        {
-                          "leading_trivia": [],
-                          "token": {
-                            "start_position": {
-                              "bytes": 20,
-                              "character": 21,
-                              "line": 1
-                            },
-                            "end_position": {
-                              "bytes": 21,
-                              "character": 22,
-                              "line": 1
-                            },
-                            "token_type": {
-                              "type": "Symbol",
-                              "symbol": ")"
-                            }
-                          },
-                          "trailing_trivia": []
-                        }
-                      ]
-                    },
-                    "expression": {
-                      "lhs": {
-                        "value": {
-                          "Number": {
-                            "leading_trivia": [],
-                            "token": {
-                              "start_position": {
-                                "bytes": 15,
-                                "character": 16,
-                                "line": 1
-                              },
-                              "end_position": {
-                                "bytes": 16,
-                                "character": 17,
-                                "line": 1
-                              },
-                              "token_type": {
-                                "type": "Number",
-                                "text": "2"
-                              }
-                            },
-                            "trailing_trivia": [
-                              {
+                    "value": {
+                      "ParenthesesExpression": {
+                        "contained": {
+                          "tokens": [
+                            {
+                              "leading_trivia": [],
+                              "token": {
                                 "start_position": {
-                                  "bytes": 16,
-                                  "character": 17,
+                                  "bytes": 14,
+                                  "character": 15,
                                   "line": 1
                                 },
                                 "end_position": {
+                                  "bytes": 15,
+                                  "character": 16,
+                                  "line": 1
+                                },
+                                "token_type": {
+                                  "type": "Symbol",
+                                  "symbol": "("
+                                }
+                              },
+                              "trailing_trivia": []
+                            },
+                            {
+                              "leading_trivia": [],
+                              "token": {
+                                "start_position": {
+                                  "bytes": 20,
+                                  "character": 21,
+                                  "line": 1
+                                },
+                                "end_position": {
+                                  "bytes": 21,
+                                  "character": 22,
+                                  "line": 1
+                                },
+                                "token_type": {
+                                  "type": "Symbol",
+                                  "symbol": ")"
+                                }
+                              },
+                              "trailing_trivia": []
+                            }
+                          ]
+                        },
+                        "expression": {
+                          "lhs": {
+                            "value": {
+                              "Number": {
+                                "leading_trivia": [],
+                                "token": {
+                                  "start_position": {
+                                    "bytes": 15,
+                                    "character": 16,
+                                    "line": 1
+                                  },
+                                  "end_position": {
+                                    "bytes": 16,
+                                    "character": 17,
+                                    "line": 1
+                                  },
+                                  "token_type": {
+                                    "type": "Number",
+                                    "text": "2"
+                                  }
+                                },
+                                "trailing_trivia": [
+                                  {
+                                    "start_position": {
+                                      "bytes": 16,
+                                      "character": 17,
+                                      "line": 1
+                                    },
+                                    "end_position": {
+                                      "bytes": 17,
+                                      "character": 18,
+                                      "line": 1
+                                    },
+                                    "token_type": {
+                                      "type": "Whitespace",
+                                      "characters": " "
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          },
+                          "binop": {
+                            "Minus": {
+                              "leading_trivia": [],
+                              "token": {
+                                "start_position": {
                                   "bytes": 17,
                                   "character": 18,
                                   "line": 1
                                 },
+                                "end_position": {
+                                  "bytes": 18,
+                                  "character": 19,
+                                  "line": 1
+                                },
                                 "token_type": {
-                                  "type": "Whitespace",
-                                  "characters": " "
+                                  "type": "Symbol",
+                                  "symbol": "-"
                                 }
-                              }
-                            ]
-                          }
-                        }
-                      },
-                      "binop": {
-                        "Minus": {
-                          "leading_trivia": [],
-                          "token": {
-                            "start_position": {
-                              "bytes": 17,
-                              "character": 18,
-                              "line": 1
-                            },
-                            "end_position": {
-                              "bytes": 18,
-                              "character": 19,
-                              "line": 1
-                            },
-                            "token_type": {
-                              "type": "Symbol",
-                              "symbol": "-"
+                              },
+                              "trailing_trivia": [
+                                {
+                                  "start_position": {
+                                    "bytes": 18,
+                                    "character": 19,
+                                    "line": 1
+                                  },
+                                  "end_position": {
+                                    "bytes": 19,
+                                    "character": 20,
+                                    "line": 1
+                                  },
+                                  "token_type": {
+                                    "type": "Whitespace",
+                                    "characters": " "
+                                  }
+                                }
+                              ]
                             }
                           },
-                          "trailing_trivia": [
-                            {
-                              "start_position": {
-                                "bytes": 18,
-                                "character": 19,
-                                "line": 1
-                              },
-                              "end_position": {
-                                "bytes": 19,
-                                "character": 20,
-                                "line": 1
-                              },
-                              "token_type": {
-                                "type": "Whitespace",
-                                "characters": " "
+                          "rhs": {
+                            "value": {
+                              "Number": {
+                                "leading_trivia": [],
+                                "token": {
+                                  "start_position": {
+                                    "bytes": 19,
+                                    "character": 20,
+                                    "line": 1
+                                  },
+                                  "end_position": {
+                                    "bytes": 20,
+                                    "character": 21,
+                                    "line": 1
+                                  },
+                                  "token_type": {
+                                    "type": "Number",
+                                    "text": "3"
+                                  }
+                                },
+                                "trailing_trivia": []
                               }
                             }
-                          ]
-                        }
-                      },
-                      "rhs": {
-                        "value": {
-                          "Number": {
-                            "leading_trivia": [],
-                            "token": {
-                              "start_position": {
-                                "bytes": 19,
-                                "character": 20,
-                                "line": 1
-                              },
-                              "end_position": {
-                                "bytes": 20,
-                                "character": 21,
-                                "line": 1
-                              },
-                              "token_type": {
-                                "type": "Number",
-                                "text": "3"
-                              }
-                            },
-                            "trailing_trivia": []
                           }
                         }
                       }

--- a/full-moon/tests/cases/pass/semicolons-1/ast.json
+++ b/full-moon/tests/cases/pass/semicolons-1/ast.json
@@ -145,8 +145,7 @@
                       },
                       "trailing_trivia": []
                     }
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]
@@ -280,111 +279,110 @@
             "pairs": [
               {
                 "End": {
-                  "value": {
-                    "Var": {
-                      "Name": {
-                        "leading_trivia": [],
-                        "token": {
-                          "start_position": {
-                            "bytes": 17,
-                            "character": 18,
-                            "line": 1
-                          },
-                          "end_position": {
-                            "bytes": 18,
-                            "character": 19,
-                            "line": 1
-                          },
-                          "token_type": {
-                            "type": "Identifier",
-                            "identifier": "x"
-                          }
-                        },
-                        "trailing_trivia": [
-                          {
+                  "lhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
+                          "leading_trivia": [],
+                          "token": {
                             "start_position": {
+                              "bytes": 17,
+                              "character": 18,
+                              "line": 1
+                            },
+                            "end_position": {
                               "bytes": 18,
                               "character": 19,
                               "line": 1
                             },
-                            "end_position": {
-                              "bytes": 19,
-                              "character": 20,
-                              "line": 1
-                            },
                             "token_type": {
-                              "type": "Whitespace",
-                              "characters": " "
+                              "type": "Identifier",
+                              "identifier": "x"
                             }
-                          }
-                        ]
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 18,
+                                "character": 19,
+                                "line": 1
+                              },
+                              "end_position": {
+                                "bytes": 19,
+                                "character": 20,
+                                "line": 1
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
                       }
                     }
                   },
                   "binop": {
-                    "bin_op": {
-                      "Plus": {
-                        "leading_trivia": [],
-                        "token": {
+                    "Plus": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 19,
+                          "character": 20,
+                          "line": 1
+                        },
+                        "end_position": {
+                          "bytes": 20,
+                          "character": 21,
+                          "line": 1
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "+"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
                           "start_position": {
-                            "bytes": 19,
-                            "character": 20,
-                            "line": 1
-                          },
-                          "end_position": {
                             "bytes": 20,
                             "character": 21,
                             "line": 1
                           },
+                          "end_position": {
+                            "bytes": 21,
+                            "character": 22,
+                            "line": 1
+                          },
                           "token_type": {
-                            "type": "Symbol",
-                            "symbol": "+"
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "value": {
+                      "Number": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 21,
+                            "character": 22,
+                            "line": 1
+                          },
+                          "end_position": {
+                            "bytes": 22,
+                            "character": 23,
+                            "line": 1
+                          },
+                          "token_type": {
+                            "type": "Number",
+                            "text": "1"
                           }
                         },
-                        "trailing_trivia": [
-                          {
-                            "start_position": {
-                              "bytes": 20,
-                              "character": 21,
-                              "line": 1
-                            },
-                            "end_position": {
-                              "bytes": 21,
-                              "character": 22,
-                              "line": 1
-                            },
-                            "token_type": {
-                              "type": "Whitespace",
-                              "characters": " "
-                            }
-                          }
-                        ]
+                        "trailing_trivia": []
                       }
-                    },
-                    "rhs": {
-                      "value": {
-                        "Number": {
-                          "leading_trivia": [],
-                          "token": {
-                            "start_position": {
-                              "bytes": 21,
-                              "character": 22,
-                              "line": 1
-                            },
-                            "end_position": {
-                              "bytes": 22,
-                              "character": 23,
-                              "line": 1
-                            },
-                            "token_type": {
-                              "type": "Number",
-                              "text": "1"
-                            }
-                          },
-                          "trailing_trivia": []
-                        }
-                      },
-                      "binop": null
                     }
                   }
                 }

--- a/full-moon/tests/cases/pass/utf-8/ast.json
+++ b/full-moon/tests/cases/pass/utf-8/ast.json
@@ -78,36 +78,77 @@
                       "pairs": [
                         {
                           "End": {
-                            "value": {
-                              "String": {
+                            "lhs": {
+                              "value": {
+                                "String": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 6,
+                                      "character": 7,
+                                      "line": 1
+                                    },
+                                    "end_position": {
+                                      "bytes": 13,
+                                      "character": 11,
+                                      "line": 1
+                                    },
+                                    "token_type": {
+                                      "type": "StringLiteral",
+                                      "literal": "👚 ",
+                                      "quote_type": "Double"
+                                    }
+                                  },
+                                  "trailing_trivia": [
+                                    {
+                                      "start_position": {
+                                        "bytes": 13,
+                                        "character": 11,
+                                        "line": 1
+                                      },
+                                      "end_position": {
+                                        "bytes": 14,
+                                        "character": 12,
+                                        "line": 1
+                                      },
+                                      "token_type": {
+                                        "type": "Whitespace",
+                                        "characters": " "
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            },
+                            "binop": {
+                              "TwoDots": {
                                 "leading_trivia": [],
                                 "token": {
                                   "start_position": {
-                                    "bytes": 6,
-                                    "character": 7,
+                                    "bytes": 14,
+                                    "character": 12,
                                     "line": 1
                                   },
                                   "end_position": {
-                                    "bytes": 13,
-                                    "character": 11,
+                                    "bytes": 16,
+                                    "character": 14,
                                     "line": 1
                                   },
                                   "token_type": {
-                                    "type": "StringLiteral",
-                                    "literal": "👚 ",
-                                    "quote_type": "Double"
+                                    "type": "Symbol",
+                                    "symbol": ".."
                                   }
                                 },
                                 "trailing_trivia": [
                                   {
                                     "start_position": {
-                                      "bytes": 13,
-                                      "character": 11,
+                                      "bytes": 16,
+                                      "character": 14,
                                       "line": 1
                                     },
                                     "end_position": {
-                                      "bytes": 14,
-                                      "character": 12,
+                                      "bytes": 17,
+                                      "character": 15,
                                       "line": 1
                                     },
                                     "token_type": {
@@ -118,72 +159,30 @@
                                 ]
                               }
                             },
-                            "binop": {
-                              "bin_op": {
-                                "TwoDots": {
-                                  "leading_trivia": [],
-                                  "token": {
-                                    "start_position": {
-                                      "bytes": 14,
-                                      "character": 12,
-                                      "line": 1
-                                    },
-                                    "end_position": {
-                                      "bytes": 16,
-                                      "character": 14,
-                                      "line": 1
-                                    },
-                                    "token_type": {
-                                      "type": "Symbol",
-                                      "symbol": ".."
-                                    }
-                                  },
-                                  "trailing_trivia": [
-                                    {
+                            "rhs": {
+                              "value": {
+                                "Var": {
+                                  "Name": {
+                                    "leading_trivia": [],
+                                    "token": {
                                       "start_position": {
-                                        "bytes": 16,
-                                        "character": 14,
-                                        "line": 1
-                                      },
-                                      "end_position": {
                                         "bytes": 17,
                                         "character": 15,
                                         "line": 1
                                       },
-                                      "token_type": {
-                                        "type": "Whitespace",
-                                        "characters": " "
-                                      }
-                                    }
-                                  ]
-                                }
-                              },
-                              "rhs": {
-                                "value": {
-                                  "Var": {
-                                    "Name": {
-                                      "leading_trivia": [],
-                                      "token": {
-                                        "start_position": {
-                                          "bytes": 17,
-                                          "character": 15,
-                                          "line": 1
-                                        },
-                                        "end_position": {
-                                          "bytes": 24,
-                                          "character": 22,
-                                          "line": 1
-                                        },
-                                        "token_type": {
-                                          "type": "Identifier",
-                                          "identifier": "message"
-                                        }
+                                      "end_position": {
+                                        "bytes": 24,
+                                        "character": 22,
+                                        "line": 1
                                       },
-                                      "trailing_trivia": []
-                                    }
+                                      "token_type": {
+                                        "type": "Identifier",
+                                        "identifier": "message"
+                                      }
+                                    },
+                                    "trailing_trivia": []
                                   }
-                                },
-                                "binop": null
+                                }
                               }
                             }
                           }

--- a/full-moon/tests/roblox_cases/pass/no_roblox_syntax/ast.json
+++ b/full-moon/tests/roblox_cases/pass/no_roblox_syntax/ast.json
@@ -300,8 +300,7 @@
                                               },
                                               "trailing_trivia": []
                                             }
-                                          },
-                                          "binop": null
+                                          }
                                         }
                                       }
                                     ]
@@ -313,8 +312,7 @@
                         }
                       ]
                     }
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]
@@ -607,8 +605,7 @@
                                               },
                                               "trailing_trivia": []
                                             }
-                                          },
-                                          "binop": null
+                                          }
                                         }
                                       }
                                     ]
@@ -620,8 +617,7 @@
                         }
                       ]
                     }
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]
@@ -988,8 +984,7 @@
                                               ]
                                             }
                                           }
-                                        },
-                                        "binop": null
+                                        }
                                       }
                                     }
                                   ]
@@ -1000,8 +995,7 @@
                         }
                       ]
                     }
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]
@@ -1191,8 +1185,7 @@
                       },
                       "trailing_trivia": []
                     }
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]
@@ -1307,214 +1300,213 @@
             "pairs": [
               {
                 "End": {
-                  "value": {
-                    "Var": {
-                      "Name": {
-                        "leading_trivia": [],
-                        "token": {
-                          "start_position": {
-                            "bytes": 298,
-                            "character": 9,
-                            "line": 8
-                          },
-                          "end_position": {
-                            "bytes": 303,
-                            "character": 14,
-                            "line": 8
-                          },
-                          "token_type": {
-                            "type": "Identifier",
-                            "identifier": "DEBUG"
-                          }
-                        },
-                        "trailing_trivia": [
-                          {
+                  "lhs": {
+                    "value": {
+                      "Var": {
+                        "Name": {
+                          "leading_trivia": [],
+                          "token": {
                             "start_position": {
+                              "bytes": 298,
+                              "character": 9,
+                              "line": 8
+                            },
+                            "end_position": {
                               "bytes": 303,
                               "character": 14,
                               "line": 8
                             },
-                            "end_position": {
-                              "bytes": 304,
-                              "character": 15,
-                              "line": 8
-                            },
                             "token_type": {
-                              "type": "Whitespace",
-                              "characters": " "
+                              "type": "Identifier",
+                              "identifier": "DEBUG"
                             }
-                          }
-                        ]
+                          },
+                          "trailing_trivia": [
+                            {
+                              "start_position": {
+                                "bytes": 303,
+                                "character": 14,
+                                "line": 8
+                              },
+                              "end_position": {
+                                "bytes": 304,
+                                "character": 15,
+                                "line": 8
+                              },
+                              "token_type": {
+                                "type": "Whitespace",
+                                "characters": " "
+                              }
+                            }
+                          ]
+                        }
                       }
                     }
                   },
                   "binop": {
-                    "bin_op": {
-                      "And": {
-                        "leading_trivia": [],
-                        "token": {
+                    "And": {
+                      "leading_trivia": [],
+                      "token": {
+                        "start_position": {
+                          "bytes": 304,
+                          "character": 15,
+                          "line": 8
+                        },
+                        "end_position": {
+                          "bytes": 307,
+                          "character": 18,
+                          "line": 8
+                        },
+                        "token_type": {
+                          "type": "Symbol",
+                          "symbol": "and"
+                        }
+                      },
+                      "trailing_trivia": [
+                        {
                           "start_position": {
-                            "bytes": 304,
-                            "character": 15,
-                            "line": 8
-                          },
-                          "end_position": {
                             "bytes": 307,
                             "character": 18,
                             "line": 8
                           },
+                          "end_position": {
+                            "bytes": 308,
+                            "character": 19,
+                            "line": 8
+                          },
                           "token_type": {
-                            "type": "Symbol",
-                            "symbol": "and"
+                            "type": "Whitespace",
+                            "characters": " "
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "rhs": {
+                    "value": {
+                      "FunctionCall": {
+                        "prefix": {
+                          "Name": {
+                            "leading_trivia": [],
+                            "token": {
+                              "start_position": {
+                                "bytes": 308,
+                                "character": 19,
+                                "line": 8
+                              },
+                              "end_position": {
+                                "bytes": 318,
+                                "character": 29,
+                                "line": 8
+                              },
+                              "token_type": {
+                                "type": "Identifier",
+                                "identifier": "RunService"
+                              }
+                            },
+                            "trailing_trivia": []
                           }
                         },
-                        "trailing_trivia": [
+                        "suffixes": [
                           {
-                            "start_position": {
-                              "bytes": 307,
-                              "character": 18,
-                              "line": 8
-                            },
-                            "end_position": {
-                              "bytes": 308,
-                              "character": 19,
-                              "line": 8
-                            },
-                            "token_type": {
-                              "type": "Whitespace",
-                              "characters": " "
-                            }
-                          }
-                        ]
-                      }
-                    },
-                    "rhs": {
-                      "value": {
-                        "FunctionCall": {
-                          "prefix": {
-                            "Name": {
-                              "leading_trivia": [],
-                              "token": {
-                                "start_position": {
-                                  "bytes": 308,
-                                  "character": 19,
-                                  "line": 8
-                                },
-                                "end_position": {
-                                  "bytes": 318,
-                                  "character": 29,
-                                  "line": 8
-                                },
-                                "token_type": {
-                                  "type": "Identifier",
-                                  "identifier": "RunService"
-                                }
-                              },
-                              "trailing_trivia": []
-                            }
-                          },
-                          "suffixes": [
-                            {
-                              "Call": {
-                                "MethodCall": {
-                                  "colon_token": {
-                                    "leading_trivia": [],
-                                    "token": {
-                                      "start_position": {
-                                        "bytes": 318,
-                                        "character": 29,
-                                        "line": 8
-                                      },
-                                      "end_position": {
-                                        "bytes": 319,
-                                        "character": 30,
-                                        "line": 8
-                                      },
-                                      "token_type": {
-                                        "type": "Symbol",
-                                        "symbol": ":"
-                                      }
+                            "Call": {
+                              "MethodCall": {
+                                "colon_token": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 318,
+                                      "character": 29,
+                                      "line": 8
                                     },
-                                    "trailing_trivia": []
-                                  },
-                                  "name": {
-                                    "leading_trivia": [],
-                                    "token": {
-                                      "start_position": {
-                                        "bytes": 319,
-                                        "character": 30,
-                                        "line": 8
-                                      },
-                                      "end_position": {
-                                        "bytes": 327,
-                                        "character": 38,
-                                        "line": 8
-                                      },
-                                      "token_type": {
-                                        "type": "Identifier",
-                                        "identifier": "IsStudio"
-                                      }
+                                    "end_position": {
+                                      "bytes": 319,
+                                      "character": 30,
+                                      "line": 8
                                     },
-                                    "trailing_trivia": []
+                                    "token_type": {
+                                      "type": "Symbol",
+                                      "symbol": ":"
+                                    }
                                   },
-                                  "args": {
-                                    "Parentheses": {
-                                      "parentheses": {
-                                        "tokens": [
-                                          {
-                                            "leading_trivia": [],
-                                            "token": {
-                                              "start_position": {
-                                                "bytes": 327,
-                                                "character": 38,
-                                                "line": 8
-                                              },
-                                              "end_position": {
-                                                "bytes": 328,
-                                                "character": 39,
-                                                "line": 8
-                                              },
-                                              "token_type": {
-                                                "type": "Symbol",
-                                                "symbol": "("
-                                              }
+                                  "trailing_trivia": []
+                                },
+                                "name": {
+                                  "leading_trivia": [],
+                                  "token": {
+                                    "start_position": {
+                                      "bytes": 319,
+                                      "character": 30,
+                                      "line": 8
+                                    },
+                                    "end_position": {
+                                      "bytes": 327,
+                                      "character": 38,
+                                      "line": 8
+                                    },
+                                    "token_type": {
+                                      "type": "Identifier",
+                                      "identifier": "IsStudio"
+                                    }
+                                  },
+                                  "trailing_trivia": []
+                                },
+                                "args": {
+                                  "Parentheses": {
+                                    "parentheses": {
+                                      "tokens": [
+                                        {
+                                          "leading_trivia": [],
+                                          "token": {
+                                            "start_position": {
+                                              "bytes": 327,
+                                              "character": 38,
+                                              "line": 8
                                             },
-                                            "trailing_trivia": []
+                                            "end_position": {
+                                              "bytes": 328,
+                                              "character": 39,
+                                              "line": 8
+                                            },
+                                            "token_type": {
+                                              "type": "Symbol",
+                                              "symbol": "("
+                                            }
                                           },
-                                          {
-                                            "leading_trivia": [],
-                                            "token": {
-                                              "start_position": {
-                                                "bytes": 328,
-                                                "character": 39,
-                                                "line": 8
-                                              },
-                                              "end_position": {
-                                                "bytes": 329,
-                                                "character": 40,
-                                                "line": 8
-                                              },
-                                              "token_type": {
-                                                "type": "Symbol",
-                                                "symbol": ")"
-                                              }
+                                          "trailing_trivia": []
+                                        },
+                                        {
+                                          "leading_trivia": [],
+                                          "token": {
+                                            "start_position": {
+                                              "bytes": 328,
+                                              "character": 39,
+                                              "line": 8
                                             },
-                                            "trailing_trivia": []
-                                          }
-                                        ]
-                                      },
-                                      "arguments": {
-                                        "pairs": []
-                                      }
+                                            "end_position": {
+                                              "bytes": 329,
+                                              "character": 40,
+                                              "line": 8
+                                            },
+                                            "token_type": {
+                                              "type": "Symbol",
+                                              "symbol": ")"
+                                            }
+                                          },
+                                          "trailing_trivia": []
+                                        }
+                                      ]
+                                    },
+                                    "arguments": {
+                                      "pairs": []
                                     }
                                   }
                                 }
                               }
                             }
-                          ]
-                        }
-                      },
-                      "binop": null
+                          }
+                        ]
+                      }
                     }
                   }
                 }
@@ -1749,8 +1741,7 @@
                   ]
                 }
               }
-            },
-            "binop": null
+            }
           },
           "then_token": {
             "leading_trivia": [],
@@ -2054,8 +2045,7 @@
                                                         },
                                                         "trailing_trivia": []
                                                       }
-                                                    },
-                                                    "binop": null
+                                                    }
                                                   },
                                                   {
                                                     "leading_trivia": [],
@@ -2119,8 +2109,7 @@
                                                       },
                                                       "trailing_trivia": []
                                                     }
-                                                  },
-                                                  "binop": null
+                                                  }
                                                 }
                                               }
                                             ]
@@ -2935,166 +2924,207 @@
                                   ]
                                 },
                                 "condition": {
-                                  "value": {
-                                    "FunctionCall": {
-                                      "prefix": {
-                                        "Name": {
-                                          "leading_trivia": [],
-                                          "token": {
-                                            "start_position": {
-                                              "bytes": 514,
-                                              "character": 5,
-                                              "line": 22
+                                  "lhs": {
+                                    "value": {
+                                      "FunctionCall": {
+                                        "prefix": {
+                                          "Name": {
+                                            "leading_trivia": [],
+                                            "token": {
+                                              "start_position": {
+                                                "bytes": 514,
+                                                "character": 5,
+                                                "line": 22
+                                              },
+                                              "end_position": {
+                                                "bytes": 520,
+                                                "character": 11,
+                                                "line": 22
+                                              },
+                                              "token_type": {
+                                                "type": "Identifier",
+                                                "identifier": "typeof"
+                                              }
                                             },
-                                            "end_position": {
-                                              "bytes": 520,
-                                              "character": 11,
-                                              "line": 22
-                                            },
-                                            "token_type": {
-                                              "type": "Identifier",
-                                              "identifier": "typeof"
-                                            }
-                                          },
-                                          "trailing_trivia": []
-                                        }
-                                      },
-                                      "suffixes": [
-                                        {
-                                          "Call": {
-                                            "AnonymousCall": {
-                                              "Parentheses": {
-                                                "parentheses": {
-                                                  "tokens": [
-                                                    {
-                                                      "leading_trivia": [],
-                                                      "token": {
-                                                        "start_position": {
-                                                          "bytes": 520,
-                                                          "character": 11,
-                                                          "line": 22
-                                                        },
-                                                        "end_position": {
-                                                          "bytes": 521,
-                                                          "character": 12,
-                                                          "line": 22
-                                                        },
-                                                        "token_type": {
-                                                          "type": "Symbol",
-                                                          "symbol": "("
-                                                        }
-                                                      },
-                                                      "trailing_trivia": []
-                                                    },
-                                                    {
-                                                      "leading_trivia": [],
-                                                      "token": {
-                                                        "start_position": {
-                                                          "bytes": 527,
-                                                          "character": 18,
-                                                          "line": 22
-                                                        },
-                                                        "end_position": {
-                                                          "bytes": 528,
-                                                          "character": 19,
-                                                          "line": 22
-                                                        },
-                                                        "token_type": {
-                                                          "type": "Symbol",
-                                                          "symbol": ")"
-                                                        }
-                                                      },
-                                                      "trailing_trivia": [
-                                                        {
+                                            "trailing_trivia": []
+                                          }
+                                        },
+                                        "suffixes": [
+                                          {
+                                            "Call": {
+                                              "AnonymousCall": {
+                                                "Parentheses": {
+                                                  "parentheses": {
+                                                    "tokens": [
+                                                      {
+                                                        "leading_trivia": [],
+                                                        "token": {
                                                           "start_position": {
+                                                            "bytes": 520,
+                                                            "character": 11,
+                                                            "line": 22
+                                                          },
+                                                          "end_position": {
+                                                            "bytes": 521,
+                                                            "character": 12,
+                                                            "line": 22
+                                                          },
+                                                          "token_type": {
+                                                            "type": "Symbol",
+                                                            "symbol": "("
+                                                          }
+                                                        },
+                                                        "trailing_trivia": []
+                                                      },
+                                                      {
+                                                        "leading_trivia": [],
+                                                        "token": {
+                                                          "start_position": {
+                                                            "bytes": 527,
+                                                            "character": 18,
+                                                            "line": 22
+                                                          },
+                                                          "end_position": {
                                                             "bytes": 528,
                                                             "character": 19,
                                                             "line": 22
                                                           },
-                                                          "end_position": {
-                                                            "bytes": 529,
-                                                            "character": 20,
-                                                            "line": 22
-                                                          },
                                                           "token_type": {
-                                                            "type": "Whitespace",
-                                                            "characters": " "
-                                                          }
-                                                        }
-                                                      ]
-                                                    }
-                                                  ]
-                                                },
-                                                "arguments": {
-                                                  "pairs": [
-                                                    {
-                                                      "End": {
-                                                        "value": {
-                                                          "Var": {
-                                                            "Name": {
-                                                              "leading_trivia": [],
-                                                              "token": {
-                                                                "start_position": {
-                                                                  "bytes": 521,
-                                                                  "character": 12,
-                                                                  "line": 22
-                                                                },
-                                                                "end_position": {
-                                                                  "bytes": 527,
-                                                                  "character": 18,
-                                                                  "line": 22
-                                                                },
-                                                                "token_type": {
-                                                                  "type": "Identifier",
-                                                                  "identifier": "origin"
-                                                                }
-                                                              },
-                                                              "trailing_trivia": []
-                                                            }
+                                                            "type": "Symbol",
+                                                            "symbol": ")"
                                                           }
                                                         },
-                                                        "binop": null
+                                                        "trailing_trivia": [
+                                                          {
+                                                            "start_position": {
+                                                              "bytes": 528,
+                                                              "character": 19,
+                                                              "line": 22
+                                                            },
+                                                            "end_position": {
+                                                              "bytes": 529,
+                                                              "character": 20,
+                                                              "line": 22
+                                                            },
+                                                            "token_type": {
+                                                              "type": "Whitespace",
+                                                              "characters": " "
+                                                            }
+                                                          }
+                                                        ]
                                                       }
-                                                    }
-                                                  ]
+                                                    ]
+                                                  },
+                                                  "arguments": {
+                                                    "pairs": [
+                                                      {
+                                                        "End": {
+                                                          "value": {
+                                                            "Var": {
+                                                              "Name": {
+                                                                "leading_trivia": [],
+                                                                "token": {
+                                                                  "start_position": {
+                                                                    "bytes": 521,
+                                                                    "character": 12,
+                                                                    "line": 22
+                                                                  },
+                                                                  "end_position": {
+                                                                    "bytes": 527,
+                                                                    "character": 18,
+                                                                    "line": 22
+                                                                  },
+                                                                  "token_type": {
+                                                                    "type": "Identifier",
+                                                                    "identifier": "origin"
+                                                                  }
+                                                                },
+                                                                "trailing_trivia": []
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    ]
+                                                  }
                                                 }
                                               }
                                             }
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  },
+                                  "binop": {
+                                    "TwoEqual": {
+                                      "leading_trivia": [],
+                                      "token": {
+                                        "start_position": {
+                                          "bytes": 529,
+                                          "character": 20,
+                                          "line": 22
+                                        },
+                                        "end_position": {
+                                          "bytes": 531,
+                                          "character": 22,
+                                          "line": 22
+                                        },
+                                        "token_type": {
+                                          "type": "Symbol",
+                                          "symbol": "=="
+                                        }
+                                      },
+                                      "trailing_trivia": [
+                                        {
+                                          "start_position": {
+                                            "bytes": 531,
+                                            "character": 22,
+                                            "line": 22
+                                          },
+                                          "end_position": {
+                                            "bytes": 532,
+                                            "character": 23,
+                                            "line": 22
+                                          },
+                                          "token_type": {
+                                            "type": "Whitespace",
+                                            "characters": " "
                                           }
                                         }
                                       ]
                                     }
                                   },
-                                  "binop": {
-                                    "bin_op": {
-                                      "TwoEqual": {
+                                  "rhs": {
+                                    "value": {
+                                      "String": {
                                         "leading_trivia": [],
                                         "token": {
                                           "start_position": {
-                                            "bytes": 529,
-                                            "character": 20,
+                                            "bytes": 532,
+                                            "character": 23,
                                             "line": 22
                                           },
                                           "end_position": {
-                                            "bytes": 531,
-                                            "character": 22,
+                                            "bytes": 542,
+                                            "character": 33,
                                             "line": 22
                                           },
                                           "token_type": {
-                                            "type": "Symbol",
-                                            "symbol": "=="
+                                            "type": "StringLiteral",
+                                            "literal": "Instance",
+                                            "quote_type": "Double"
                                           }
                                         },
                                         "trailing_trivia": [
                                           {
                                             "start_position": {
-                                              "bytes": 531,
-                                              "character": 22,
+                                              "bytes": 542,
+                                              "character": 33,
                                               "line": 22
                                             },
                                             "end_position": {
-                                              "bytes": 532,
-                                              "character": 23,
+                                              "bytes": 543,
+                                              "character": 34,
                                               "line": 22
                                             },
                                             "token_type": {
@@ -3104,49 +3134,6 @@
                                           }
                                         ]
                                       }
-                                    },
-                                    "rhs": {
-                                      "value": {
-                                        "String": {
-                                          "leading_trivia": [],
-                                          "token": {
-                                            "start_position": {
-                                              "bytes": 532,
-                                              "character": 23,
-                                              "line": 22
-                                            },
-                                            "end_position": {
-                                              "bytes": 542,
-                                              "character": 33,
-                                              "line": 22
-                                            },
-                                            "token_type": {
-                                              "type": "StringLiteral",
-                                              "literal": "Instance",
-                                              "quote_type": "Double"
-                                            }
-                                          },
-                                          "trailing_trivia": [
-                                            {
-                                              "start_position": {
-                                                "bytes": 542,
-                                                "character": 33,
-                                                "line": 22
-                                              },
-                                              "end_position": {
-                                                "bytes": 543,
-                                                "character": 34,
-                                                "line": 22
-                                              },
-                                              "token_type": {
-                                                "type": "Whitespace",
-                                                "characters": " "
-                                              }
-                                            }
-                                          ]
-                                        }
-                                      },
-                                      "binop": null
                                     }
                                   }
                                 },
@@ -3532,8 +3519,7 @@
                                                                           ]
                                                                         }
                                                                       }
-                                                                    },
-                                                                    "binop": null
+                                                                    }
                                                                   }
                                                                 }
                                                               ]
@@ -3545,8 +3531,7 @@
                                                   }
                                                 ]
                                               }
-                                            },
-                                            "binop": null
+                                            }
                                           },
                                           "then_token": {
                                             "leading_trivia": [],
@@ -3687,8 +3672,7 @@
                                                                           },
                                                                           "trailing_trivia": []
                                                                         }
-                                                                      },
-                                                                      "binop": null
+                                                                      }
                                                                     }
                                                                   }
                                                                 ]
@@ -3788,8 +3772,7 @@
                                                                   "trailing_trivia": []
                                                                 }
                                                               }
-                                                            },
-                                                            "binop": null
+                                                            }
                                                           },
                                                           {
                                                             "leading_trivia": [],
@@ -3907,8 +3890,7 @@
                                                                 ]
                                                               }
                                                             }
-                                                          },
-                                                          "binop": null
+                                                          }
                                                         }
                                                       }
                                                     ]
@@ -4159,8 +4141,7 @@
                                                         ]
                                                       }
                                                     }
-                                                  },
-                                                  "binop": null
+                                                  }
                                                 }
                                               }
                                             ]
@@ -4337,140 +4318,139 @@
                                   "pairs": [
                                     {
                                       "End": {
-                                        "value": {
-                                          "Var": {
-                                            "Name": {
-                                              "leading_trivia": [],
-                                              "token": {
-                                                "start_position": {
-                                                  "bytes": 734,
-                                                  "character": 14,
-                                                  "line": 31
-                                                },
-                                                "end_position": {
-                                                  "bytes": 743,
-                                                  "character": 23,
-                                                  "line": 31
-                                                },
-                                                "token_type": {
-                                                  "type": "Identifier",
-                                                  "identifier": "blacklist"
-                                                }
-                                              },
-                                              "trailing_trivia": [
-                                                {
+                                        "lhs": {
+                                          "value": {
+                                            "Var": {
+                                              "Name": {
+                                                "leading_trivia": [],
+                                                "token": {
                                                   "start_position": {
+                                                    "bytes": 734,
+                                                    "character": 14,
+                                                    "line": 31
+                                                  },
+                                                  "end_position": {
                                                     "bytes": 743,
                                                     "character": 23,
                                                     "line": 31
                                                   },
-                                                  "end_position": {
-                                                    "bytes": 744,
-                                                    "character": 24,
-                                                    "line": 31
-                                                  },
                                                   "token_type": {
-                                                    "type": "Whitespace",
-                                                    "characters": " "
+                                                    "type": "Identifier",
+                                                    "identifier": "blacklist"
                                                   }
-                                                }
-                                              ]
+                                                },
+                                                "trailing_trivia": [
+                                                  {
+                                                    "start_position": {
+                                                      "bytes": 743,
+                                                      "character": 23,
+                                                      "line": 31
+                                                    },
+                                                    "end_position": {
+                                                      "bytes": 744,
+                                                      "character": 24,
+                                                      "line": 31
+                                                    },
+                                                    "token_type": {
+                                                      "type": "Whitespace",
+                                                      "characters": " "
+                                                    }
+                                                  }
+                                                ]
+                                              }
                                             }
                                           }
                                         },
                                         "binop": {
-                                          "bin_op": {
-                                            "Or": {
-                                              "leading_trivia": [],
-                                              "token": {
+                                          "Or": {
+                                            "leading_trivia": [],
+                                            "token": {
+                                              "start_position": {
+                                                "bytes": 744,
+                                                "character": 24,
+                                                "line": 31
+                                              },
+                                              "end_position": {
+                                                "bytes": 746,
+                                                "character": 26,
+                                                "line": 31
+                                              },
+                                              "token_type": {
+                                                "type": "Symbol",
+                                                "symbol": "or"
+                                              }
+                                            },
+                                            "trailing_trivia": [
+                                              {
                                                 "start_position": {
-                                                  "bytes": 744,
-                                                  "character": 24,
-                                                  "line": 31
-                                                },
-                                                "end_position": {
                                                   "bytes": 746,
                                                   "character": 26,
                                                   "line": 31
                                                 },
-                                                "token_type": {
-                                                  "type": "Symbol",
-                                                  "symbol": "or"
-                                                }
-                                              },
-                                              "trailing_trivia": [
-                                                {
-                                                  "start_position": {
-                                                    "bytes": 746,
-                                                    "character": 26,
-                                                    "line": 31
-                                                  },
-                                                  "end_position": {
-                                                    "bytes": 747,
-                                                    "character": 27,
-                                                    "line": 31
-                                                  },
-                                                  "token_type": {
-                                                    "type": "Whitespace",
-                                                    "characters": " "
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          "rhs": {
-                                            "value": {
-                                              "TableConstructor": {
-                                                "braces": {
-                                                  "tokens": [
-                                                    {
-                                                      "leading_trivia": [],
-                                                      "token": {
-                                                        "start_position": {
-                                                          "bytes": 747,
-                                                          "character": 27,
-                                                          "line": 31
-                                                        },
-                                                        "end_position": {
-                                                          "bytes": 748,
-                                                          "character": 28,
-                                                          "line": 31
-                                                        },
-                                                        "token_type": {
-                                                          "type": "Symbol",
-                                                          "symbol": "{"
-                                                        }
-                                                      },
-                                                      "trailing_trivia": []
-                                                    },
-                                                    {
-                                                      "leading_trivia": [],
-                                                      "token": {
-                                                        "start_position": {
-                                                          "bytes": 748,
-                                                          "character": 28,
-                                                          "line": 31
-                                                        },
-                                                        "end_position": {
-                                                          "bytes": 749,
-                                                          "character": 29,
-                                                          "line": 31
-                                                        },
-                                                        "token_type": {
-                                                          "type": "Symbol",
-                                                          "symbol": "}"
-                                                        }
-                                                      },
-                                                      "trailing_trivia": []
-                                                    }
-                                                  ]
+                                                "end_position": {
+                                                  "bytes": 747,
+                                                  "character": 27,
+                                                  "line": 31
                                                 },
-                                                "fields": {
-                                                  "pairs": []
+                                                "token_type": {
+                                                  "type": "Whitespace",
+                                                  "characters": " "
                                                 }
                                               }
-                                            },
-                                            "binop": null
+                                            ]
+                                          }
+                                        },
+                                        "rhs": {
+                                          "value": {
+                                            "TableConstructor": {
+                                              "braces": {
+                                                "tokens": [
+                                                  {
+                                                    "leading_trivia": [],
+                                                    "token": {
+                                                      "start_position": {
+                                                        "bytes": 747,
+                                                        "character": 27,
+                                                        "line": 31
+                                                      },
+                                                      "end_position": {
+                                                        "bytes": 748,
+                                                        "character": 28,
+                                                        "line": 31
+                                                      },
+                                                      "token_type": {
+                                                        "type": "Symbol",
+                                                        "symbol": "{"
+                                                      }
+                                                    },
+                                                    "trailing_trivia": []
+                                                  },
+                                                  {
+                                                    "leading_trivia": [],
+                                                    "token": {
+                                                      "start_position": {
+                                                        "bytes": 748,
+                                                        "character": 28,
+                                                        "line": 31
+                                                      },
+                                                      "end_position": {
+                                                        "bytes": 749,
+                                                        "character": 29,
+                                                        "line": 31
+                                                      },
+                                                      "token_type": {
+                                                        "type": "Symbol",
+                                                        "symbol": "}"
+                                                      }
+                                                    },
+                                                    "trailing_trivia": []
+                                                  }
+                                                ]
+                                              },
+                                              "fields": {
+                                                "pairs": []
+                                              }
+                                            }
                                           }
                                         }
                                       }
@@ -4791,8 +4771,7 @@
                                                   }
                                                 ]
                                               }
-                                            },
-                                            "binop": null
+                                            }
                                           },
                                           "do_token": {
                                             "leading_trivia": [],
@@ -5210,8 +5189,7 @@
                                                                                                                   "trailing_trivia": []
                                                                                                                 }
                                                                                                               }
-                                                                                                            },
-                                                                                                            "binop": null
+                                                                                                            }
                                                                                                           },
                                                                                                           {
                                                                                                             "leading_trivia": [],
@@ -5254,99 +5232,101 @@
                                                                                                       },
                                                                                                       {
                                                                                                         "End": {
-                                                                                                          "value": {
-                                                                                                            "Var": {
-                                                                                                              "Expression": {
-                                                                                                                "prefix": {
-                                                                                                                  "Expression": {
-                                                                                                                    "contained": {
-                                                                                                                      "tokens": [
-                                                                                                                        {
-                                                                                                                          "leading_trivia": [],
-                                                                                                                          "token": {
-                                                                                                                            "start_position": {
-                                                                                                                              "bytes": 828,
-                                                                                                                              "character": 41,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "end_position": {
-                                                                                                                              "bytes": 829,
-                                                                                                                              "character": 42,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "token_type": {
-                                                                                                                              "type": "Symbol",
-                                                                                                                              "symbol": "("
-                                                                                                                            }
-                                                                                                                          },
-                                                                                                                          "trailing_trivia": []
-                                                                                                                        },
-                                                                                                                        {
-                                                                                                                          "leading_trivia": [],
-                                                                                                                          "token": {
-                                                                                                                            "start_position": {
-                                                                                                                              "bytes": 868,
-                                                                                                                              "character": 81,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "end_position": {
-                                                                                                                              "bytes": 869,
-                                                                                                                              "character": 82,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "token_type": {
-                                                                                                                              "type": "Symbol",
-                                                                                                                              "symbol": ")"
-                                                                                                                            }
-                                                                                                                          },
-                                                                                                                          "trailing_trivia": []
-                                                                                                                        }
-                                                                                                                      ]
-                                                                                                                    },
-                                                                                                                    "expression": {
-                                                                                                                      "value": {
-                                                                                                                        "Var": {
-                                                                                                                          "Name": {
+                                                                                                          "lhs": {
+                                                                                                            "value": {
+                                                                                                              "Var": {
+                                                                                                                "Expression": {
+                                                                                                                  "prefix": {
+                                                                                                                    "Expression": {
+                                                                                                                      "contained": {
+                                                                                                                        "tokens": [
+                                                                                                                          {
                                                                                                                             "leading_trivia": [],
                                                                                                                             "token": {
                                                                                                                               "start_position": {
+                                                                                                                                "bytes": 828,
+                                                                                                                                "character": 41,
+                                                                                                                                "line": 35
+                                                                                                                              },
+                                                                                                                              "end_position": {
                                                                                                                                 "bytes": 829,
                                                                                                                                 "character": 42,
                                                                                                                                 "line": 35
                                                                                                                               },
+                                                                                                                              "token_type": {
+                                                                                                                                "type": "Symbol",
+                                                                                                                                "symbol": "("
+                                                                                                                              }
+                                                                                                                            },
+                                                                                                                            "trailing_trivia": []
+                                                                                                                          },
+                                                                                                                          {
+                                                                                                                            "leading_trivia": [],
+                                                                                                                            "token": {
+                                                                                                                              "start_position": {
+                                                                                                                                "bytes": 868,
+                                                                                                                                "character": 81,
+                                                                                                                                "line": 35
+                                                                                                                              },
                                                                                                                               "end_position": {
-                                                                                                                                "bytes": 835,
-                                                                                                                                "character": 48,
+                                                                                                                                "bytes": 869,
+                                                                                                                                "character": 82,
                                                                                                                                 "line": 35
                                                                                                                               },
                                                                                                                               "token_type": {
-                                                                                                                                "type": "Identifier",
-                                                                                                                                "identifier": "origin"
+                                                                                                                                "type": "Symbol",
+                                                                                                                                "symbol": ")"
                                                                                                                               }
                                                                                                                             },
-                                                                                                                            "trailing_trivia": [
-                                                                                                                              {
-                                                                                                                                "start_position": {
-                                                                                                                                  "bytes": 835,
-                                                                                                                                  "character": 48,
-                                                                                                                                  "line": 35
-                                                                                                                                },
-                                                                                                                                "end_position": {
-                                                                                                                                  "bytes": 836,
-                                                                                                                                  "character": 49,
-                                                                                                                                  "line": 35
-                                                                                                                                },
-                                                                                                                                "token_type": {
-                                                                                                                                  "type": "Whitespace",
-                                                                                                                                  "characters": " "
-                                                                                                                                }
-                                                                                                                              }
-                                                                                                                            ]
+                                                                                                                            "trailing_trivia": []
                                                                                                                           }
-                                                                                                                        }
+                                                                                                                        ]
                                                                                                                       },
-                                                                                                                      "binop": {
-                                                                                                                        "bin_op": {
+                                                                                                                      "expression": {
+                                                                                                                        "lhs": {
+                                                                                                                          "value": {
+                                                                                                                            "Var": {
+                                                                                                                              "Name": {
+                                                                                                                                "leading_trivia": [],
+                                                                                                                                "token": {
+                                                                                                                                  "start_position": {
+                                                                                                                                    "bytes": 829,
+                                                                                                                                    "character": 42,
+                                                                                                                                    "line": 35
+                                                                                                                                  },
+                                                                                                                                  "end_position": {
+                                                                                                                                    "bytes": 835,
+                                                                                                                                    "character": 48,
+                                                                                                                                    "line": 35
+                                                                                                                                  },
+                                                                                                                                  "token_type": {
+                                                                                                                                    "type": "Identifier",
+                                                                                                                                    "identifier": "origin"
+                                                                                                                                  }
+                                                                                                                                },
+                                                                                                                                "trailing_trivia": [
+                                                                                                                                  {
+                                                                                                                                    "start_position": {
+                                                                                                                                      "bytes": 835,
+                                                                                                                                      "character": 48,
+                                                                                                                                      "line": 35
+                                                                                                                                    },
+                                                                                                                                    "end_position": {
+                                                                                                                                      "bytes": 836,
+                                                                                                                                      "character": 49,
+                                                                                                                                      "line": 35
+                                                                                                                                    },
+                                                                                                                                    "token_type": {
+                                                                                                                                      "type": "Whitespace",
+                                                                                                                                      "characters": " "
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                ]
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "binop": {
                                                                                                                           "Minus": {
                                                                                                                             "leading_trivia": [],
                                                                                                                             "token": {
@@ -5507,170 +5487,166 @@
                                                                                                                                 ]
                                                                                                                               }
                                                                                                                             }
-                                                                                                                          },
-                                                                                                                          "binop": null
+                                                                                                                          }
                                                                                                                         }
                                                                                                                       }
                                                                                                                     }
-                                                                                                                  }
-                                                                                                                },
-                                                                                                                "suffixes": [
-                                                                                                                  {
-                                                                                                                    "Index": {
-                                                                                                                      "Dot": {
-                                                                                                                        "dot": {
-                                                                                                                          "leading_trivia": [],
-                                                                                                                          "token": {
-                                                                                                                            "start_position": {
-                                                                                                                              "bytes": 869,
-                                                                                                                              "character": 82,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "end_position": {
-                                                                                                                              "bytes": 870,
-                                                                                                                              "character": 83,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "token_type": {
-                                                                                                                              "type": "Symbol",
-                                                                                                                              "symbol": "."
-                                                                                                                            }
-                                                                                                                          },
-                                                                                                                          "trailing_trivia": []
-                                                                                                                        },
-                                                                                                                        "name": {
-                                                                                                                          "leading_trivia": [],
-                                                                                                                          "token": {
-                                                                                                                            "start_position": {
-                                                                                                                              "bytes": 870,
-                                                                                                                              "character": 83,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "end_position": {
-                                                                                                                              "bytes": 874,
-                                                                                                                              "character": 87,
-                                                                                                                              "line": 35
-                                                                                                                            },
-                                                                                                                            "token_type": {
-                                                                                                                              "type": "Identifier",
-                                                                                                                              "identifier": "Unit"
-                                                                                                                            }
-                                                                                                                          },
-                                                                                                                          "trailing_trivia": [
-                                                                                                                            {
+                                                                                                                  },
+                                                                                                                  "suffixes": [
+                                                                                                                    {
+                                                                                                                      "Index": {
+                                                                                                                        "Dot": {
+                                                                                                                          "dot": {
+                                                                                                                            "leading_trivia": [],
+                                                                                                                            "token": {
                                                                                                                               "start_position": {
+                                                                                                                                "bytes": 869,
+                                                                                                                                "character": 82,
+                                                                                                                                "line": 35
+                                                                                                                              },
+                                                                                                                              "end_position": {
+                                                                                                                                "bytes": 870,
+                                                                                                                                "character": 83,
+                                                                                                                                "line": 35
+                                                                                                                              },
+                                                                                                                              "token_type": {
+                                                                                                                                "type": "Symbol",
+                                                                                                                                "symbol": "."
+                                                                                                                              }
+                                                                                                                            },
+                                                                                                                            "trailing_trivia": []
+                                                                                                                          },
+                                                                                                                          "name": {
+                                                                                                                            "leading_trivia": [],
+                                                                                                                            "token": {
+                                                                                                                              "start_position": {
+                                                                                                                                "bytes": 870,
+                                                                                                                                "character": 83,
+                                                                                                                                "line": 35
+                                                                                                                              },
+                                                                                                                              "end_position": {
                                                                                                                                 "bytes": 874,
                                                                                                                                 "character": 87,
                                                                                                                                 "line": 35
                                                                                                                               },
-                                                                                                                              "end_position": {
-                                                                                                                                "bytes": 875,
-                                                                                                                                "character": 88,
-                                                                                                                                "line": 35
-                                                                                                                              },
                                                                                                                               "token_type": {
-                                                                                                                                "type": "Whitespace",
-                                                                                                                                "characters": " "
+                                                                                                                                "type": "Identifier",
+                                                                                                                                "identifier": "Unit"
                                                                                                                               }
-                                                                                                                            }
-                                                                                                                          ]
+                                                                                                                            },
+                                                                                                                            "trailing_trivia": [
+                                                                                                                              {
+                                                                                                                                "start_position": {
+                                                                                                                                  "bytes": 874,
+                                                                                                                                  "character": 87,
+                                                                                                                                  "line": 35
+                                                                                                                                },
+                                                                                                                                "end_position": {
+                                                                                                                                  "bytes": 875,
+                                                                                                                                  "character": 88,
+                                                                                                                                  "line": 35
+                                                                                                                                },
+                                                                                                                                "token_type": {
+                                                                                                                                  "type": "Whitespace",
+                                                                                                                                  "characters": " "
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            ]
+                                                                                                                          }
                                                                                                                         }
                                                                                                                       }
                                                                                                                     }
-                                                                                                                  }
-                                                                                                                ]
+                                                                                                                  ]
+                                                                                                                }
                                                                                                               }
                                                                                                             }
                                                                                                           },
                                                                                                           "binop": {
-                                                                                                            "bin_op": {
-                                                                                                              "Star": {
-                                                                                                                "leading_trivia": [],
-                                                                                                                "token": {
+                                                                                                            "Star": {
+                                                                                                              "leading_trivia": [],
+                                                                                                              "token": {
+                                                                                                                "start_position": {
+                                                                                                                  "bytes": 875,
+                                                                                                                  "character": 88,
+                                                                                                                  "line": 35
+                                                                                                                },
+                                                                                                                "end_position": {
+                                                                                                                  "bytes": 876,
+                                                                                                                  "character": 89,
+                                                                                                                  "line": 35
+                                                                                                                },
+                                                                                                                "token_type": {
+                                                                                                                  "type": "Symbol",
+                                                                                                                  "symbol": "*"
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "trailing_trivia": [
+                                                                                                                {
                                                                                                                   "start_position": {
-                                                                                                                    "bytes": 875,
-                                                                                                                    "character": 88,
-                                                                                                                    "line": 35
-                                                                                                                  },
-                                                                                                                  "end_position": {
                                                                                                                     "bytes": 876,
                                                                                                                     "character": 89,
                                                                                                                     "line": 35
                                                                                                                   },
+                                                                                                                  "end_position": {
+                                                                                                                    "bytes": 877,
+                                                                                                                    "character": 90,
+                                                                                                                    "line": 35
+                                                                                                                  },
+                                                                                                                  "token_type": {
+                                                                                                                    "type": "Whitespace",
+                                                                                                                    "characters": " "
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "rhs": {
+                                                                                                            "unop": {
+                                                                                                              "Minus": {
+                                                                                                                "leading_trivia": [],
+                                                                                                                "token": {
+                                                                                                                  "start_position": {
+                                                                                                                    "bytes": 877,
+                                                                                                                    "character": 90,
+                                                                                                                    "line": 35
+                                                                                                                  },
+                                                                                                                  "end_position": {
+                                                                                                                    "bytes": 878,
+                                                                                                                    "character": 91,
+                                                                                                                    "line": 35
+                                                                                                                  },
                                                                                                                   "token_type": {
                                                                                                                     "type": "Symbol",
-                                                                                                                    "symbol": "*"
+                                                                                                                    "symbol": "-"
                                                                                                                   }
                                                                                                                 },
-                                                                                                                "trailing_trivia": [
-                                                                                                                  {
-                                                                                                                    "start_position": {
-                                                                                                                      "bytes": 876,
-                                                                                                                      "character": 89,
-                                                                                                                      "line": 35
-                                                                                                                    },
-                                                                                                                    "end_position": {
-                                                                                                                      "bytes": 877,
-                                                                                                                      "character": 90,
-                                                                                                                      "line": 35
-                                                                                                                    },
-                                                                                                                    "token_type": {
-                                                                                                                      "type": "Whitespace",
-                                                                                                                      "characters": " "
-                                                                                                                    }
-                                                                                                                  }
-                                                                                                                ]
+                                                                                                                "trailing_trivia": []
                                                                                                               }
                                                                                                             },
-                                                                                                            "rhs": {
-                                                                                                              "unop": {
-                                                                                                                "Minus": {
-                                                                                                                  "leading_trivia": [],
-                                                                                                                  "token": {
-                                                                                                                    "start_position": {
-                                                                                                                      "bytes": 877,
-                                                                                                                      "character": 90,
-                                                                                                                      "line": 35
-                                                                                                                    },
-                                                                                                                    "end_position": {
-                                                                                                                      "bytes": 878,
-                                                                                                                      "character": 91,
-                                                                                                                      "line": 35
-                                                                                                                    },
-                                                                                                                    "token_type": {
-                                                                                                                      "type": "Symbol",
-                                                                                                                      "symbol": "-"
-                                                                                                                    }
-                                                                                                                  },
-                                                                                                                  "trailing_trivia": []
-                                                                                                                }
-                                                                                                              },
-                                                                                                              "expression": {
-                                                                                                                "value": {
-                                                                                                                  "Var": {
-                                                                                                                    "Name": {
-                                                                                                                      "leading_trivia": [],
-                                                                                                                      "token": {
-                                                                                                                        "start_position": {
-                                                                                                                          "bytes": 878,
-                                                                                                                          "character": 91,
-                                                                                                                          "line": 35
-                                                                                                                        },
-                                                                                                                        "end_position": {
-                                                                                                                          "bytes": 883,
-                                                                                                                          "character": 96,
-                                                                                                                          "line": 35
-                                                                                                                        },
-                                                                                                                        "token_type": {
-                                                                                                                          "type": "Identifier",
-                                                                                                                          "identifier": "range"
-                                                                                                                        }
+                                                                                                            "expression": {
+                                                                                                              "value": {
+                                                                                                                "Var": {
+                                                                                                                  "Name": {
+                                                                                                                    "leading_trivia": [],
+                                                                                                                    "token": {
+                                                                                                                      "start_position": {
+                                                                                                                        "bytes": 878,
+                                                                                                                        "character": 91,
+                                                                                                                        "line": 35
                                                                                                                       },
-                                                                                                                      "trailing_trivia": []
-                                                                                                                    }
+                                                                                                                      "end_position": {
+                                                                                                                        "bytes": 883,
+                                                                                                                        "character": 96,
+                                                                                                                        "line": 35
+                                                                                                                      },
+                                                                                                                      "token_type": {
+                                                                                                                        "type": "Identifier",
+                                                                                                                        "identifier": "range"
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "trailing_trivia": []
                                                                                                                   }
-                                                                                                                },
-                                                                                                                "binop": null
+                                                                                                                }
                                                                                                               }
                                                                                                             }
                                                                                                           }
@@ -5684,8 +5660,7 @@
                                                                                           }
                                                                                         ]
                                                                                       }
-                                                                                    },
-                                                                                    "binop": null
+                                                                                    }
                                                                                   },
                                                                                   {
                                                                                     "leading_trivia": [],
@@ -5751,8 +5726,7 @@
                                                                                         "trailing_trivia": []
                                                                                       }
                                                                                     }
-                                                                                  },
-                                                                                  "binop": null
+                                                                                  }
                                                                                 }
                                                                               }
                                                                             ]
@@ -5763,8 +5737,7 @@
                                                                   }
                                                                 ]
                                                               }
-                                                            },
-                                                            "binop": null
+                                                            }
                                                           }
                                                         }
                                                       ]
@@ -5847,261 +5820,259 @@
                                                       ]
                                                     },
                                                     "condition": {
-                                                      "value": {
-                                                        "Var": {
-                                                          "Name": {
-                                                            "leading_trivia": [],
-                                                            "token": {
-                                                              "start_position": {
-                                                                "bytes": 904,
-                                                                "character": 7,
-                                                                "line": 37
-                                                              },
-                                                              "end_position": {
-                                                                "bytes": 907,
-                                                                "character": 10,
-                                                                "line": 37
-                                                              },
-                                                              "token_type": {
-                                                                "type": "Identifier",
-                                                                "identifier": "hit"
-                                                              }
-                                                            },
-                                                            "trailing_trivia": [
-                                                              {
+                                                      "lhs": {
+                                                        "value": {
+                                                          "Var": {
+                                                            "Name": {
+                                                              "leading_trivia": [],
+                                                              "token": {
                                                                 "start_position": {
+                                                                  "bytes": 904,
+                                                                  "character": 7,
+                                                                  "line": 37
+                                                                },
+                                                                "end_position": {
                                                                   "bytes": 907,
                                                                   "character": 10,
                                                                   "line": 37
                                                                 },
-                                                                "end_position": {
-                                                                  "bytes": 908,
-                                                                  "character": 11,
-                                                                  "line": 37
-                                                                },
                                                                 "token_type": {
-                                                                  "type": "Whitespace",
-                                                                  "characters": " "
+                                                                  "type": "Identifier",
+                                                                  "identifier": "hit"
                                                                 }
-                                                              }
-                                                            ]
+                                                              },
+                                                              "trailing_trivia": [
+                                                                {
+                                                                  "start_position": {
+                                                                    "bytes": 907,
+                                                                    "character": 10,
+                                                                    "line": 37
+                                                                  },
+                                                                  "end_position": {
+                                                                    "bytes": 908,
+                                                                    "character": 11,
+                                                                    "line": 37
+                                                                  },
+                                                                  "token_type": {
+                                                                    "type": "Whitespace",
+                                                                    "characters": " "
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
                                                           }
                                                         }
                                                       },
                                                       "binop": {
-                                                        "bin_op": {
-                                                          "And": {
-                                                            "leading_trivia": [],
-                                                            "token": {
+                                                        "And": {
+                                                          "leading_trivia": [],
+                                                          "token": {
+                                                            "start_position": {
+                                                              "bytes": 908,
+                                                              "character": 11,
+                                                              "line": 37
+                                                            },
+                                                            "end_position": {
+                                                              "bytes": 911,
+                                                              "character": 14,
+                                                              "line": 37
+                                                            },
+                                                            "token_type": {
+                                                              "type": "Symbol",
+                                                              "symbol": "and"
+                                                            }
+                                                          },
+                                                          "trailing_trivia": [
+                                                            {
                                                               "start_position": {
-                                                                "bytes": 908,
-                                                                "character": 11,
-                                                                "line": 37
-                                                              },
-                                                              "end_position": {
                                                                 "bytes": 911,
                                                                 "character": 14,
                                                                 "line": 37
                                                               },
+                                                              "end_position": {
+                                                                "bytes": 912,
+                                                                "character": 15,
+                                                                "line": 37
+                                                              },
                                                               "token_type": {
-                                                                "type": "Symbol",
-                                                                "symbol": "and"
+                                                                "type": "Whitespace",
+                                                                "characters": " "
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "rhs": {
+                                                        "value": {
+                                                          "FunctionCall": {
+                                                            "prefix": {
+                                                              "Name": {
+                                                                "leading_trivia": [],
+                                                                "token": {
+                                                                  "start_position": {
+                                                                    "bytes": 912,
+                                                                    "character": 15,
+                                                                    "line": 37
+                                                                  },
+                                                                  "end_position": {
+                                                                    "bytes": 915,
+                                                                    "character": 18,
+                                                                    "line": 37
+                                                                  },
+                                                                  "token_type": {
+                                                                    "type": "Identifier",
+                                                                    "identifier": "hit"
+                                                                  }
+                                                                },
+                                                                "trailing_trivia": []
                                                               }
                                                             },
-                                                            "trailing_trivia": [
+                                                            "suffixes": [
                                                               {
-                                                                "start_position": {
-                                                                  "bytes": 911,
-                                                                  "character": 14,
-                                                                  "line": 37
-                                                                },
-                                                                "end_position": {
-                                                                  "bytes": 912,
-                                                                  "character": 15,
-                                                                  "line": 37
-                                                                },
-                                                                "token_type": {
-                                                                  "type": "Whitespace",
-                                                                  "characters": " "
-                                                                }
-                                                              }
-                                                            ]
-                                                          }
-                                                        },
-                                                        "rhs": {
-                                                          "value": {
-                                                            "FunctionCall": {
-                                                              "prefix": {
-                                                                "Name": {
-                                                                  "leading_trivia": [],
-                                                                  "token": {
-                                                                    "start_position": {
-                                                                      "bytes": 912,
-                                                                      "character": 15,
-                                                                      "line": 37
-                                                                    },
-                                                                    "end_position": {
-                                                                      "bytes": 915,
-                                                                      "character": 18,
-                                                                      "line": 37
-                                                                    },
-                                                                    "token_type": {
-                                                                      "type": "Identifier",
-                                                                      "identifier": "hit"
-                                                                    }
-                                                                  },
-                                                                  "trailing_trivia": []
-                                                                }
-                                                              },
-                                                              "suffixes": [
-                                                                {
-                                                                  "Call": {
-                                                                    "MethodCall": {
-                                                                      "colon_token": {
-                                                                        "leading_trivia": [],
-                                                                        "token": {
-                                                                          "start_position": {
-                                                                            "bytes": 915,
-                                                                            "character": 18,
-                                                                            "line": 37
-                                                                          },
-                                                                          "end_position": {
-                                                                            "bytes": 916,
-                                                                            "character": 19,
-                                                                            "line": 37
-                                                                          },
-                                                                          "token_type": {
-                                                                            "type": "Symbol",
-                                                                            "symbol": ":"
-                                                                          }
+                                                                "Call": {
+                                                                  "MethodCall": {
+                                                                    "colon_token": {
+                                                                      "leading_trivia": [],
+                                                                      "token": {
+                                                                        "start_position": {
+                                                                          "bytes": 915,
+                                                                          "character": 18,
+                                                                          "line": 37
                                                                         },
-                                                                        "trailing_trivia": []
-                                                                      },
-                                                                      "name": {
-                                                                        "leading_trivia": [],
-                                                                        "token": {
-                                                                          "start_position": {
-                                                                            "bytes": 916,
-                                                                            "character": 19,
-                                                                            "line": 37
-                                                                          },
-                                                                          "end_position": {
-                                                                            "bytes": 930,
-                                                                            "character": 33,
-                                                                            "line": 37
-                                                                          },
-                                                                          "token_type": {
-                                                                            "type": "Identifier",
-                                                                            "identifier": "IsDescendantOf"
-                                                                          }
+                                                                        "end_position": {
+                                                                          "bytes": 916,
+                                                                          "character": 19,
+                                                                          "line": 37
                                                                         },
-                                                                        "trailing_trivia": []
+                                                                        "token_type": {
+                                                                          "type": "Symbol",
+                                                                          "symbol": ":"
+                                                                        }
                                                                       },
-                                                                      "args": {
-                                                                        "Parentheses": {
-                                                                          "parentheses": {
-                                                                            "tokens": [
-                                                                              {
-                                                                                "leading_trivia": [],
-                                                                                "token": {
-                                                                                  "start_position": {
-                                                                                    "bytes": 930,
-                                                                                    "character": 33,
-                                                                                    "line": 37
-                                                                                  },
-                                                                                  "end_position": {
-                                                                                    "bytes": 931,
-                                                                                    "character": 34,
-                                                                                    "line": 37
-                                                                                  },
-                                                                                  "token_type": {
-                                                                                    "type": "Symbol",
-                                                                                    "symbol": "("
-                                                                                  }
+                                                                      "trailing_trivia": []
+                                                                    },
+                                                                    "name": {
+                                                                      "leading_trivia": [],
+                                                                      "token": {
+                                                                        "start_position": {
+                                                                          "bytes": 916,
+                                                                          "character": 19,
+                                                                          "line": 37
+                                                                        },
+                                                                        "end_position": {
+                                                                          "bytes": 930,
+                                                                          "character": 33,
+                                                                          "line": 37
+                                                                        },
+                                                                        "token_type": {
+                                                                          "type": "Identifier",
+                                                                          "identifier": "IsDescendantOf"
+                                                                        }
+                                                                      },
+                                                                      "trailing_trivia": []
+                                                                    },
+                                                                    "args": {
+                                                                      "Parentheses": {
+                                                                        "parentheses": {
+                                                                          "tokens": [
+                                                                            {
+                                                                              "leading_trivia": [],
+                                                                              "token": {
+                                                                                "start_position": {
+                                                                                  "bytes": 930,
+                                                                                  "character": 33,
+                                                                                  "line": 37
                                                                                 },
-                                                                                "trailing_trivia": []
+                                                                                "end_position": {
+                                                                                  "bytes": 931,
+                                                                                  "character": 34,
+                                                                                  "line": 37
+                                                                                },
+                                                                                "token_type": {
+                                                                                  "type": "Symbol",
+                                                                                  "symbol": "("
+                                                                                }
                                                                               },
-                                                                              {
-                                                                                "leading_trivia": [],
-                                                                                "token": {
+                                                                              "trailing_trivia": []
+                                                                            },
+                                                                            {
+                                                                              "leading_trivia": [],
+                                                                              "token": {
+                                                                                "start_position": {
+                                                                                  "bytes": 940,
+                                                                                  "character": 43,
+                                                                                  "line": 37
+                                                                                },
+                                                                                "end_position": {
+                                                                                  "bytes": 941,
+                                                                                  "character": 44,
+                                                                                  "line": 37
+                                                                                },
+                                                                                "token_type": {
+                                                                                  "type": "Symbol",
+                                                                                  "symbol": ")"
+                                                                                }
+                                                                              },
+                                                                              "trailing_trivia": [
+                                                                                {
                                                                                   "start_position": {
-                                                                                    "bytes": 940,
-                                                                                    "character": 43,
-                                                                                    "line": 37
-                                                                                  },
-                                                                                  "end_position": {
                                                                                     "bytes": 941,
                                                                                     "character": 44,
                                                                                     "line": 37
                                                                                   },
-                                                                                  "token_type": {
-                                                                                    "type": "Symbol",
-                                                                                    "symbol": ")"
-                                                                                  }
-                                                                                },
-                                                                                "trailing_trivia": [
-                                                                                  {
-                                                                                    "start_position": {
-                                                                                      "bytes": 941,
-                                                                                      "character": 44,
-                                                                                      "line": 37
-                                                                                    },
-                                                                                    "end_position": {
-                                                                                      "bytes": 942,
-                                                                                      "character": 45,
-                                                                                      "line": 37
-                                                                                    },
-                                                                                    "token_type": {
-                                                                                      "type": "Whitespace",
-                                                                                      "characters": " "
-                                                                                    }
-                                                                                  }
-                                                                                ]
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          "arguments": {
-                                                                            "pairs": [
-                                                                              {
-                                                                                "End": {
-                                                                                  "value": {
-                                                                                    "Var": {
-                                                                                      "Name": {
-                                                                                        "leading_trivia": [],
-                                                                                        "token": {
-                                                                                          "start_position": {
-                                                                                            "bytes": 931,
-                                                                                            "character": 34,
-                                                                                            "line": 37
-                                                                                          },
-                                                                                          "end_position": {
-                                                                                            "bytes": 940,
-                                                                                            "character": 43,
-                                                                                            "line": 37
-                                                                                          },
-                                                                                          "token_type": {
-                                                                                            "type": "Identifier",
-                                                                                            "identifier": "character"
-                                                                                          }
-                                                                                        },
-                                                                                        "trailing_trivia": []
-                                                                                      }
-                                                                                    }
+                                                                                  "end_position": {
+                                                                                    "bytes": 942,
+                                                                                    "character": 45,
+                                                                                    "line": 37
                                                                                   },
-                                                                                  "binop": null
+                                                                                  "token_type": {
+                                                                                    "type": "Whitespace",
+                                                                                    "characters": " "
+                                                                                  }
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        "arguments": {
+                                                                          "pairs": [
+                                                                            {
+                                                                              "End": {
+                                                                                "value": {
+                                                                                  "Var": {
+                                                                                    "Name": {
+                                                                                      "leading_trivia": [],
+                                                                                      "token": {
+                                                                                        "start_position": {
+                                                                                          "bytes": 931,
+                                                                                          "character": 34,
+                                                                                          "line": 37
+                                                                                        },
+                                                                                        "end_position": {
+                                                                                          "bytes": 940,
+                                                                                          "character": 43,
+                                                                                          "line": 37
+                                                                                        },
+                                                                                        "token_type": {
+                                                                                          "type": "Identifier",
+                                                                                          "identifier": "character"
+                                                                                        }
+                                                                                      },
+                                                                                      "trailing_trivia": []
+                                                                                    }
+                                                                                  }
                                                                                 }
                                                                               }
-                                                                            ]
-                                                                          }
+                                                                            }
+                                                                          ]
                                                                         }
                                                                       }
                                                                     }
                                                                   }
                                                                 }
-                                                              ]
-                                                            }
-                                                          },
-                                                          "binop": null
+                                                              }
+                                                            ]
+                                                          }
                                                         }
                                                       }
                                                     },
@@ -6227,219 +6198,217 @@
                                                           ]
                                                         },
                                                         "condition": {
-                                                          "value": {
-                                                            "Var": {
-                                                              "Name": {
-                                                                "leading_trivia": [],
-                                                                "token": {
-                                                                  "start_position": {
-                                                                    "bytes": 967,
-                                                                    "character": 11,
-                                                                    "line": 39
-                                                                  },
-                                                                  "end_position": {
-                                                                    "bytes": 970,
-                                                                    "character": 14,
-                                                                    "line": 39
-                                                                  },
-                                                                  "token_type": {
-                                                                    "type": "Identifier",
-                                                                    "identifier": "hit"
-                                                                  }
-                                                                },
-                                                                "trailing_trivia": [
-                                                                  {
+                                                          "lhs": {
+                                                            "value": {
+                                                              "Var": {
+                                                                "Name": {
+                                                                  "leading_trivia": [],
+                                                                  "token": {
                                                                     "start_position": {
+                                                                      "bytes": 967,
+                                                                      "character": 11,
+                                                                      "line": 39
+                                                                    },
+                                                                    "end_position": {
                                                                       "bytes": 970,
                                                                       "character": 14,
                                                                       "line": 39
                                                                     },
-                                                                    "end_position": {
-                                                                      "bytes": 971,
-                                                                      "character": 15,
-                                                                      "line": 39
-                                                                    },
                                                                     "token_type": {
-                                                                      "type": "Whitespace",
-                                                                      "characters": " "
-                                                                    }
-                                                                  }
-                                                                ]
-                                                              }
-                                                            }
-                                                          },
-                                                          "binop": {
-                                                            "bin_op": {
-                                                              "And": {
-                                                                "leading_trivia": [],
-                                                                "token": {
-                                                                  "start_position": {
-                                                                    "bytes": 971,
-                                                                    "character": 15,
-                                                                    "line": 39
-                                                                  },
-                                                                  "end_position": {
-                                                                    "bytes": 974,
-                                                                    "character": 18,
-                                                                    "line": 39
-                                                                  },
-                                                                  "token_type": {
-                                                                    "type": "Symbol",
-                                                                    "symbol": "and"
-                                                                  }
-                                                                },
-                                                                "trailing_trivia": [
-                                                                  {
-                                                                    "start_position": {
-                                                                      "bytes": 974,
-                                                                      "character": 18,
-                                                                      "line": 39
-                                                                    },
-                                                                    "end_position": {
-                                                                      "bytes": 975,
-                                                                      "character": 19,
-                                                                      "line": 39
-                                                                    },
-                                                                    "token_type": {
-                                                                      "type": "Whitespace",
-                                                                      "characters": " "
-                                                                    }
-                                                                  }
-                                                                ]
-                                                              }
-                                                            },
-                                                            "rhs": {
-                                                              "value": {
-                                                                "FunctionCall": {
-                                                                  "prefix": {
-                                                                    "Name": {
-                                                                      "leading_trivia": [],
-                                                                      "token": {
-                                                                        "start_position": {
-                                                                          "bytes": 975,
-                                                                          "character": 19,
-                                                                          "line": 39
-                                                                        },
-                                                                        "end_position": {
-                                                                          "bytes": 983,
-                                                                          "character": 27,
-                                                                          "line": 39
-                                                                        },
-                                                                        "token_type": {
-                                                                          "type": "Identifier",
-                                                                          "identifier": "ignoreIf"
-                                                                        }
-                                                                      },
-                                                                      "trailing_trivia": []
+                                                                      "type": "Identifier",
+                                                                      "identifier": "hit"
                                                                     }
                                                                   },
-                                                                  "suffixes": [
+                                                                  "trailing_trivia": [
                                                                     {
-                                                                      "Call": {
-                                                                        "AnonymousCall": {
-                                                                          "Parentheses": {
-                                                                            "parentheses": {
-                                                                              "tokens": [
-                                                                                {
-                                                                                  "leading_trivia": [],
-                                                                                  "token": {
-                                                                                    "start_position": {
-                                                                                      "bytes": 983,
-                                                                                      "character": 27,
-                                                                                      "line": 39
-                                                                                    },
-                                                                                    "end_position": {
-                                                                                      "bytes": 984,
-                                                                                      "character": 28,
-                                                                                      "line": 39
-                                                                                    },
-                                                                                    "token_type": {
-                                                                                      "type": "Symbol",
-                                                                                      "symbol": "("
-                                                                                    }
-                                                                                  },
-                                                                                  "trailing_trivia": []
-                                                                                },
-                                                                                {
-                                                                                  "leading_trivia": [],
-                                                                                  "token": {
-                                                                                    "start_position": {
-                                                                                      "bytes": 987,
-                                                                                      "character": 31,
-                                                                                      "line": 39
-                                                                                    },
-                                                                                    "end_position": {
-                                                                                      "bytes": 988,
-                                                                                      "character": 32,
-                                                                                      "line": 39
-                                                                                    },
-                                                                                    "token_type": {
-                                                                                      "type": "Symbol",
-                                                                                      "symbol": ")"
-                                                                                    }
-                                                                                  },
-                                                                                  "trailing_trivia": [
-                                                                                    {
-                                                                                      "start_position": {
-                                                                                        "bytes": 988,
-                                                                                        "character": 32,
-                                                                                        "line": 39
-                                                                                      },
-                                                                                      "end_position": {
-                                                                                        "bytes": 989,
-                                                                                        "character": 33,
-                                                                                        "line": 39
-                                                                                      },
-                                                                                      "token_type": {
-                                                                                        "type": "Whitespace",
-                                                                                        "characters": " "
-                                                                                      }
-                                                                                    }
-                                                                                  ]
-                                                                                }
-                                                                              ]
-                                                                            },
-                                                                            "arguments": {
-                                                                              "pairs": [
-                                                                                {
-                                                                                  "End": {
-                                                                                    "value": {
-                                                                                      "Var": {
-                                                                                        "Name": {
-                                                                                          "leading_trivia": [],
-                                                                                          "token": {
-                                                                                            "start_position": {
-                                                                                              "bytes": 984,
-                                                                                              "character": 28,
-                                                                                              "line": 39
-                                                                                            },
-                                                                                            "end_position": {
-                                                                                              "bytes": 987,
-                                                                                              "character": 31,
-                                                                                              "line": 39
-                                                                                            },
-                                                                                            "token_type": {
-                                                                                              "type": "Identifier",
-                                                                                              "identifier": "hit"
-                                                                                            }
-                                                                                          },
-                                                                                          "trailing_trivia": []
-                                                                                        }
-                                                                                      }
-                                                                                    },
-                                                                                    "binop": null
-                                                                                  }
-                                                                                }
-                                                                              ]
-                                                                            }
-                                                                          }
-                                                                        }
+                                                                      "start_position": {
+                                                                        "bytes": 970,
+                                                                        "character": 14,
+                                                                        "line": 39
+                                                                      },
+                                                                      "end_position": {
+                                                                        "bytes": 971,
+                                                                        "character": 15,
+                                                                        "line": 39
+                                                                      },
+                                                                      "token_type": {
+                                                                        "type": "Whitespace",
+                                                                        "characters": " "
                                                                       }
                                                                     }
                                                                   ]
                                                                 }
+                                                              }
+                                                            }
+                                                          },
+                                                          "binop": {
+                                                            "And": {
+                                                              "leading_trivia": [],
+                                                              "token": {
+                                                                "start_position": {
+                                                                  "bytes": 971,
+                                                                  "character": 15,
+                                                                  "line": 39
+                                                                },
+                                                                "end_position": {
+                                                                  "bytes": 974,
+                                                                  "character": 18,
+                                                                  "line": 39
+                                                                },
+                                                                "token_type": {
+                                                                  "type": "Symbol",
+                                                                  "symbol": "and"
+                                                                }
                                                               },
-                                                              "binop": null
+                                                              "trailing_trivia": [
+                                                                {
+                                                                  "start_position": {
+                                                                    "bytes": 974,
+                                                                    "character": 18,
+                                                                    "line": 39
+                                                                  },
+                                                                  "end_position": {
+                                                                    "bytes": 975,
+                                                                    "character": 19,
+                                                                    "line": 39
+                                                                  },
+                                                                  "token_type": {
+                                                                    "type": "Whitespace",
+                                                                    "characters": " "
+                                                                  }
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "rhs": {
+                                                            "value": {
+                                                              "FunctionCall": {
+                                                                "prefix": {
+                                                                  "Name": {
+                                                                    "leading_trivia": [],
+                                                                    "token": {
+                                                                      "start_position": {
+                                                                        "bytes": 975,
+                                                                        "character": 19,
+                                                                        "line": 39
+                                                                      },
+                                                                      "end_position": {
+                                                                        "bytes": 983,
+                                                                        "character": 27,
+                                                                        "line": 39
+                                                                      },
+                                                                      "token_type": {
+                                                                        "type": "Identifier",
+                                                                        "identifier": "ignoreIf"
+                                                                      }
+                                                                    },
+                                                                    "trailing_trivia": []
+                                                                  }
+                                                                },
+                                                                "suffixes": [
+                                                                  {
+                                                                    "Call": {
+                                                                      "AnonymousCall": {
+                                                                        "Parentheses": {
+                                                                          "parentheses": {
+                                                                            "tokens": [
+                                                                              {
+                                                                                "leading_trivia": [],
+                                                                                "token": {
+                                                                                  "start_position": {
+                                                                                    "bytes": 983,
+                                                                                    "character": 27,
+                                                                                    "line": 39
+                                                                                  },
+                                                                                  "end_position": {
+                                                                                    "bytes": 984,
+                                                                                    "character": 28,
+                                                                                    "line": 39
+                                                                                  },
+                                                                                  "token_type": {
+                                                                                    "type": "Symbol",
+                                                                                    "symbol": "("
+                                                                                  }
+                                                                                },
+                                                                                "trailing_trivia": []
+                                                                              },
+                                                                              {
+                                                                                "leading_trivia": [],
+                                                                                "token": {
+                                                                                  "start_position": {
+                                                                                    "bytes": 987,
+                                                                                    "character": 31,
+                                                                                    "line": 39
+                                                                                  },
+                                                                                  "end_position": {
+                                                                                    "bytes": 988,
+                                                                                    "character": 32,
+                                                                                    "line": 39
+                                                                                  },
+                                                                                  "token_type": {
+                                                                                    "type": "Symbol",
+                                                                                    "symbol": ")"
+                                                                                  }
+                                                                                },
+                                                                                "trailing_trivia": [
+                                                                                  {
+                                                                                    "start_position": {
+                                                                                      "bytes": 988,
+                                                                                      "character": 32,
+                                                                                      "line": 39
+                                                                                    },
+                                                                                    "end_position": {
+                                                                                      "bytes": 989,
+                                                                                      "character": 33,
+                                                                                      "line": 39
+                                                                                    },
+                                                                                    "token_type": {
+                                                                                      "type": "Whitespace",
+                                                                                      "characters": " "
+                                                                                    }
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          "arguments": {
+                                                                            "pairs": [
+                                                                              {
+                                                                                "End": {
+                                                                                  "value": {
+                                                                                    "Var": {
+                                                                                      "Name": {
+                                                                                        "leading_trivia": [],
+                                                                                        "token": {
+                                                                                          "start_position": {
+                                                                                            "bytes": 984,
+                                                                                            "character": 28,
+                                                                                            "line": 39
+                                                                                          },
+                                                                                          "end_position": {
+                                                                                            "bytes": 987,
+                                                                                            "character": 31,
+                                                                                            "line": 39
+                                                                                          },
+                                                                                          "token_type": {
+                                                                                            "type": "Identifier",
+                                                                                            "identifier": "hit"
+                                                                                          }
+                                                                                        },
+                                                                                        "trailing_trivia": []
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            ]
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                ]
+                                                              }
                                                             }
                                                           }
                                                         },
@@ -6583,8 +6552,7 @@
                                                                                           },
                                                                                           "trailing_trivia": []
                                                                                         }
-                                                                                      },
-                                                                                      "binop": null
+                                                                                      }
                                                                                     },
                                                                                     {
                                                                                       "leading_trivia": [],
@@ -6751,8 +6719,7 @@
                                                                                           }
                                                                                         ]
                                                                                       }
-                                                                                    },
-                                                                                    "binop": null
+                                                                                    }
                                                                                   }
                                                                                 }
                                                                               ]
@@ -6879,134 +6846,133 @@
                                                                                       ]
                                                                                     },
                                                                                     "expression": {
-                                                                                      "unop": {
-                                                                                        "Hash": {
-                                                                                          "leading_trivia": [],
-                                                                                          "token": {
-                                                                                            "start_position": {
-                                                                                              "bytes": 1056,
-                                                                                              "character": 15,
-                                                                                              "line": 41
-                                                                                            },
-                                                                                            "end_position": {
-                                                                                              "bytes": 1057,
-                                                                                              "character": 16,
-                                                                                              "line": 41
-                                                                                            },
-                                                                                            "token_type": {
-                                                                                              "type": "Symbol",
-                                                                                              "symbol": "#"
-                                                                                            }
-                                                                                          },
-                                                                                          "trailing_trivia": []
-                                                                                        }
-                                                                                      },
-                                                                                      "expression": {
-                                                                                        "value": {
-                                                                                          "Var": {
-                                                                                            "Name": {
-                                                                                              "leading_trivia": [],
-                                                                                              "token": {
-                                                                                                "start_position": {
-                                                                                                  "bytes": 1057,
-                                                                                                  "character": 16,
-                                                                                                  "line": 41
-                                                                                                },
-                                                                                                "end_position": {
-                                                                                                  "bytes": 1066,
-                                                                                                  "character": 25,
-                                                                                                  "line": 41
-                                                                                                },
-                                                                                                "token_type": {
-                                                                                                  "type": "Identifier",
-                                                                                                  "identifier": "blacklist"
-                                                                                                }
+                                                                                      "lhs": {
+                                                                                        "unop": {
+                                                                                          "Hash": {
+                                                                                            "leading_trivia": [],
+                                                                                            "token": {
+                                                                                              "start_position": {
+                                                                                                "bytes": 1056,
+                                                                                                "character": 15,
+                                                                                                "line": 41
                                                                                               },
-                                                                                              "trailing_trivia": [
-                                                                                                {
+                                                                                              "end_position": {
+                                                                                                "bytes": 1057,
+                                                                                                "character": 16,
+                                                                                                "line": 41
+                                                                                              },
+                                                                                              "token_type": {
+                                                                                                "type": "Symbol",
+                                                                                                "symbol": "#"
+                                                                                              }
+                                                                                            },
+                                                                                            "trailing_trivia": []
+                                                                                          }
+                                                                                        },
+                                                                                        "expression": {
+                                                                                          "value": {
+                                                                                            "Var": {
+                                                                                              "Name": {
+                                                                                                "leading_trivia": [],
+                                                                                                "token": {
                                                                                                   "start_position": {
+                                                                                                    "bytes": 1057,
+                                                                                                    "character": 16,
+                                                                                                    "line": 41
+                                                                                                  },
+                                                                                                  "end_position": {
                                                                                                     "bytes": 1066,
                                                                                                     "character": 25,
                                                                                                     "line": 41
                                                                                                   },
-                                                                                                  "end_position": {
-                                                                                                    "bytes": 1067,
-                                                                                                    "character": 26,
-                                                                                                    "line": 41
-                                                                                                  },
                                                                                                   "token_type": {
-                                                                                                    "type": "Whitespace",
-                                                                                                    "characters": " "
+                                                                                                    "type": "Identifier",
+                                                                                                    "identifier": "blacklist"
                                                                                                   }
-                                                                                                }
-                                                                                              ]
+                                                                                                },
+                                                                                                "trailing_trivia": [
+                                                                                                  {
+                                                                                                    "start_position": {
+                                                                                                      "bytes": 1066,
+                                                                                                      "character": 25,
+                                                                                                      "line": 41
+                                                                                                    },
+                                                                                                    "end_position": {
+                                                                                                      "bytes": 1067,
+                                                                                                      "character": 26,
+                                                                                                      "line": 41
+                                                                                                    },
+                                                                                                    "token_type": {
+                                                                                                      "type": "Whitespace",
+                                                                                                      "characters": " "
+                                                                                                    }
+                                                                                                  }
+                                                                                                ]
+                                                                                              }
                                                                                             }
                                                                                           }
-                                                                                        },
-                                                                                        "binop": {
-                                                                                          "bin_op": {
-                                                                                            "Plus": {
-                                                                                              "leading_trivia": [],
-                                                                                              "token": {
-                                                                                                "start_position": {
-                                                                                                  "bytes": 1067,
-                                                                                                  "character": 26,
-                                                                                                  "line": 41
-                                                                                                },
-                                                                                                "end_position": {
-                                                                                                  "bytes": 1068,
-                                                                                                  "character": 27,
-                                                                                                  "line": 41
-                                                                                                },
-                                                                                                "token_type": {
-                                                                                                  "type": "Symbol",
-                                                                                                  "symbol": "+"
-                                                                                                }
-                                                                                              },
-                                                                                              "trailing_trivia": [
-                                                                                                {
-                                                                                                  "start_position": {
-                                                                                                    "bytes": 1068,
-                                                                                                    "character": 27,
-                                                                                                    "line": 41
-                                                                                                  },
-                                                                                                  "end_position": {
-                                                                                                    "bytes": 1069,
-                                                                                                    "character": 28,
-                                                                                                    "line": 41
-                                                                                                  },
-                                                                                                  "token_type": {
-                                                                                                    "type": "Whitespace",
-                                                                                                    "characters": " "
-                                                                                                  }
-                                                                                                }
-                                                                                              ]
+                                                                                        }
+                                                                                      },
+                                                                                      "binop": {
+                                                                                        "Plus": {
+                                                                                          "leading_trivia": [],
+                                                                                          "token": {
+                                                                                            "start_position": {
+                                                                                              "bytes": 1067,
+                                                                                              "character": 26,
+                                                                                              "line": 41
+                                                                                            },
+                                                                                            "end_position": {
+                                                                                              "bytes": 1068,
+                                                                                              "character": 27,
+                                                                                              "line": 41
+                                                                                            },
+                                                                                            "token_type": {
+                                                                                              "type": "Symbol",
+                                                                                              "symbol": "+"
                                                                                             }
                                                                                           },
-                                                                                          "rhs": {
-                                                                                            "value": {
-                                                                                              "Number": {
-                                                                                                "leading_trivia": [],
-                                                                                                "token": {
-                                                                                                  "start_position": {
-                                                                                                    "bytes": 1069,
-                                                                                                    "character": 28,
-                                                                                                    "line": 41
-                                                                                                  },
-                                                                                                  "end_position": {
-                                                                                                    "bytes": 1070,
-                                                                                                    "character": 29,
-                                                                                                    "line": 41
-                                                                                                  },
-                                                                                                  "token_type": {
-                                                                                                    "type": "Number",
-                                                                                                    "text": "1"
-                                                                                                  }
-                                                                                                },
-                                                                                                "trailing_trivia": []
+                                                                                          "trailing_trivia": [
+                                                                                            {
+                                                                                              "start_position": {
+                                                                                                "bytes": 1068,
+                                                                                                "character": 27,
+                                                                                                "line": 41
+                                                                                              },
+                                                                                              "end_position": {
+                                                                                                "bytes": 1069,
+                                                                                                "character": 28,
+                                                                                                "line": 41
+                                                                                              },
+                                                                                              "token_type": {
+                                                                                                "type": "Whitespace",
+                                                                                                "characters": " "
+                                                                                              }
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      },
+                                                                                      "rhs": {
+                                                                                        "value": {
+                                                                                          "Number": {
+                                                                                            "leading_trivia": [],
+                                                                                            "token": {
+                                                                                              "start_position": {
+                                                                                                "bytes": 1069,
+                                                                                                "character": 28,
+                                                                                                "line": 41
+                                                                                              },
+                                                                                              "end_position": {
+                                                                                                "bytes": 1070,
+                                                                                                "character": 29,
+                                                                                                "line": 41
+                                                                                              },
+                                                                                              "token_type": {
+                                                                                                "type": "Number",
+                                                                                                "text": "1"
                                                                                               }
                                                                                             },
-                                                                                            "binop": null
+                                                                                            "trailing_trivia": []
                                                                                           }
                                                                                         }
                                                                                       }
@@ -7084,8 +7050,7 @@
                                                                                 "trailing_trivia": []
                                                                               }
                                                                             }
-                                                                          },
-                                                                          "binop": null
+                                                                          }
                                                                         }
                                                                       }
                                                                     ]
@@ -7441,8 +7406,7 @@
                                                         },
                                                         "trailing_trivia": []
                                                       }
-                                                    },
-                                                    "binop": null
+                                                    }
                                                   },
                                                   {
                                                     "leading_trivia": [],
@@ -7485,214 +7449,213 @@
                                               },
                                               {
                                                 "End": {
-                                                  "value": {
-                                                    "Var": {
-                                                      "Name": {
-                                                        "leading_trivia": [],
-                                                        "token": {
-                                                          "start_position": {
-                                                            "bytes": 1136,
-                                                            "character": 22,
-                                                            "line": 48
-                                                          },
-                                                          "end_position": {
-                                                            "bytes": 1139,
-                                                            "character": 25,
-                                                            "line": 48
-                                                          },
-                                                          "token_type": {
-                                                            "type": "Identifier",
-                                                            "identifier": "hit"
-                                                          }
-                                                        },
-                                                        "trailing_trivia": [
-                                                          {
+                                                  "lhs": {
+                                                    "value": {
+                                                      "Var": {
+                                                        "Name": {
+                                                          "leading_trivia": [],
+                                                          "token": {
                                                             "start_position": {
+                                                              "bytes": 1136,
+                                                              "character": 22,
+                                                              "line": 48
+                                                            },
+                                                            "end_position": {
                                                               "bytes": 1139,
                                                               "character": 25,
                                                               "line": 48
                                                             },
-                                                            "end_position": {
-                                                              "bytes": 1140,
-                                                              "character": 26,
-                                                              "line": 48
-                                                            },
                                                             "token_type": {
-                                                              "type": "Whitespace",
-                                                              "characters": " "
+                                                              "type": "Identifier",
+                                                              "identifier": "hit"
                                                             }
-                                                          }
-                                                        ]
+                                                          },
+                                                          "trailing_trivia": [
+                                                            {
+                                                              "start_position": {
+                                                                "bytes": 1139,
+                                                                "character": 25,
+                                                                "line": 48
+                                                              },
+                                                              "end_position": {
+                                                                "bytes": 1140,
+                                                                "character": 26,
+                                                                "line": 48
+                                                              },
+                                                              "token_type": {
+                                                                "type": "Whitespace",
+                                                                "characters": " "
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
                                                       }
                                                     }
                                                   },
                                                   "binop": {
-                                                    "bin_op": {
-                                                      "And": {
-                                                        "leading_trivia": [],
-                                                        "token": {
+                                                    "And": {
+                                                      "leading_trivia": [],
+                                                      "token": {
+                                                        "start_position": {
+                                                          "bytes": 1140,
+                                                          "character": 26,
+                                                          "line": 48
+                                                        },
+                                                        "end_position": {
+                                                          "bytes": 1143,
+                                                          "character": 29,
+                                                          "line": 48
+                                                        },
+                                                        "token_type": {
+                                                          "type": "Symbol",
+                                                          "symbol": "and"
+                                                        }
+                                                      },
+                                                      "trailing_trivia": [
+                                                        {
                                                           "start_position": {
-                                                            "bytes": 1140,
-                                                            "character": 26,
-                                                            "line": 48
-                                                          },
-                                                          "end_position": {
                                                             "bytes": 1143,
                                                             "character": 29,
                                                             "line": 48
                                                           },
+                                                          "end_position": {
+                                                            "bytes": 1144,
+                                                            "character": 30,
+                                                            "line": 48
+                                                          },
                                                           "token_type": {
-                                                            "type": "Symbol",
-                                                            "symbol": "and"
+                                                            "type": "Whitespace",
+                                                            "characters": " "
+                                                          }
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "rhs": {
+                                                    "value": {
+                                                      "FunctionCall": {
+                                                        "prefix": {
+                                                          "Name": {
+                                                            "leading_trivia": [],
+                                                            "token": {
+                                                              "start_position": {
+                                                                "bytes": 1144,
+                                                                "character": 30,
+                                                                "line": 48
+                                                              },
+                                                              "end_position": {
+                                                                "bytes": 1147,
+                                                                "character": 33,
+                                                                "line": 48
+                                                              },
+                                                              "token_type": {
+                                                                "type": "Identifier",
+                                                                "identifier": "hit"
+                                                              }
+                                                            },
+                                                            "trailing_trivia": []
                                                           }
                                                         },
-                                                        "trailing_trivia": [
+                                                        "suffixes": [
                                                           {
-                                                            "start_position": {
-                                                              "bytes": 1143,
-                                                              "character": 29,
-                                                              "line": 48
-                                                            },
-                                                            "end_position": {
-                                                              "bytes": 1144,
-                                                              "character": 30,
-                                                              "line": 48
-                                                            },
-                                                            "token_type": {
-                                                              "type": "Whitespace",
-                                                              "characters": " "
-                                                            }
-                                                          }
-                                                        ]
-                                                      }
-                                                    },
-                                                    "rhs": {
-                                                      "value": {
-                                                        "FunctionCall": {
-                                                          "prefix": {
-                                                            "Name": {
-                                                              "leading_trivia": [],
-                                                              "token": {
-                                                                "start_position": {
-                                                                  "bytes": 1144,
-                                                                  "character": 30,
-                                                                  "line": 48
-                                                                },
-                                                                "end_position": {
-                                                                  "bytes": 1147,
-                                                                  "character": 33,
-                                                                  "line": 48
-                                                                },
-                                                                "token_type": {
-                                                                  "type": "Identifier",
-                                                                  "identifier": "hit"
-                                                                }
-                                                              },
-                                                              "trailing_trivia": []
-                                                            }
-                                                          },
-                                                          "suffixes": [
-                                                            {
-                                                              "Call": {
-                                                                "MethodCall": {
-                                                                  "colon_token": {
-                                                                    "leading_trivia": [],
-                                                                    "token": {
-                                                                      "start_position": {
-                                                                        "bytes": 1147,
-                                                                        "character": 33,
-                                                                        "line": 48
-                                                                      },
-                                                                      "end_position": {
-                                                                        "bytes": 1148,
-                                                                        "character": 34,
-                                                                        "line": 48
-                                                                      },
-                                                                      "token_type": {
-                                                                        "type": "Symbol",
-                                                                        "symbol": ":"
-                                                                      }
+                                                            "Call": {
+                                                              "MethodCall": {
+                                                                "colon_token": {
+                                                                  "leading_trivia": [],
+                                                                  "token": {
+                                                                    "start_position": {
+                                                                      "bytes": 1147,
+                                                                      "character": 33,
+                                                                      "line": 48
                                                                     },
-                                                                    "trailing_trivia": []
-                                                                  },
-                                                                  "name": {
-                                                                    "leading_trivia": [],
-                                                                    "token": {
-                                                                      "start_position": {
-                                                                        "bytes": 1148,
-                                                                        "character": 34,
-                                                                        "line": 48
-                                                                      },
-                                                                      "end_position": {
-                                                                        "bytes": 1159,
-                                                                        "character": 45,
-                                                                        "line": 48
-                                                                      },
-                                                                      "token_type": {
-                                                                        "type": "Identifier",
-                                                                        "identifier": "GetFullName"
-                                                                      }
+                                                                    "end_position": {
+                                                                      "bytes": 1148,
+                                                                      "character": 34,
+                                                                      "line": 48
                                                                     },
-                                                                    "trailing_trivia": []
+                                                                    "token_type": {
+                                                                      "type": "Symbol",
+                                                                      "symbol": ":"
+                                                                    }
                                                                   },
-                                                                  "args": {
-                                                                    "Parentheses": {
-                                                                      "parentheses": {
-                                                                        "tokens": [
-                                                                          {
-                                                                            "leading_trivia": [],
-                                                                            "token": {
-                                                                              "start_position": {
-                                                                                "bytes": 1159,
-                                                                                "character": 45,
-                                                                                "line": 48
-                                                                              },
-                                                                              "end_position": {
-                                                                                "bytes": 1160,
-                                                                                "character": 46,
-                                                                                "line": 48
-                                                                              },
-                                                                              "token_type": {
-                                                                                "type": "Symbol",
-                                                                                "symbol": "("
-                                                                              }
+                                                                  "trailing_trivia": []
+                                                                },
+                                                                "name": {
+                                                                  "leading_trivia": [],
+                                                                  "token": {
+                                                                    "start_position": {
+                                                                      "bytes": 1148,
+                                                                      "character": 34,
+                                                                      "line": 48
+                                                                    },
+                                                                    "end_position": {
+                                                                      "bytes": 1159,
+                                                                      "character": 45,
+                                                                      "line": 48
+                                                                    },
+                                                                    "token_type": {
+                                                                      "type": "Identifier",
+                                                                      "identifier": "GetFullName"
+                                                                    }
+                                                                  },
+                                                                  "trailing_trivia": []
+                                                                },
+                                                                "args": {
+                                                                  "Parentheses": {
+                                                                    "parentheses": {
+                                                                      "tokens": [
+                                                                        {
+                                                                          "leading_trivia": [],
+                                                                          "token": {
+                                                                            "start_position": {
+                                                                              "bytes": 1159,
+                                                                              "character": 45,
+                                                                              "line": 48
                                                                             },
-                                                                            "trailing_trivia": []
+                                                                            "end_position": {
+                                                                              "bytes": 1160,
+                                                                              "character": 46,
+                                                                              "line": 48
+                                                                            },
+                                                                            "token_type": {
+                                                                              "type": "Symbol",
+                                                                              "symbol": "("
+                                                                            }
                                                                           },
-                                                                          {
-                                                                            "leading_trivia": [],
-                                                                            "token": {
-                                                                              "start_position": {
-                                                                                "bytes": 1160,
-                                                                                "character": 46,
-                                                                                "line": 48
-                                                                              },
-                                                                              "end_position": {
-                                                                                "bytes": 1161,
-                                                                                "character": 47,
-                                                                                "line": 48
-                                                                              },
-                                                                              "token_type": {
-                                                                                "type": "Symbol",
-                                                                                "symbol": ")"
-                                                                              }
+                                                                          "trailing_trivia": []
+                                                                        },
+                                                                        {
+                                                                          "leading_trivia": [],
+                                                                          "token": {
+                                                                            "start_position": {
+                                                                              "bytes": 1160,
+                                                                              "character": 46,
+                                                                              "line": 48
                                                                             },
-                                                                            "trailing_trivia": []
-                                                                          }
-                                                                        ]
-                                                                      },
-                                                                      "arguments": {
-                                                                        "pairs": []
-                                                                      }
+                                                                            "end_position": {
+                                                                              "bytes": 1161,
+                                                                              "character": 47,
+                                                                              "line": 48
+                                                                            },
+                                                                            "token_type": {
+                                                                              "type": "Symbol",
+                                                                              "symbol": ")"
+                                                                            }
+                                                                          },
+                                                                          "trailing_trivia": []
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    "arguments": {
+                                                                      "pairs": []
                                                                     }
                                                                   }
                                                                 }
                                                               }
                                                             }
-                                                          ]
-                                                        }
-                                                      },
-                                                      "binop": null
+                                                          }
+                                                        ]
+                                                      }
                                                     }
                                                   }
                                                 }
@@ -7787,244 +7750,242 @@
                                   {
                                     "Punctuated": [
                                       {
-                                        "value": {
-                                          "Var": {
-                                            "Name": {
-                                              "leading_trivia": [],
-                                              "token": {
-                                                "start_position": {
-                                                  "bytes": 1172,
-                                                  "character": 9,
-                                                  "line": 50
-                                                },
-                                                "end_position": {
-                                                  "bytes": 1175,
-                                                  "character": 12,
-                                                  "line": 50
-                                                },
-                                                "token_type": {
-                                                  "type": "Identifier",
-                                                  "identifier": "hit"
-                                                }
-                                              },
-                                              "trailing_trivia": [
-                                                {
+                                        "lhs": {
+                                          "value": {
+                                            "Var": {
+                                              "Name": {
+                                                "leading_trivia": [],
+                                                "token": {
                                                   "start_position": {
+                                                    "bytes": 1172,
+                                                    "character": 9,
+                                                    "line": 50
+                                                  },
+                                                  "end_position": {
                                                     "bytes": 1175,
                                                     "character": 12,
                                                     "line": 50
                                                   },
-                                                  "end_position": {
-                                                    "bytes": 1176,
-                                                    "character": 13,
-                                                    "line": 50
-                                                  },
                                                   "token_type": {
-                                                    "type": "Whitespace",
-                                                    "characters": " "
+                                                    "type": "Identifier",
+                                                    "identifier": "hit"
                                                   }
-                                                }
-                                              ]
+                                                },
+                                                "trailing_trivia": [
+                                                  {
+                                                    "start_position": {
+                                                      "bytes": 1175,
+                                                      "character": 12,
+                                                      "line": 50
+                                                    },
+                                                    "end_position": {
+                                                      "bytes": 1176,
+                                                      "character": 13,
+                                                      "line": 50
+                                                    },
+                                                    "token_type": {
+                                                      "type": "Whitespace",
+                                                      "characters": " "
+                                                    }
+                                                  }
+                                                ]
+                                              }
                                             }
                                           }
                                         },
                                         "binop": {
-                                          "bin_op": {
-                                            "And": {
-                                              "leading_trivia": [],
-                                              "token": {
+                                          "And": {
+                                            "leading_trivia": [],
+                                            "token": {
+                                              "start_position": {
+                                                "bytes": 1176,
+                                                "character": 13,
+                                                "line": 50
+                                              },
+                                              "end_position": {
+                                                "bytes": 1179,
+                                                "character": 16,
+                                                "line": 50
+                                              },
+                                              "token_type": {
+                                                "type": "Symbol",
+                                                "symbol": "and"
+                                              }
+                                            },
+                                            "trailing_trivia": [
+                                              {
                                                 "start_position": {
-                                                  "bytes": 1176,
-                                                  "character": 13,
-                                                  "line": 50
-                                                },
-                                                "end_position": {
                                                   "bytes": 1179,
                                                   "character": 16,
                                                   "line": 50
                                                 },
+                                                "end_position": {
+                                                  "bytes": 1180,
+                                                  "character": 17,
+                                                  "line": 50
+                                                },
                                                 "token_type": {
-                                                  "type": "Symbol",
-                                                  "symbol": "and"
+                                                  "type": "Whitespace",
+                                                  "characters": " "
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "rhs": {
+                                          "value": {
+                                            "FunctionCall": {
+                                              "prefix": {
+                                                "Name": {
+                                                  "leading_trivia": [],
+                                                  "token": {
+                                                    "start_position": {
+                                                      "bytes": 1180,
+                                                      "character": 17,
+                                                      "line": 50
+                                                    },
+                                                    "end_position": {
+                                                      "bytes": 1183,
+                                                      "character": 20,
+                                                      "line": 50
+                                                    },
+                                                    "token_type": {
+                                                      "type": "Identifier",
+                                                      "identifier": "hit"
+                                                    }
+                                                  },
+                                                  "trailing_trivia": []
                                                 }
                                               },
-                                              "trailing_trivia": [
+                                              "suffixes": [
                                                 {
-                                                  "start_position": {
-                                                    "bytes": 1179,
-                                                    "character": 16,
-                                                    "line": 50
-                                                  },
-                                                  "end_position": {
-                                                    "bytes": 1180,
-                                                    "character": 17,
-                                                    "line": 50
-                                                  },
-                                                  "token_type": {
-                                                    "type": "Whitespace",
-                                                    "characters": " "
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          },
-                                          "rhs": {
-                                            "value": {
-                                              "FunctionCall": {
-                                                "prefix": {
-                                                  "Name": {
-                                                    "leading_trivia": [],
-                                                    "token": {
-                                                      "start_position": {
-                                                        "bytes": 1180,
-                                                        "character": 17,
-                                                        "line": 50
-                                                      },
-                                                      "end_position": {
-                                                        "bytes": 1183,
-                                                        "character": 20,
-                                                        "line": 50
-                                                      },
-                                                      "token_type": {
-                                                        "type": "Identifier",
-                                                        "identifier": "hit"
-                                                      }
-                                                    },
-                                                    "trailing_trivia": []
-                                                  }
-                                                },
-                                                "suffixes": [
-                                                  {
-                                                    "Call": {
-                                                      "MethodCall": {
-                                                        "colon_token": {
-                                                          "leading_trivia": [],
-                                                          "token": {
-                                                            "start_position": {
-                                                              "bytes": 1183,
-                                                              "character": 20,
-                                                              "line": 50
-                                                            },
-                                                            "end_position": {
-                                                              "bytes": 1184,
-                                                              "character": 21,
-                                                              "line": 50
-                                                            },
-                                                            "token_type": {
-                                                              "type": "Symbol",
-                                                              "symbol": ":"
-                                                            }
+                                                  "Call": {
+                                                    "MethodCall": {
+                                                      "colon_token": {
+                                                        "leading_trivia": [],
+                                                        "token": {
+                                                          "start_position": {
+                                                            "bytes": 1183,
+                                                            "character": 20,
+                                                            "line": 50
                                                           },
-                                                          "trailing_trivia": []
-                                                        },
-                                                        "name": {
-                                                          "leading_trivia": [],
-                                                          "token": {
-                                                            "start_position": {
-                                                              "bytes": 1184,
-                                                              "character": 21,
-                                                              "line": 50
-                                                            },
-                                                            "end_position": {
-                                                              "bytes": 1198,
-                                                              "character": 35,
-                                                              "line": 50
-                                                            },
-                                                            "token_type": {
-                                                              "type": "Identifier",
-                                                              "identifier": "IsDescendantOf"
-                                                            }
+                                                          "end_position": {
+                                                            "bytes": 1184,
+                                                            "character": 21,
+                                                            "line": 50
                                                           },
-                                                          "trailing_trivia": []
+                                                          "token_type": {
+                                                            "type": "Symbol",
+                                                            "symbol": ":"
+                                                          }
                                                         },
-                                                        "args": {
-                                                          "Parentheses": {
-                                                            "parentheses": {
-                                                              "tokens": [
-                                                                {
-                                                                  "leading_trivia": [],
-                                                                  "token": {
-                                                                    "start_position": {
-                                                                      "bytes": 1198,
-                                                                      "character": 35,
-                                                                      "line": 50
-                                                                    },
-                                                                    "end_position": {
-                                                                      "bytes": 1199,
-                                                                      "character": 36,
-                                                                      "line": 50
-                                                                    },
-                                                                    "token_type": {
-                                                                      "type": "Symbol",
-                                                                      "symbol": "("
-                                                                    }
+                                                        "trailing_trivia": []
+                                                      },
+                                                      "name": {
+                                                        "leading_trivia": [],
+                                                        "token": {
+                                                          "start_position": {
+                                                            "bytes": 1184,
+                                                            "character": 21,
+                                                            "line": 50
+                                                          },
+                                                          "end_position": {
+                                                            "bytes": 1198,
+                                                            "character": 35,
+                                                            "line": 50
+                                                          },
+                                                          "token_type": {
+                                                            "type": "Identifier",
+                                                            "identifier": "IsDescendantOf"
+                                                          }
+                                                        },
+                                                        "trailing_trivia": []
+                                                      },
+                                                      "args": {
+                                                        "Parentheses": {
+                                                          "parentheses": {
+                                                            "tokens": [
+                                                              {
+                                                                "leading_trivia": [],
+                                                                "token": {
+                                                                  "start_position": {
+                                                                    "bytes": 1198,
+                                                                    "character": 35,
+                                                                    "line": 50
                                                                   },
-                                                                  "trailing_trivia": []
+                                                                  "end_position": {
+                                                                    "bytes": 1199,
+                                                                    "character": 36,
+                                                                    "line": 50
+                                                                  },
+                                                                  "token_type": {
+                                                                    "type": "Symbol",
+                                                                    "symbol": "("
+                                                                  }
                                                                 },
-                                                                {
-                                                                  "leading_trivia": [],
-                                                                  "token": {
-                                                                    "start_position": {
-                                                                      "bytes": 1208,
-                                                                      "character": 45,
-                                                                      "line": 50
-                                                                    },
-                                                                    "end_position": {
-                                                                      "bytes": 1209,
-                                                                      "character": 46,
-                                                                      "line": 50
-                                                                    },
-                                                                    "token_type": {
-                                                                      "type": "Symbol",
-                                                                      "symbol": ")"
-                                                                    }
+                                                                "trailing_trivia": []
+                                                              },
+                                                              {
+                                                                "leading_trivia": [],
+                                                                "token": {
+                                                                  "start_position": {
+                                                                    "bytes": 1208,
+                                                                    "character": 45,
+                                                                    "line": 50
                                                                   },
-                                                                  "trailing_trivia": []
-                                                                }
-                                                              ]
-                                                            },
-                                                            "arguments": {
-                                                              "pairs": [
-                                                                {
-                                                                  "End": {
-                                                                    "value": {
-                                                                      "Var": {
-                                                                        "Name": {
-                                                                          "leading_trivia": [],
-                                                                          "token": {
-                                                                            "start_position": {
-                                                                              "bytes": 1199,
-                                                                              "character": 36,
-                                                                              "line": 50
-                                                                            },
-                                                                            "end_position": {
-                                                                              "bytes": 1208,
-                                                                              "character": 45,
-                                                                              "line": 50
-                                                                            },
-                                                                            "token_type": {
-                                                                              "type": "Identifier",
-                                                                              "identifier": "character"
-                                                                            }
+                                                                  "end_position": {
+                                                                    "bytes": 1209,
+                                                                    "character": 46,
+                                                                    "line": 50
+                                                                  },
+                                                                  "token_type": {
+                                                                    "type": "Symbol",
+                                                                    "symbol": ")"
+                                                                  }
+                                                                },
+                                                                "trailing_trivia": []
+                                                              }
+                                                            ]
+                                                          },
+                                                          "arguments": {
+                                                            "pairs": [
+                                                              {
+                                                                "End": {
+                                                                  "value": {
+                                                                    "Var": {
+                                                                      "Name": {
+                                                                        "leading_trivia": [],
+                                                                        "token": {
+                                                                          "start_position": {
+                                                                            "bytes": 1199,
+                                                                            "character": 36,
+                                                                            "line": 50
                                                                           },
-                                                                          "trailing_trivia": []
-                                                                        }
+                                                                          "end_position": {
+                                                                            "bytes": 1208,
+                                                                            "character": 45,
+                                                                            "line": 50
+                                                                          },
+                                                                          "token_type": {
+                                                                            "type": "Identifier",
+                                                                            "identifier": "character"
+                                                                          }
+                                                                        },
+                                                                        "trailing_trivia": []
                                                                       }
-                                                                    },
-                                                                    "binop": null
+                                                                    }
                                                                   }
                                                                 }
-                                                              ]
-                                                            }
+                                                              }
+                                                            ]
                                                           }
                                                         }
                                                       }
                                                     }
                                                   }
-                                                ]
-                                              }
-                                            },
-                                            "binop": null
+                                                }
+                                              ]
+                                            }
                                           }
                                         }
                                       },
@@ -8092,8 +8053,7 @@
                                             "trailing_trivia": []
                                           }
                                         }
-                                      },
-                                      "binop": null
+                                      }
                                     }
                                   }
                                 ]
@@ -8142,8 +8102,7 @@
                       }
                     }
                   ]
-                },
-                "binop": null
+                }
               }
             }
           ]

--- a/full-moon/tests/roblox_cases/pass/types/ast.json
+++ b/full-moon/tests/roblox_cases/pass/types/ast.json
@@ -1268,47 +1268,49 @@
                 ]
               },
               "inner": {
-                "value": {
-                  "Number": {
-                    "leading_trivia": [],
-                    "token": {
-                      "start_position": {
-                        "bytes": 118,
-                        "character": 22,
-                        "line": 4
-                      },
-                      "end_position": {
-                        "bytes": 119,
-                        "character": 23,
-                        "line": 4
-                      },
-                      "token_type": {
-                        "type": "Number",
-                        "text": "2"
-                      }
-                    },
-                    "trailing_trivia": [
-                      {
-                        "start_position": {
-                          "bytes": 119,
-                          "character": 23,
-                          "line": 4
+                "lhs": {
+                  "lhs": {
+                    "value": {
+                      "Number": {
+                        "leading_trivia": [],
+                        "token": {
+                          "start_position": {
+                            "bytes": 118,
+                            "character": 22,
+                            "line": 4
+                          },
+                          "end_position": {
+                            "bytes": 119,
+                            "character": 23,
+                            "line": 4
+                          },
+                          "token_type": {
+                            "type": "Number",
+                            "text": "2"
+                          }
                         },
-                        "end_position": {
-                          "bytes": 120,
-                          "character": 24,
-                          "line": 4
-                        },
-                        "token_type": {
-                          "type": "Whitespace",
-                          "characters": " "
-                        }
+                        "trailing_trivia": [
+                          {
+                            "start_position": {
+                              "bytes": 119,
+                              "character": 23,
+                              "line": 4
+                            },
+                            "end_position": {
+                              "bytes": 120,
+                              "character": 24,
+                              "line": 4
+                            },
+                            "token_type": {
+                              "type": "Whitespace",
+                              "characters": " "
+                            }
+                          }
+                        ]
                       }
-                    ]
-                  }
-                },
-                "binop": {
-                  "bin_op": {
+                    }
+                  },
+                  "binop": {
                     "Plus": {
                       "leading_trivia": [],
                       "token": {
@@ -1386,133 +1388,130 @@
                           }
                         ]
                       }
+                    }
+                  }
+                },
+                "binop": {
+                  "Plus": {
+                    "leading_trivia": [],
+                    "token": {
+                      "start_position": {
+                        "bytes": 124,
+                        "character": 28,
+                        "line": 4
+                      },
+                      "end_position": {
+                        "bytes": 125,
+                        "character": 29,
+                        "line": 4
+                      },
+                      "token_type": {
+                        "type": "Symbol",
+                        "symbol": "+"
+                      }
                     },
-                    "binop": {
-                      "bin_op": {
-                        "Plus": {
+                    "trailing_trivia": [
+                      {
+                        "start_position": {
+                          "bytes": 125,
+                          "character": 29,
+                          "line": 4
+                        },
+                        "end_position": {
+                          "bytes": 126,
+                          "character": 30,
+                          "line": 4
+                        },
+                        "token_type": {
+                          "type": "Whitespace",
+                          "characters": " "
+                        }
+                      }
+                    ]
+                  }
+                },
+                "rhs": {
+                  "value": {
+                    "FunctionCall": {
+                      "prefix": {
+                        "Name": {
                           "leading_trivia": [],
                           "token": {
                             "start_position": {
-                              "bytes": 124,
-                              "character": 28,
+                              "bytes": 126,
+                              "character": 30,
                               "line": 4
                             },
                             "end_position": {
-                              "bytes": 125,
-                              "character": 29,
+                              "bytes": 129,
+                              "character": 33,
                               "line": 4
                             },
                             "token_type": {
-                              "type": "Symbol",
-                              "symbol": "+"
+                              "type": "Identifier",
+                              "identifier": "foo"
                             }
                           },
-                          "trailing_trivia": [
-                            {
-                              "start_position": {
-                                "bytes": 125,
-                                "character": 29,
-                                "line": 4
-                              },
-                              "end_position": {
-                                "bytes": 126,
-                                "character": 30,
-                                "line": 4
-                              },
-                              "token_type": {
-                                "type": "Whitespace",
-                                "characters": " "
-                              }
-                            }
-                          ]
+                          "trailing_trivia": []
                         }
                       },
-                      "rhs": {
-                        "value": {
-                          "FunctionCall": {
-                            "prefix": {
-                              "Name": {
-                                "leading_trivia": [],
-                                "token": {
-                                  "start_position": {
-                                    "bytes": 126,
-                                    "character": 30,
-                                    "line": 4
-                                  },
-                                  "end_position": {
-                                    "bytes": 129,
-                                    "character": 33,
-                                    "line": 4
-                                  },
-                                  "token_type": {
-                                    "type": "Identifier",
-                                    "identifier": "foo"
-                                  }
-                                },
-                                "trailing_trivia": []
-                              }
-                            },
-                            "suffixes": [
-                              {
-                                "Call": {
-                                  "AnonymousCall": {
-                                    "Parentheses": {
-                                      "parentheses": {
-                                        "tokens": [
-                                          {
-                                            "leading_trivia": [],
-                                            "token": {
-                                              "start_position": {
-                                                "bytes": 129,
-                                                "character": 33,
-                                                "line": 4
-                                              },
-                                              "end_position": {
-                                                "bytes": 130,
-                                                "character": 34,
-                                                "line": 4
-                                              },
-                                              "token_type": {
-                                                "type": "Symbol",
-                                                "symbol": "("
-                                              }
-                                            },
-                                            "trailing_trivia": []
-                                          },
-                                          {
-                                            "leading_trivia": [],
-                                            "token": {
-                                              "start_position": {
-                                                "bytes": 130,
-                                                "character": 34,
-                                                "line": 4
-                                              },
-                                              "end_position": {
-                                                "bytes": 131,
-                                                "character": 35,
-                                                "line": 4
-                                              },
-                                              "token_type": {
-                                                "type": "Symbol",
-                                                "symbol": ")"
-                                              }
-                                            },
-                                            "trailing_trivia": []
-                                          }
-                                        ]
+                      "suffixes": [
+                        {
+                          "Call": {
+                            "AnonymousCall": {
+                              "Parentheses": {
+                                "parentheses": {
+                                  "tokens": [
+                                    {
+                                      "leading_trivia": [],
+                                      "token": {
+                                        "start_position": {
+                                          "bytes": 129,
+                                          "character": 33,
+                                          "line": 4
+                                        },
+                                        "end_position": {
+                                          "bytes": 130,
+                                          "character": 34,
+                                          "line": 4
+                                        },
+                                        "token_type": {
+                                          "type": "Symbol",
+                                          "symbol": "("
+                                        }
                                       },
-                                      "arguments": {
-                                        "pairs": []
-                                      }
+                                      "trailing_trivia": []
+                                    },
+                                    {
+                                      "leading_trivia": [],
+                                      "token": {
+                                        "start_position": {
+                                          "bytes": 130,
+                                          "character": 34,
+                                          "line": 4
+                                        },
+                                        "end_position": {
+                                          "bytes": 131,
+                                          "character": 35,
+                                          "line": 4
+                                        },
+                                        "token_type": {
+                                          "type": "Symbol",
+                                          "symbol": ")"
+                                        }
+                                      },
+                                      "trailing_trivia": []
                                     }
-                                  }
+                                  ]
+                                },
+                                "arguments": {
+                                  "pairs": []
                                 }
                               }
-                            ]
+                            }
                           }
-                        },
-                        "binop": null
-                      }
+                        }
+                      ]
                     }
                   }
                 }
@@ -3803,8 +3802,7 @@
                       },
                       "trailing_trivia": []
                     }
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]
@@ -4695,7 +4693,6 @@
                       }
                     }
                   },
-                  "binop": null,
                   "as_assertion": {
                     "as_token": {
                       "leading_trivia": [],
@@ -6571,8 +6568,7 @@
                                   "trailing_trivia": []
                                 }
                               }
-                            },
-                            "binop": null
+                            }
                           }
                         }
                       ]
@@ -7567,8 +7563,7 @@
                                             },
                                             "trailing_trivia": []
                                           }
-                                        },
-                                        "binop": null
+                                        }
                                       }
                                     }
                                   ]
@@ -7617,8 +7612,7 @@
                         }
                       }
                     ]
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]
@@ -8100,8 +8094,7 @@
                                             },
                                             "trailing_trivia": []
                                           }
-                                        },
-                                        "binop": null
+                                        }
                                       }
                                     }
                                   ]
@@ -8150,8 +8143,7 @@
                         }
                       }
                     ]
-                  },
-                  "binop": null
+                  }
                 }
               }
             ]


### PR DESCRIPTION
This PR modifies the way binary operators are parsed and handled in the AST.
Previously, binary operators were handled using `BinOpRhs` and a `binop` member in `Expression::Value{}`. This did not have support for precedence.
This PR is a **breaking change**

Changes made:
- Added a new struct enum `Expression::BinaryOperator { lhs, binop, rhs }`. The `binop` member from `Expression::Value` has been removed.
- Removed the `BinOpRhs` struct
- Added a new method `operator.precedence()` available on `BinOp` and `UnOp` - this returns the precedence value for that operator, on a scale of 1 to 8, where 8 is the highest precedence
- Added a new method `binop.is_right_associative()` to determine if a BinOp is right associative
- ~~Removed `Value::ParseExpression` as it is no longer required. This was used when we had a LHS of a binop that was contained within parentheses. This is no longer required, as it is now part of `lhs` in `Expression::BinaryOperator` - the `lhs` will return an `Expression::Parentheses`~~ (See: https://github.com/Kampfkarren/full-moon/pull/135#issuecomment-790821559)
- Removed the `visit_bin_op`/`visit_bin_op_end` and the related VisitorMut visitors. This is now handled within the expression visitor.

Closes #64 

Old tests have been verified to still be correct. I also just want to verify that you are happy with the new API names