### PR TITLE
New, more consistent names (remove iter_*, and *_list)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ See [#125](https://github.com/Kampfkarren/full-moon/pull/125) for more details.
 	- `Block::iter_stmts_with_semicolon` -> `stmts_with_semicolon`
 	- `VarExpression::iter_suffixes` -> `VarExpression::suffixes`
 	- `FunctionCall::iter_suffixes` -> `FunctionCall::suffixes`
+	- `FunctionBody::func_body` -> `FunctionBody::body`
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed the assertion operator from `as` to `::` under the roblox feature flag. `AsAssertion` has been renamed to `TypeAssertion`, with `as_token` renamed to `assertion_op`.
 - **[BREAKING CHANGE]** Changed how newline trailing trivia is bound to tokens. A token now owns any trailing trivia on the same line up to and including the newline character.
 See [#125](https://github.com/Kampfkarren/full-moon/pull/125) for more details.
+- **[BREAKING CHANGE]** The following names have been changed for consistency.
+	- `GenericFor::expr_list` -> `GenericFor::expressions`
+	- `GenericFor::with_expr_list` -> `GenericFor::with_expressions`
+	- `Assignment::expr_list` -> `Assignment::expressions`
+	- `Assignment::with_expr_list` -> `Assignment::with_expressions`
+	- `Assignment::var_list` -> `Assignment::variables`
+	- `Assignment::with_var_list` -> `Assignment::with_variables`
+	- `LocalAssignment::expr_list` -> `LocalAssignment::expressions`
+	- `LocalAssignment::with_expr_list` -> `LocalAssignment::with_expressions`
+	- `LocalAssignment::name_list` -> `LocalAssignment::names`
+	- `LocalAssignment::with_name_list` -> `LocalAssignment::with_names`
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ See [#125](https://github.com/Kampfkarren/full-moon/pull/125) for more details.
 	- `LocalAssignment::with_expr_list` -> `LocalAssignment::with_expressions`
 	- `LocalAssignment::name_list` -> `LocalAssignment::names`
 	- `LocalAssignment::with_name_list` -> `LocalAssignment::with_names`
+	- `Block::iter_stmts` -> `Block::stmts`
+	- `Block::iter_stmts_with_semicolon` -> `stmts_with_semicolon`
+	- `VarExpression::iter_suffixes` -> `VarExpression::suffixes`
+	- `FunctionCall::iter_suffixes` -> `FunctionCall::suffixes`
 
 ### Fixed
 - Fixed the start position of tokens at the beginning of a line to not be at the end of the previous line.

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1650,7 +1650,7 @@ impl<'a> LocalFunction<'a> {
     }
 
     /// The function body, everything except `local function x` in `local function x(a, b, c) call() end`
-    pub fn func_body(&self) -> &FunctionBody<'a> {
+    pub fn body(&self) -> &FunctionBody<'a> {
         &self.func_body
     }
 

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2231,7 +2231,7 @@ impl<'a> Ast<'a> {
     ///
     /// ```rust
     /// # fn main() -> Result<(), Box<std::error::Error>> {
-    /// assert_eq!(full_moon::parse("local x = 1; local y = 2")?.nodes().iter_stmts().count(), 2);
+    /// assert_eq!(full_moon::parse("local x = 1; local y = 2")?.nodes().stmts().count(), 2);
     /// # Ok(())
     /// # }
     /// ```

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -790,7 +790,7 @@ impl<'a> GenericFor<'a> {
 
     /// Returns the punctuated sequence of the expressions looped over
     /// In `for index, value in pairs(list) do`, iterates over `pairs(list)`
-    pub fn expr_list(&self) -> &Punctuated<'a, Expression<'a>> {
+    pub fn expressions(&self) -> &Punctuated<'a, Expression<'a>> {
         &self.expr_list
     }
 
@@ -834,7 +834,7 @@ impl<'a> GenericFor<'a> {
     }
 
     /// Returns a new GenericFor with the given expression list
-    pub fn with_expr_list(self, expr_list: Punctuated<'a, Expression<'a>>) -> Self {
+    pub fn with_expressions(self, expr_list: Punctuated<'a, Expression<'a>>) -> Self {
         Self { expr_list, ..self }
     }
 
@@ -1582,7 +1582,7 @@ impl<'a> Assignment<'a> {
 
     /// Returns the punctuated sequence over the expressions being assigned.
     /// This is the the `1, 2` part of `x, y["a"] = 1, 2`
-    pub fn expr_list(&self) -> &Punctuated<'a, Expression<'a>> {
+    pub fn expressions(&self) -> &Punctuated<'a, Expression<'a>> {
         &self.expr_list
     }
 
@@ -1593,12 +1593,12 @@ impl<'a> Assignment<'a> {
 
     /// Returns the punctuated sequence over the variables being assigned to.
     /// This is the `x, y["a"]` part of `x, y["a"] = 1, 2`
-    pub fn var_list(&self) -> &Punctuated<'a, Var<'a>> {
+    pub fn variables(&self) -> &Punctuated<'a, Var<'a>> {
         &self.var_list
     }
 
-    /// Returns a new Assignment with the given var list
-    pub fn with_var_list(self, var_list: Punctuated<'a, Var<'a>>) -> Self {
+    /// Returns a new Assignment with the given variables
+    pub fn with_variables(self, var_list: Punctuated<'a, Var<'a>>) -> Self {
         Self { var_list, ..self }
     }
 
@@ -1611,7 +1611,7 @@ impl<'a> Assignment<'a> {
     }
 
     /// Returns a new Assignment with the given expressions
-    pub fn with_expr_list(self, expr_list: Punctuated<'a, Expression<'a>>) -> Self {
+    pub fn with_expressions(self, expr_list: Punctuated<'a, Expression<'a>>) -> Self {
         Self { expr_list, ..self }
     }
 }
@@ -1725,13 +1725,13 @@ impl<'a> LocalAssignment<'a> {
 
     /// Returns the punctuated sequence of the expressions being assigned.
     /// This is the `1, 2` part of `local x, y = 1, 2`
-    pub fn expr_list(&self) -> &Punctuated<'a, Expression<'a>> {
+    pub fn expressions(&self) -> &Punctuated<'a, Expression<'a>> {
         &self.expr_list
     }
 
     /// Returns the punctuated sequence of names being assigned to.
     /// This is the `x, y` part of `local x, y = 1, 2`
-    pub fn name_list(&self) -> &Punctuated<'a, Cow<'a, TokenReference<'a>>> {
+    pub fn names(&self) -> &Punctuated<'a, Cow<'a, TokenReference<'a>>> {
         &self.name_list
     }
 
@@ -1762,7 +1762,7 @@ impl<'a> LocalAssignment<'a> {
     }
 
     /// Returns a new LocalAssignment with the given name list
-    pub fn with_name_list(self, name_list: Punctuated<'a, Cow<'a, TokenReference<'a>>>) -> Self {
+    pub fn with_names(self, name_list: Punctuated<'a, Cow<'a, TokenReference<'a>>>) -> Self {
         Self { name_list, ..self }
     }
 
@@ -1775,7 +1775,7 @@ impl<'a> LocalAssignment<'a> {
     }
 
     /// Returns a new LocalAssignment with the given expression list
-    pub fn with_expr_list(self, expr_list: Punctuated<'a, Expression<'a>>) -> Self {
+    pub fn with_expressions(self, expr_list: Punctuated<'a, Expression<'a>>) -> Self {
         Self { expr_list, ..self }
     }
 }

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -63,13 +63,13 @@ impl<'a> Block<'a> {
     }
 
     /// An iterator over the statements in the block, such as `local foo = 1`
-    pub fn iter_stmts(&self) -> impl Iterator<Item = &Stmt<'a>> {
+    pub fn stmts(&self) -> impl Iterator<Item = &Stmt<'a>> {
         self.stmts.iter().map(|(stmt, _)| stmt)
     }
 
     /// An iterator over the statements in the block, including any optional
     /// semicolon token reference present
-    pub fn iter_stmts_with_semicolon(
+    pub fn stmts_with_semicolon(
         &self,
     ) -> impl Iterator<Item = &(Stmt<'a>, Option<Cow<'a, TokenReference<'a>>>)> {
         self.stmts.iter()
@@ -1527,7 +1527,7 @@ impl<'a> VarExpression<'a> {
     }
 
     /// An iter over the suffixes, such as indexing or calling
-    pub fn iter_suffixes(&self) -> impl Iterator<Item = &Suffix<'a>> {
+    pub fn suffixes(&self) -> impl Iterator<Item = &Suffix<'a>> {
         self.suffixes.iter()
     }
 
@@ -1899,7 +1899,7 @@ impl<'a> FunctionCall<'a> {
     }
 
     /// The suffix of a function call, the `()` part of `call()`
-    pub fn iter_suffixes(&self) -> impl Iterator<Item = &Suffix<'a>> {
+    pub fn suffixes(&self) -> impl Iterator<Item = &Suffix<'a>> {
         self.suffixes.iter()
     }
 

--- a/full-moon/src/visitors.rs
+++ b/full-moon/src/visitors.rs
@@ -35,7 +35,7 @@ macro_rules! create_visitor {
         ///
         /// impl<'ast> Visitor<'ast> for LocalVariableVisitor {
         ///     fn visit_local_assignment(&mut self, local_assignment: &ast::LocalAssignment<'ast>) {
-        ///         self.names.extend(&mut local_assignment.name_list().iter().map(|name| name.token().to_string()));
+        ///         self.names.extend(&mut local_assignment.names().iter().map(|name| name.token().to_string()));
         ///     }
         /// }
         ///

--- a/full-moon/tests/node.rs
+++ b/full-moon/tests/node.rs
@@ -3,7 +3,7 @@ use full_moon::{node::Node, parse};
 #[test]
 fn surrounding_trivia() {
     let ast = parse(include_str!("cases/pass/local-assignment-5/source.lua")).unwrap();
-    let stmt = ast.nodes().iter_stmts().nth(1);
+    let stmt = ast.nodes().stmts().nth(1);
 
     let (prev, _) = stmt.surrounding_trivia();
 
@@ -16,7 +16,7 @@ fn surrounding_trivia() {
 #[test]
 fn test_similar() {
     let ast = parse("local x = 1; --[[ uh oh, filler ]] local x = 1; local x = 2;").unwrap();
-    let stmts = ast.nodes().iter_stmts().collect::<Vec<_>>();
+    let stmts = ast.nodes().stmts().collect::<Vec<_>>();
 
     assert!(stmts[0].similar(stmts[1]));
     assert!(stmts[1].similar(stmts[0]));

--- a/full-moon/tests/one_line_range.rs
+++ b/full-moon/tests/one_line_range.rs
@@ -19,7 +19,7 @@ fn test_one_line_range() {
     )
     .unwrap();
 
-    for stmt in ast.nodes().iter_stmts() {
+    for stmt in ast.nodes().stmts() {
         let (start, end) = stmt.range().unwrap();
         assert_eq!(
             end.line() - start.line(),

--- a/full-moon/tests/visitors.rs
+++ b/full-moon/tests/visitors.rs
@@ -41,7 +41,7 @@ fn test_visitor_mut() {
             assignment: ast::LocalAssignment<'ast>,
         ) -> ast::LocalAssignment<'ast> {
             let name_list = assignment
-                .name_list()
+                .names()
                 .pairs()
                 .map(|name| {
                     name.to_owned().map(|value| {
@@ -52,7 +52,7 @@ fn test_visitor_mut() {
                 })
                 .collect();
 
-            assignment.with_name_list(name_list)
+            assignment.with_names(name_list)
         }
     }
 
@@ -64,7 +64,7 @@ fn test_visitor_mut() {
 
     impl<'ast> Visitor<'ast> for PositionValidator {
         fn visit_local_assignment(&mut self, assignment: &ast::LocalAssignment<'ast>) {
-            for name in assignment.name_list() {
+            for name in assignment.names() {
                 assert_eq!(
                     name.end_position().bytes() - name.start_position().bytes(),
                     name.token().to_string().len()


### PR DESCRIPTION
The functions were not marked deprecated, as we are ideally moving to 1.0.0 very shortly (and the deprecated stuff should get removed around then anyway).

Closes #35 