### PR TITLE
Lua52: fix incorrect method to get `name` for `Label

### DIFF
--- a/full-moon/src/ast/lua52.rs
+++ b/full-moon/src/ast/lua52.rs
@@ -75,7 +75,7 @@ impl<'a> Label<'a> {
     }
 
     /// The name used for the label, the `label` part of `::label::`
-    pub fn body(&self) -> &TokenReference<'a> {
+    pub fn name(&self) -> &TokenReference<'a> {
         &self.name
     }
 


### PR DESCRIPTION
Fix typo from `body()` -> `name()` for `Label` in Lua 5.2