### PR TITLE
Rename ParseExpression to ParenthesesExpression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated dependency cfg_if to v1.0
+- **[BREAKING CHANGE]** Renamed `Value::ParseExpression` to `Value::ParenthesesExpression`
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -379,7 +379,7 @@ pub enum Value<'a> {
     Number(Cow<'a, TokenReference<'a>>),
     /// An expression between parentheses, such as `(3 + 2)`
     #[display(fmt = "{}", "_0")]
-    ParseExpression(Expression<'a>),
+    ParenthesesExpression(Expression<'a>),
     /// A string token, such as `"hello"`
     #[display(fmt = "{}", "_0")]
     String(Cow<'a, TokenReference<'a>>),

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -350,7 +350,7 @@ define_parser!(
         ParseTableConstructor => Value::TableConstructor,
         ParseFunctionCall => Value::FunctionCall,
         ParseVar => Value::Var,
-        ParseParenExpression => Value::ParseExpression,
+        ParseParenExpression => Value::ParenthesesExpression,
     })
 );
 

--- a/full-moon/tests/cases/pass/paren-expressions/ast.json
+++ b/full-moon/tests/cases/pass/paren-expressions/ast.json
@@ -205,7 +205,7 @@
                     },
                     "rhs": {
                       "value": {
-                        "ParseExpression": {
+                        "ParenthesesExpression": {
                           "contained": {
                             "tokens": [
                               {


### PR DESCRIPTION
- Renamed `Value::ParseExpression` to `Value::ParenthesesExpression` (Closes #43)
This PR is a **breaking change**