### PR TITLE
Remove non_exhaustive feature, make everything non_exhaustive instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated dependency cfg_if to v1.0
 - **[BREAKING CHANGE]** Moved binary operations to `Expression::BinaryOperator`. `binop` has been removed from `Expression::Value`
 - **[BREAKING CHANGE]** Renamed `Value::ParseExpression` to `Value::ParenthesesExpression`
-- **[BREAKING CHANGE (for `roblox` users)]** When using the `non-exhaustive` feature flag (on by default when using the `roblox` feature flag), enums will now be marked as `non_exhaustive`, meaning matches on them must factor in the `_` case.
+- **[BREAKING CHANGE]** Enums are now be marked as `non_exhaustive`, meaning matches on them must factor in the `_` case.
 - Changed the assertion operator from `as` to `::` under the roblox feature flag. `AsAssertion` has been renamed to `TypeAssertion`, with `as_token` renamed to `assertion_op`.
 - **[BREAKING CHANGE]** Changed how newline trailing trivia is bound to tokens. A token now owns any trailing trivia on the same line up to and including the newline character.
 See [#125](https://github.com/Kampfkarren/full-moon/pull/125) for more details.

--- a/full-moon-derive/src/symbols.rs
+++ b/full-moon-derive/src/symbols.rs
@@ -97,7 +97,7 @@ pub fn parse(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         /// A literal symbol, used for both words important to syntax (like while) and operators (like +)
         #[derive(Clone, Copy, Debug, Eq, PartialEq)]
         #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-        #[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+        #[non_exhaustive]
         pub enum Symbol {
             #(
                 #[cfg_attr(feature = "serde", serde(rename = #string))]

--- a/full-moon/Cargo.toml
+++ b/full-moon/Cargo.toml
@@ -15,14 +15,9 @@ features = ["roblox", "lua52"]
 
 [features]
 default = ["serde"]
-roblox = ["non-exhaustive"] # Luau is always changing, and therefore is non-exhaustive.
+roblox = []
 lua52 = []
 no-source-tests = []
-
-# non-exhaustive is its own feature, as Lua 5.1 isn't going to update to add more.
-# Opting into non-standard Lua 5.1 syntax is always its own feature flag, and therefore will need to
-# be handled by the developer anyway.
-non-exhaustive = []
 
 [dependencies]
 bytecount = "0.5"

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -99,7 +99,7 @@ impl<'a> Block<'a> {
 /// The last statement of a [`Block`]
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum LastStmt<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     /// A `break` statement
@@ -162,7 +162,7 @@ impl Default for Return<'_> {
 /// Fields of a [`TableConstructor`]
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Field<'a> {
     /// A key in the format of `[expression] = value`
     #[display(
@@ -259,7 +259,7 @@ impl Default for TableConstructor<'_> {
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(untagged))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Expression<'a> {
     /// A binary operation, such as `1 + 3`
     #[display(fmt = "{}{}{}", "lhs", "binop", "rhs")]
@@ -321,7 +321,7 @@ pub enum Expression<'a> {
 /// Values that cannot be used standalone, but as part of things such as [`Stmt`]
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Value<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     /// An anonymous function, such as `function() end)`
@@ -353,7 +353,7 @@ pub enum Value<'a> {
 /// A statement that stands alone
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Stmt<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     /// An assignment, such as `x = 1`
@@ -418,7 +418,7 @@ pub enum Stmt<'a> {
 /// The `("foo")` part of `("foo"):upper()`
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Prefix<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     #[display(fmt = "{}", _0)]
@@ -433,7 +433,7 @@ pub enum Prefix<'a> {
 /// Values of variants are the keys, such as `"y"`
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Index<'a> {
     /// Indexing in the form of `x["y"]`
     #[display(
@@ -464,7 +464,7 @@ pub enum Index<'a> {
 /// Arguments used for a function
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum FunctionArgs<'a> {
     /// Used when a function is called in the form of `call(1, 2, 3)`
     #[display(
@@ -1288,7 +1288,7 @@ impl<'a> MethodCall<'a> {
 /// Something being called
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Call<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     #[display(fmt = "{}", "_0")]
@@ -1457,7 +1457,7 @@ impl fmt::Display for FunctionBody<'_> {
 /// A parameter in a function declaration
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Parameter<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     /// The `...` vararg syntax, such as `function x(...)`
@@ -1470,7 +1470,7 @@ pub enum Parameter<'a> {
 /// Can be stacked on top of each other, such as in `x()()()`
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Suffix<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     #[display(fmt = "{}", "_0")]
@@ -1524,7 +1524,7 @@ impl<'a> VarExpression<'a> {
 /// Used in [`Assignment`s](Assignment) and [`Value`s](Value)
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum Var<'a> {
     /// An expression, such as `x.y.z` or `x()`
     #[cfg_attr(feature = "serde", serde(borrow))]

--- a/full-moon/src/ast/parser_util.rs
+++ b/full-moon/src/ast/parser_util.rs
@@ -79,7 +79,7 @@ macro_rules! make_op {
     ($enum:ident, $(#[$outer:meta])* { $($operator:ident,)+ }) => {
         #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
         #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-        #[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+        #[non_exhaustive]
         $(#[$outer])*
         #[display(fmt = "{}")]
         pub enum $enum<'a> {

--- a/full-moon/src/ast/types.rs
+++ b/full-moon/src/ast/types.rs
@@ -7,7 +7,7 @@ use derive_more::Display;
 /// Any type, such as `string`, `boolean?`, `number | boolean`, etc.
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum TypeInfo<'a> {
     /// A shorthand type annotating the structure of an array: { number }
     #[display(fmt = "{}{}{}", "braces.tokens().0", "type_info", "braces.tokens().1")]
@@ -172,7 +172,7 @@ pub enum TypeInfo<'a> {
 /// A subset of TypeInfo that consists of items which can only be used as an index, such as `Foo` and `Foo<Bar>`,
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum IndexedTypeInfo<'a> {
     /// A standalone type, such as `string` or `Foo`.
     #[display(fmt = "{}", "_0")]
@@ -260,7 +260,7 @@ impl<'a> TypeField<'a> {
 /// A key in a [`TypeField`]. Can either be a name or an index signature.
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum TypeFieldKey<'a> {
     /// A name, such as `foo`.
     #[display(fmt = "{}", "_0")]

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -106,7 +106,7 @@ pub enum TokenizerErrorType {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum TokenType<'a> {
     /// End of file, should always be the very last token
     Eof,
@@ -235,7 +235,7 @@ impl<'a> TokenType<'a> {
 
 /// The kind of token. Contains no additional data.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum TokenKind {
     /// End of file, should always be the very last token
     Eof,
@@ -629,7 +629,7 @@ struct TokenAdvancement<'a> {
 /// The types of quotes used in a Lua string
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[cfg_attr(feature = "non-exhaustive", non_exhaustive)]
+#[non_exhaustive]
 pub enum StringLiteralQuoteType {
     /// Strings formatted \[\[with brackets\]\]
     Brackets,


### PR DESCRIPTION
I've been told that what we were doing is a violation of features--features are meant to be able to be combined together without breaking compilation.

I'm still unhappy about this solution, as Lua 5.1 users won't ever experience changes, but it makes sense to apply it everywhere so that multiple crates can import full-moon without clashing.

Perhaps we can find a way to split off stuff like Roblox parsing into its own crate that peers with full_moon, Idunno.