### PR TITLE
Only store the EOF token in the ast.

### DIFF
--- a/full-moon/src/visitors.rs
+++ b/full-moon/src/visitors.rs
@@ -90,7 +90,7 @@ macro_rules! create_visitor {
                 Ast {
                     nodes,
                     // Everything gets cloned with this visitor, so there's no original tokens
-                    tokens: vec![self.visit_eof(eof)],
+                    eof: self.visit_eof(eof),
                 }
             }
 


### PR DESCRIPTION
Since we don't refer to any of the other items in the `Vec` after consrtucting
an ast, there is no reason to keep around the rest of the elements.

This does mean that all of the `Cow<'a, TokenReference<'a>` don't have anything
to borrow from, but as we already cloning everything, this isn't a change.

We should either make the borrows work, or remove the use of `Cow` in the API.
See #129 for some discussion of options. In the mean time, this saves some
memory without impacting the API.