### PR TITLE
Move extraction of trivia from parsing to tokenization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- **[BREAKING CHANGE]** Moved trivia handling to tokenization. Now ``tokens`` returns a vector of ``TokenReference``s and ``Ast::from_tokens`` takes the same. 
 - Switched from using nom to peg for lexing.
 
 ## [0.10.0] - 2021-03-26

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2135,11 +2135,10 @@ impl<'a> Ast<'a> {
     ///
     /// More likely, if the tokens pass are invalid Lua 5.1 code, an
     /// UnexpectedToken error will be returned.
-    pub fn from_tokens(tokens: Vec<Token<'a>>) -> Result<Ast<'a>, AstError<'a>> {
+    pub fn from_tokens(mut tokens: Vec<TokenReference<'a>>) -> Result<Ast<'a>, AstError<'a>> {
         if *tokens.last().ok_or(AstError::Empty)?.token_type() != TokenType::Eof {
             Err(AstError::NoEof)
         } else {
-            let mut tokens = extract_token_references(tokens);
             let mut state = ParserState::new(&tokens);
 
             if tokens
@@ -2230,86 +2229,10 @@ impl<'a> Ast<'a> {
     }
 }
 
-/// Extracts leading and trailing trivia from tokens
-pub(crate) fn extract_token_references(mut tokens: Vec<Token>) -> Vec<TokenReference> {
-    let mut references = Vec::new();
-    let (mut leading_trivia, mut trailing_trivia) = (Vec::new(), Vec::new());
-    let mut tokens = tokens.drain(..).peekable();
-
-    while let Some(token) = tokens.next() {
-        if token.token_type().is_trivia() {
-            leading_trivia.push(token);
-        } else {
-            while let Some(token) = tokens.peek() {
-                if token.token_type().is_trivia() {
-                    // Take all trivia up to and including the newline character. If we see a newline character
-                    // we should break once we have taken it in.
-                    let should_break =
-                        if let TokenType::Whitespace { ref characters } = &*token.token_type() {
-                            // Use contains in order to tolerate \r\n line endings and mixed whitespace tokens
-                            characters.contains('\n')
-                        } else {
-                            false
-                        };
-
-                    trailing_trivia.push(tokens.next().unwrap());
-
-                    if should_break {
-                        break;
-                    }
-                } else {
-                    break;
-                }
-            }
-
-            references.push(TokenReference {
-                leading_trivia: leading_trivia.drain(..).collect(),
-                trailing_trivia: trailing_trivia.drain(..).collect(),
-                token,
-            });
-        }
-    }
-
-    references
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{parse, print, tokenizer::tokens, visitors::VisitorMut};
-
-    #[test]
-    fn test_extract_token_references() {
-        let tokens = tokens("print(1)\n-- hello world\nlocal foo -- this is the word foo").unwrap();
-
-        let references = extract_token_references(tokens);
-        assert_eq!(references.len(), 7);
-
-        assert!(references[0].trailing_trivia.is_empty());
-        assert_eq!(references[0].token.to_string(), "print");
-        assert!(references[0].leading_trivia.is_empty());
-
-        assert!(references[1].trailing_trivia.is_empty());
-        assert_eq!(references[1].token.to_string(), "(");
-        assert!(references[1].leading_trivia.is_empty());
-
-        assert!(references[2].trailing_trivia.is_empty());
-        assert_eq!(references[2].token.to_string(), "1");
-        assert!(references[2].leading_trivia.is_empty());
-
-        assert_eq!(references[3].trailing_trivia[0].to_string(), "\n");
-        assert_eq!(references[3].token.to_string(), ")");
-        assert!(references[3].leading_trivia.is_empty());
-
-        assert_eq!(
-            references[4].leading_trivia[0].to_string(),
-            "-- hello world",
-        );
-
-        assert_eq!(references[4].leading_trivia[1].to_string(), "\n");
-        assert_eq!(references[4].token.to_string(), "local");
-        assert_eq!(references[4].trailing_trivia[0].to_string(), " ");
-    }
+    use crate::{parse, print, visitors::VisitorMut};
 
     #[test]
     fn test_with_eof_safety() {

--- a/full-moon/tests/cases/fail/parser/assignment-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/assignment-1/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/assignment-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 1
+        line: 1
+        character: 2
+      end_position:
+        bytes: 2
+        line: 1
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/assignment-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/assignment-2/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/assignment-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 1
+        line: 1
+        character: 2
+      end_position:
+        bytes: 2
+        line: 1
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/assignment-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/assignment-3/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/assignment-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/bin-op-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/bin-op-1/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/bin-op-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/bin-op-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/bin-op-2/tokens.snap
@@ -4,91 +4,106 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/bin-op-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/call-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/call-1/tokens.snap
@@ -4,36 +4,45 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/call-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/call-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/call-2/tokens.snap
@@ -4,48 +4,60 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/call-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: StringLiteral
-    literal: hello
-    quote_type: Double
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: StringLiteral
+      literal: hello
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/call-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/call-3/tokens.snap
@@ -4,82 +4,100 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/call-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: StringLiteral
-    literal: hello
-    quote_type: Double
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: StringLiteral
-    literal: world
-    quote_type: Double
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: StringLiteral
+      literal: hello
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: StringLiteral
+      literal: world
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 1
+      character: 22
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/call-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/call-4/tokens.snap
@@ -4,58 +4,73 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/call-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/do-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/do-1/tokens.snap
@@ -4,80 +4,95 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/do-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 3
-    line: 2
-    character: 1
-  end_position:
-    bytes: 4
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 4
-    line: 2
-    character: 2
-  end_position:
-    bytes: 8
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 8
-    line: 2
-    character: 6
-  end_position:
-    bytes: 9
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 9
-    line: 2
-    character: 7
-  end_position:
-    bytes: 10
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 10
-    line: 2
-    character: 8
-  end_position:
-    bytes: 10
-    line: 2
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 3
+        line: 2
+        character: 1
+      end_position:
+        bytes: 4
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 4
+      line: 2
+      character: 2
+    end_position:
+      bytes: 8
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 2
+      character: 6
+    end_position:
+      bytes: 9
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 2
+      character: 7
+    end_position:
+      bytes: 10
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 8
+    end_position:
+      bytes: 10
+      line: 2
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/do-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/do-2/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/do-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-1/tokens.snap
@@ -4,25 +4,31 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-2/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-3/tokens.snap
@@ -4,69 +4,84 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-4/tokens.snap
@@ -4,58 +4,70 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-5/tokens.snap
@@ -4,91 +4,109 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-6/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-6/tokens.snap
@@ -4,69 +4,84 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-6
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-7/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-7/tokens.snap
@@ -4,135 +4,162 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-7
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 19
-    line: 2
-    character: 1
-  end_position:
-    bytes: 22
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 22
-    line: 2
-    character: 4
-  end_position:
-    bytes: 22
-    line: 2
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 1
+        character: 19
+      end_position:
+        bytes: 19
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 1
+    end_position:
+      bytes: 22
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 4
+    end_position:
+      bytes: 22
+      line: 2
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/function-8/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/function-8/tokens.snap
@@ -4,113 +4,137 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/function-8
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: name
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: name
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 1
+      character: 22
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/generic-for-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-1/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/generic-for-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: in
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: in
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/generic-for-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-2/tokens.snap
@@ -4,124 +4,148 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/generic-for-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: in
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: pairs
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: in
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: pairs
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/generic-for-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-3/tokens.snap
@@ -4,146 +4,173 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/generic-for-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: in
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: pairs
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: in
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: pairs
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/generic-for-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-4/tokens.snap
@@ -4,201 +4,237 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/generic-for-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: index
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: in
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: pairs
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 26
-    line: 1
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 26
-    line: 1
-    character: 27
-  end_position:
-    bytes: 30
-    line: 1
-    character: 31
-  token_type:
-    type: Identifier
-    identifier: list
-- start_position:
-    bytes: 30
-    line: 1
-    character: 31
-  end_position:
-    bytes: 31
-    line: 1
-    character: 32
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 31
-    line: 1
-    character: 32
-  end_position:
-    bytes: 32
-    line: 1
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 32
-    line: 1
-    character: 33
-  end_position:
-    bytes: 34
-    line: 1
-    character: 35
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 34
-    line: 1
-    character: 35
-  end_position:
-    bytes: 35
-    line: 1
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 35
-    line: 1
-    character: 36
-  end_position:
-    bytes: 38
-    line: 1
-    character: 39
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 38
-    line: 1
-    character: 39
-  end_position:
-    bytes: 38
-    line: 1
-    character: 39
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: index
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: in
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: pairs
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 26
+      line: 1
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 1
+      character: 27
+    end_position:
+      bytes: 30
+      line: 1
+      character: 31
+    token_type:
+      type: Identifier
+      identifier: list
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 1
+      character: 31
+    end_position:
+      bytes: 31
+      line: 1
+      character: 32
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 1
+        character: 32
+      end_position:
+        bytes: 32
+        line: 1
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 1
+      character: 33
+    end_position:
+      bytes: 34
+      line: 1
+      character: 35
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 1
+        character: 35
+      end_position:
+        bytes: 35
+        line: 1
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 1
+      character: 36
+    end_position:
+      bytes: 38
+      line: 1
+      character: 39
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 1
+      character: 39
+    end_position:
+      bytes: 38
+      line: 1
+      character: 39
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/if-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/if-1/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/if-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/if-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/if-2/tokens.snap
@@ -4,146 +4,170 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/if-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 14
-    line: 2
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: else
-- start_position:
-    bytes: 14
-    line: 2
-    character: 5
-  end_position:
-    bytes: 15
-    line: 2
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 3
-    character: 1
-  end_position:
-    bytes: 16
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 16
-    line: 3
-    character: 2
-  end_position:
-    bytes: 20
-    line: 3
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 20
-    line: 3
-    character: 6
-  end_position:
-    bytes: 21
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 21
-    line: 3
-    character: 7
-  end_position:
-    bytes: 22
-    line: 3
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 22
-    line: 3
-    character: 8
-  end_position:
-    bytes: 22
-    line: 3
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 1
+    end_position:
+      bytes: 14
+      line: 2
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: else
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 5
+      end_position:
+        bytes: 15
+        line: 2
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 15
+        line: 3
+        character: 1
+      end_position:
+        bytes: 16
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 16
+      line: 3
+      character: 2
+    end_position:
+      bytes: 20
+      line: 3
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 3
+      character: 6
+    end_position:
+      bytes: 21
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 7
+    end_position:
+      bytes: 22
+      line: 3
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 3
+      character: 8
+    end_position:
+      bytes: 22
+      line: 3
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/if-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/if-3/tokens.snap
@@ -4,91 +4,106 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/if-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/if-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/if-4/tokens.snap
@@ -4,135 +4,156 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/if-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 16
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: elseif
-- start_position:
-    bytes: 16
-    line: 2
-    character: 7
-  end_position:
-    bytes: 17
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 2
-    character: 8
-  end_position:
-    bytes: 18
-    line: 2
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 18
-    line: 2
-    character: 9
-  end_position:
-    bytes: 19
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 19
-    line: 2
-    character: 10
-  end_position:
-    bytes: 23
-    line: 2
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 23
-    line: 2
-    character: 14
-  end_position:
-    bytes: 23
-    line: 2
-    character: 14
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 1
+    end_position:
+      bytes: 16
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: elseif
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 2
+        character: 7
+      end_position:
+        bytes: 17
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 8
+    end_position:
+      bytes: 18
+      line: 2
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 2
+        character: 9
+      end_position:
+        bytes: 19
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 10
+    end_position:
+      bytes: 23
+      line: 2
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 2
+      character: 14
+    end_position:
+      bytes: 23
+      line: 2
+      character: 14
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/if-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/if-5/tokens.snap
@@ -4,344 +4,398 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/if-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 11
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 11
-    line: 2
-    character: 2
-  end_position:
-    bytes: 16
-    line: 2
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: call1
-- start_position:
-    bytes: 16
-    line: 2
-    character: 7
-  end_position:
-    bytes: 17
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 2
-    character: 8
-  end_position:
-    bytes: 18
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 18
-    line: 2
-    character: 9
-  end_position:
-    bytes: 19
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 19
-    line: 3
-    character: 1
-  end_position:
-    bytes: 23
-    line: 3
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: else
-- start_position:
-    bytes: 23
-    line: 3
-    character: 5
-  end_position:
-    bytes: 24
-    line: 3
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 24
-    line: 4
-    character: 1
-  end_position:
-    bytes: 25
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 25
-    line: 4
-    character: 2
-  end_position:
-    bytes: 30
-    line: 4
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: call2
-- start_position:
-    bytes: 30
-    line: 4
-    character: 7
-  end_position:
-    bytes: 31
-    line: 4
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 31
-    line: 4
-    character: 8
-  end_position:
-    bytes: 32
-    line: 4
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 32
-    line: 4
-    character: 9
-  end_position:
-    bytes: 33
-    line: 4
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 33
-    line: 5
-    character: 1
-  end_position:
-    bytes: 39
-    line: 5
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: elseif
-- start_position:
-    bytes: 39
-    line: 5
-    character: 7
-  end_position:
-    bytes: 40
-    line: 5
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 5
-    character: 8
-  end_position:
-    bytes: 41
-    line: 5
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 41
-    line: 5
-    character: 9
-  end_position:
-    bytes: 42
-    line: 5
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 42
-    line: 5
-    character: 10
-  end_position:
-    bytes: 46
-    line: 5
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 46
-    line: 5
-    character: 14
-  end_position:
-    bytes: 47
-    line: 5
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 47
-    line: 6
-    character: 1
-  end_position:
-    bytes: 48
-    line: 6
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 48
-    line: 6
-    character: 2
-  end_position:
-    bytes: 53
-    line: 6
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: call3
-- start_position:
-    bytes: 53
-    line: 6
-    character: 7
-  end_position:
-    bytes: 54
-    line: 6
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 54
-    line: 6
-    character: 8
-  end_position:
-    bytes: 55
-    line: 6
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 55
-    line: 6
-    character: 9
-  end_position:
-    bytes: 56
-    line: 6
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 56
-    line: 7
-    character: 1
-  end_position:
-    bytes: 59
-    line: 7
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 59
-    line: 7
-    character: 4
-  end_position:
-    bytes: 59
-    line: 7
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 10
+        line: 2
+        character: 1
+      end_position:
+        bytes: 11
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 2
+    end_position:
+      bytes: 16
+      line: 2
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: call1
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 7
+    end_position:
+      bytes: 17
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 8
+    end_position:
+      bytes: 18
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 2
+        character: 9
+      end_position:
+        bytes: 19
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 3
+      character: 1
+    end_position:
+      bytes: 23
+      line: 3
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: else
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 3
+        character: 5
+      end_position:
+        bytes: 24
+        line: 3
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 24
+        line: 4
+        character: 1
+      end_position:
+        bytes: 25
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 25
+      line: 4
+      character: 2
+    end_position:
+      bytes: 30
+      line: 4
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: call2
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 4
+      character: 7
+    end_position:
+      bytes: 31
+      line: 4
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 4
+      character: 8
+    end_position:
+      bytes: 32
+      line: 4
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 32
+        line: 4
+        character: 9
+      end_position:
+        bytes: 33
+        line: 4
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 5
+      character: 1
+    end_position:
+      bytes: 39
+      line: 5
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: elseif
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 5
+        character: 7
+      end_position:
+        bytes: 40
+        line: 5
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 5
+      character: 8
+    end_position:
+      bytes: 41
+      line: 5
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 41
+        line: 5
+        character: 9
+      end_position:
+        bytes: 42
+        line: 5
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 5
+      character: 10
+    end_position:
+      bytes: 46
+      line: 5
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 5
+        character: 14
+      end_position:
+        bytes: 47
+        line: 5
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 47
+        line: 6
+        character: 1
+      end_position:
+        bytes: 48
+        line: 6
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 48
+      line: 6
+      character: 2
+    end_position:
+      bytes: 53
+      line: 6
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: call3
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 6
+      character: 7
+    end_position:
+      bytes: 54
+      line: 6
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 6
+      character: 8
+    end_position:
+      bytes: 55
+      line: 6
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 55
+        line: 6
+        character: 9
+      end_position:
+        bytes: 56
+        line: 6
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 56
+      line: 7
+      character: 1
+    end_position:
+      bytes: 59
+      line: 7
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 59
+      line: 7
+      character: 4
+    end_position:
+      bytes: 59
+      line: 7
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/if-6/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/if-6/tokens.snap
@@ -4,190 +4,220 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/if-6
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 14
-    line: 2
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: else
-- start_position:
-    bytes: 14
-    line: 2
-    character: 5
-  end_position:
-    bytes: 15
-    line: 2
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 2
-    character: 6
-  end_position:
-    bytes: 19
-    line: 2
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 19
-    line: 2
-    character: 10
-  end_position:
-    bytes: 20
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 20
-    line: 3
-    character: 1
-  end_position:
-    bytes: 21
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 21
-    line: 3
-    character: 2
-  end_position:
-    bytes: 25
-    line: 3
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 25
-    line: 3
-    character: 6
-  end_position:
-    bytes: 26
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 26
-    line: 3
-    character: 7
-  end_position:
-    bytes: 27
-    line: 3
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 27
-    line: 3
-    character: 8
-  end_position:
-    bytes: 28
-    line: 3
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 28
-    line: 4
-    character: 1
-  end_position:
-    bytes: 31
-    line: 4
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 31
-    line: 4
-    character: 4
-  end_position:
-    bytes: 31
-    line: 4
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 1
+    end_position:
+      bytes: 14
+      line: 2
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: else
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 5
+      end_position:
+        bytes: 15
+        line: 2
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 6
+    end_position:
+      bytes: 19
+      line: 2
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 10
+      end_position:
+        bytes: 20
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 20
+        line: 3
+        character: 1
+      end_position:
+        bytes: 21
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 2
+    end_position:
+      bytes: 25
+      line: 3
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 3
+      character: 6
+    end_position:
+      bytes: 26
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 3
+      character: 7
+    end_position:
+      bytes: 27
+      line: 3
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 3
+        character: 8
+      end_position:
+        bytes: 28
+        line: 3
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 4
+      character: 1
+    end_position:
+      bytes: 31
+      line: 4
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 4
+      character: 4
+    end_position:
+      bytes: 31
+      line: 4
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/if-7/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/if-7/tokens.snap
@@ -4,113 +4,131 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/if-7
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 13
-    line: 2
-    character: 1
-  end_position:
-    bytes: 16
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 16
-    line: 2
-    character: 4
-  end_position:
-    bytes: 16
-    line: 2
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 1
+        character: 13
+      end_position:
+        bytes: 13
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 1
+    end_position:
+      bytes: 16
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 4
+    end_position:
+      bytes: 16
+      line: 2
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/index-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/index-1/tokens.snap
@@ -4,47 +4,59 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/index-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1
+      line: 1
+      character: 2
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/index-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/index-2/tokens.snap
@@ -4,36 +4,45 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/index-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1
+      line: 1
+      character: 2
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/index-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/index-3/tokens.snap
@@ -4,91 +4,109 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/index-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1
+      line: 1
+      character: 2
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/index-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/index-4/tokens.snap
@@ -4,124 +4,148 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/index-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/index-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/index-5/tokens.snap
@@ -4,69 +4,84 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/index-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: name
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: name
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-assignment-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-1/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-assignment-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-assignment-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-2/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-assignment-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-assignment-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-3/tokens.snap
@@ -4,102 +4,120 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-assignment-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-assignment-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-4/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-assignment-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-assignment-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-5/tokens.snap
@@ -4,91 +4,106 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-assignment-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-function-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-1/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-function-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-function-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-2/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-function-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-function-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-3/tokens.snap
@@ -4,80 +4,95 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-function-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-function-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-4/tokens.snap
@@ -4,146 +4,173 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-function-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 19
-    line: 2
-    character: 1
-  end_position:
-    bytes: 20
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 20
-    line: 2
-    character: 2
-  end_position:
-    bytes: 24
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 24
-    line: 2
-    character: 6
-  end_position:
-    bytes: 25
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 25
-    line: 2
-    character: 7
-  end_position:
-    bytes: 26
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 26
-    line: 2
-    character: 8
-  end_position:
-    bytes: 26
-    line: 2
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 1
+        character: 19
+      end_position:
+        bytes: 19
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 1
+      end_position:
+        bytes: 20
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 2
+    end_position:
+      bytes: 24
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 6
+    end_position:
+      bytes: 25
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 7
+    end_position:
+      bytes: 26
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 8
+    end_position:
+      bytes: 26
+      line: 2
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-function-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-5/tokens.snap
@@ -4,168 +4,198 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-function-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 20
-    line: 2
-    character: 1
-  end_position:
-    bytes: 21
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 21
-    line: 2
-    character: 2
-  end_position:
-    bytes: 25
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 25
-    line: 2
-    character: 6
-  end_position:
-    bytes: 26
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 26
-    line: 2
-    character: 7
-  end_position:
-    bytes: 27
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 27
-    line: 2
-    character: 8
-  end_position:
-    bytes: 28
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 28
-    line: 3
-    character: 1
-  end_position:
-    bytes: 31
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 31
-    line: 3
-    character: 4
-  end_position:
-    bytes: 31
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 20
+        line: 2
+        character: 1
+      end_position:
+        bytes: 21
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 21
+      line: 2
+      character: 2
+    end_position:
+      bytes: 25
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 6
+    end_position:
+      bytes: 26
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 7
+    end_position:
+      bytes: 27
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 2
+        character: 8
+      end_position:
+        bytes: 28
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 3
+      character: 1
+    end_position:
+      bytes: 31
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 3
+      character: 4
+    end_position:
+      bytes: 31
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/local-function-6/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-6/tokens.snap
@@ -4,146 +4,176 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/local-function-6
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 22
-    line: 2
-    character: 1
-  end_position:
-    bytes: 25
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 25
-    line: 2
-    character: 4
-  end_position:
-    bytes: 25
-    line: 2
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 22
+      end_position:
+        bytes: 22
+        line: 1
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 1
+    end_position:
+      bytes: 25
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 4
+    end_position:
+      bytes: 25
+      line: 2
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/method-call-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/method-call-1/tokens.snap
@@ -4,58 +4,70 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/method-call-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: name
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: name
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/method-call-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/method-call-2/tokens.snap
@@ -4,69 +4,84 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/method-call-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: name
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: method
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: name
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: method
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/method-call-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/method-call-3/tokens.snap
@@ -4,102 +4,126 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/method-call-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: name
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: method
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: name
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: method
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 24
+      line: 1
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 1
+      character: 25
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/numeric-for-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-1/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/numeric-for-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/numeric-for-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-2/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/numeric-for-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/numeric-for-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-3/tokens.snap
@@ -4,91 +4,106 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/numeric-for-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/numeric-for-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-4/tokens.snap
@@ -4,146 +4,170 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/numeric-for-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Number
-    text: "10"
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Number
+      text: "10"
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/numeric-for-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-5/tokens.snap
@@ -4,168 +4,195 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/numeric-for-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Number
-    text: "10"
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Number
+      text: "10"
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 1
+        character: 21
+      end_position:
+        bytes: 21
+        line: 1
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 1
+      character: 22
+    end_position:
+      bytes: 24
+      line: 1
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 1
+      character: 25
+    end_position:
+      bytes: 24
+      line: 1
+      character: 25
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/paren-expression-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-1/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/paren-expression-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/paren-expression-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-2/tokens.snap
@@ -4,91 +4,109 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/paren-expression-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Number
-    text: "4"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Number
+      text: "4"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/paren-expression-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-3/tokens.snap
@@ -4,102 +4,123 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/paren-expression-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Number
-    text: "4"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Number
+      text: "4"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/paren-expression-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-4/tokens.snap
@@ -4,58 +4,70 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/paren-expression-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/paren-expression-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-5/tokens.snap
@@ -4,69 +4,84 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/paren-expression-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/repeat-until-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-1/tokens.snap
@@ -4,25 +4,31 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/repeat-until-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: repeat
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: repeat
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/repeat-until-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-2/tokens.snap
@@ -4,80 +4,95 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/repeat-until-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: repeat
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 7
-    line: 2
-    character: 1
-  end_position:
-    bytes: 8
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 8
-    line: 2
-    character: 2
-  end_position:
-    bytes: 12
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 12
-    line: 2
-    character: 6
-  end_position:
-    bytes: 13
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 13
-    line: 2
-    character: 7
-  end_position:
-    bytes: 14
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 2
-    character: 8
-  end_position:
-    bytes: 14
-    line: 2
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: repeat
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 7
+        line: 2
+        character: 1
+      end_position:
+        bytes: 8
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 8
+      line: 2
+      character: 2
+    end_position:
+      bytes: 12
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 6
+    end_position:
+      bytes: 13
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 7
+    end_position:
+      bytes: 14
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 8
+    end_position:
+      bytes: 14
+      line: 2
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/repeat-until-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-3/tokens.snap
@@ -4,102 +4,120 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/repeat-until-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: repeat
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 7
-    line: 2
-    character: 1
-  end_position:
-    bytes: 8
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 8
-    line: 2
-    character: 2
-  end_position:
-    bytes: 12
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 12
-    line: 2
-    character: 6
-  end_position:
-    bytes: 13
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 13
-    line: 2
-    character: 7
-  end_position:
-    bytes: 14
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 2
-    character: 8
-  end_position:
-    bytes: 15
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 3
-    character: 1
-  end_position:
-    bytes: 20
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 20
-    line: 3
-    character: 6
-  end_position:
-    bytes: 20
-    line: 3
-    character: 6
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: repeat
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 7
+        line: 2
+        character: 1
+      end_position:
+        bytes: 8
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 8
+      line: 2
+      character: 2
+    end_position:
+      bytes: 12
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 6
+    end_position:
+      bytes: 13
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 7
+    end_position:
+      bytes: 14
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 8
+      end_position:
+        bytes: 15
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 3
+      character: 1
+    end_position:
+      bytes: 20
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 3
+      character: 6
+    end_position:
+      bytes: 20
+      line: 3
+      character: 6
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/repeat-until-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-4/tokens.snap
@@ -4,124 +4,145 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/repeat-until-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: repeat
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 7
-    line: 2
-    character: 1
-  end_position:
-    bytes: 8
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 8
-    line: 2
-    character: 2
-  end_position:
-    bytes: 12
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 12
-    line: 2
-    character: 6
-  end_position:
-    bytes: 13
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 13
-    line: 2
-    character: 7
-  end_position:
-    bytes: 14
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 2
-    character: 8
-  end_position:
-    bytes: 15
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 3
-    character: 1
-  end_position:
-    bytes: 20
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 20
-    line: 3
-    character: 6
-  end_position:
-    bytes: 21
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 21
-    line: 3
-    character: 7
-  end_position:
-    bytes: 24
-    line: 3
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 24
-    line: 3
-    character: 10
-  end_position:
-    bytes: 24
-    line: 3
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: repeat
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 7
+        line: 2
+        character: 1
+      end_position:
+        bytes: 8
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 8
+      line: 2
+      character: 2
+    end_position:
+      bytes: 12
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 6
+    end_position:
+      bytes: 13
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 7
+    end_position:
+      bytes: 14
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 8
+      end_position:
+        bytes: 15
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 3
+      character: 1
+    end_position:
+      bytes: 20
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 3
+        character: 6
+      end_position:
+        bytes: 21
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 7
+    end_position:
+      bytes: 24
+      line: 3
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 3
+      character: 10
+    end_position:
+      bytes: 24
+      line: 3
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-1/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-2/tokens.snap
@@ -4,135 +4,156 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 11
-    line: 2
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 11
-    line: 2
-    character: 3
-  end_position:
-    bytes: 12
-    line: 2
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 2
-    character: 4
-  end_position:
-    bytes: 13
-    line: 2
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 13
-    line: 2
-    character: 5
-  end_position:
-    bytes: 14
-    line: 2
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 2
-    character: 6
-  end_position:
-    bytes: 15
-    line: 2
-    character: 7
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 15
-    line: 2
-    character: 7
-  end_position:
-    bytes: 16
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 16
-    line: 2
-    character: 8
-  end_position:
-    bytes: 16
-    line: 2
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 9
+        line: 2
+        character: 1
+      end_position:
+        bytes: 10
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 11
+      line: 2
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 2
+        character: 3
+      end_position:
+        bytes: 12
+        line: 2
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 4
+    end_position:
+      bytes: 13
+      line: 2
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 2
+        character: 5
+      end_position:
+        bytes: 14
+        line: 2
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 6
+    end_position:
+      bytes: 15
+      line: 2
+      character: 7
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 7
+    end_position:
+      bytes: 16
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 8
+    end_position:
+      bytes: 16
+      line: 2
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-3/tokens.snap
@@ -4,102 +4,117 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 11
-    line: 2
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 11
-    line: 2
-    character: 3
-  end_position:
-    bytes: 12
-    line: 2
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 2
-    character: 4
-  end_position:
-    bytes: 13
-    line: 2
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 13
-    line: 2
-    character: 5
-  end_position:
-    bytes: 13
-    line: 2
-    character: 5
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 9
+        line: 2
+        character: 1
+      end_position:
+        bytes: 10
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 11
+      line: 2
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 2
+        character: 3
+      end_position:
+        bytes: 12
+        line: 2
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 4
+    end_position:
+      bytes: 13
+      line: 2
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 5
+    end_position:
+      bytes: 13
+      line: 2
+      character: 5
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-4/tokens.snap
@@ -4,91 +4,106 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-5/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-5/tokens.snap
@@ -4,157 +4,181 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 15
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 15
-    line: 2
-    character: 7
-  end_position:
-    bytes: 16
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 16
-    line: 2
-    character: 8
-  end_position:
-    bytes: 17
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 17
-    line: 2
-    character: 9
-  end_position:
-    bytes: 18
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 2
-    character: 10
-  end_position:
-    bytes: 19
-    line: 2
-    character: 11
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 19
-    line: 2
-    character: 11
-  end_position:
-    bytes: 20
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 20
-    line: 2
-    character: 12
-  end_position:
-    bytes: 21
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 21
-    line: 3
-    character: 1
-  end_position:
-    bytes: 22
-    line: 3
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 22
-    line: 3
-    character: 2
-  end_position:
-    bytes: 22
-    line: 3
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 9
+        line: 2
+        character: 1
+      end_position:
+        bytes: 10
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 15
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 2
+        character: 7
+      end_position:
+        bytes: 16
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 8
+    end_position:
+      bytes: 17
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 2
+        character: 9
+      end_position:
+        bytes: 18
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 10
+    end_position:
+      bytes: 19
+      line: 2
+      character: 11
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 11
+    end_position:
+      bytes: 20
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 2
+        character: 12
+      end_position:
+        bytes: 21
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 1
+    end_position:
+      bytes: 22
+      line: 3
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 3
+      character: 2
+    end_position:
+      bytes: 22
+      line: 3
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-6/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-6/tokens.snap
@@ -4,157 +4,181 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-6
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 11
-    line: 2
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 11
-    line: 2
-    character: 3
-  end_position:
-    bytes: 12
-    line: 2
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 2
-    character: 4
-  end_position:
-    bytes: 13
-    line: 2
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 13
-    line: 2
-    character: 5
-  end_position:
-    bytes: 14
-    line: 2
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 2
-    character: 6
-  end_position:
-    bytes: 19
-    line: 2
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 19
-    line: 2
-    character: 11
-  end_position:
-    bytes: 20
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 20
-    line: 2
-    character: 12
-  end_position:
-    bytes: 21
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 21
-    line: 3
-    character: 1
-  end_position:
-    bytes: 22
-    line: 3
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 22
-    line: 3
-    character: 2
-  end_position:
-    bytes: 22
-    line: 3
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 9
+        line: 2
+        character: 1
+      end_position:
+        bytes: 10
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 11
+      line: 2
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 2
+        character: 3
+      end_position:
+        bytes: 12
+        line: 2
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 4
+    end_position:
+      bytes: 13
+      line: 2
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 2
+        character: 5
+      end_position:
+        bytes: 14
+        line: 2
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 6
+    end_position:
+      bytes: 19
+      line: 2
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 11
+    end_position:
+      bytes: 20
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 2
+        character: 12
+      end_position:
+        bytes: 21
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 1
+    end_position:
+      bytes: 22
+      line: 3
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 3
+      character: 2
+    end_position:
+      bytes: 22
+      line: 3
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-7/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-7/tokens.snap
@@ -4,179 +4,209 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-7
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 11
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 11
-    line: 2
-    character: 3
-  end_position:
-    bytes: 16
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 16
-    line: 2
-    character: 8
-  end_position:
-    bytes: 17
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 17
-    line: 2
-    character: 9
-  end_position:
-    bytes: 18
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 2
-    character: 10
-  end_position:
-    bytes: 19
-    line: 2
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 19
-    line: 2
-    character: 11
-  end_position:
-    bytes: 20
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 2
-    character: 12
-  end_position:
-    bytes: 24
-    line: 2
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 24
-    line: 2
-    character: 16
-  end_position:
-    bytes: 25
-    line: 2
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 25
-    line: 2
-    character: 17
-  end_position:
-    bytes: 26
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 26
-    line: 3
-    character: 1
-  end_position:
-    bytes: 27
-    line: 3
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 27
-    line: 3
-    character: 2
-  end_position:
-    bytes: 27
-    line: 3
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 9
+        line: 2
+        character: 1
+      end_position:
+        bytes: 10
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 11
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 3
+    end_position:
+      bytes: 16
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 8
+    end_position:
+      bytes: 17
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 2
+        character: 9
+      end_position:
+        bytes: 18
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 10
+    end_position:
+      bytes: 19
+      line: 2
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 11
+      end_position:
+        bytes: 20
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 12
+    end_position:
+      bytes: 24
+      line: 2
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 16
+    end_position:
+      bytes: 25
+      line: 2
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 2
+        character: 17
+      end_position:
+        bytes: 26
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 3
+      character: 1
+    end_position:
+      bytes: 27
+      line: 3
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 3
+      character: 2
+    end_position:
+      bytes: 27
+      line: 3
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/table-8/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/table-8/tokens.snap
@@ -4,168 +4,195 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/table-8
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 11
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 11
-    line: 2
-    character: 3
-  end_position:
-    bytes: 12
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 4
-  end_position:
-    bytes: 13
-    line: 2
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 13
-    line: 2
-    character: 5
-  end_position:
-    bytes: 14
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 14
-    line: 2
-    character: 6
-  end_position:
-    bytes: 15
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 2
-    character: 7
-  end_position:
-    bytes: 16
-    line: 2
-    character: 8
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 16
-    line: 2
-    character: 8
-  end_position:
-    bytes: 17
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 17
-    line: 2
-    character: 9
-  end_position:
-    bytes: 18
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 18
-    line: 3
-    character: 1
-  end_position:
-    bytes: 19
-    line: 3
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 19
-    line: 3
-    character: 2
-  end_position:
-    bytes: 19
-    line: 3
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 9
+        line: 2
+        character: 1
+      end_position:
+        bytes: 10
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 11
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 3
+    end_position:
+      bytes: 12
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 2
+        character: 4
+      end_position:
+        bytes: 13
+        line: 2
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 5
+    end_position:
+      bytes: 14
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 6
+      end_position:
+        bytes: 15
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 7
+    end_position:
+      bytes: 16
+      line: 2
+      character: 8
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 8
+    end_position:
+      bytes: 17
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 2
+        character: 9
+      end_position:
+        bytes: 18
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 3
+      character: 1
+    end_position:
+      bytes: 19
+      line: 3
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 3
+      character: 2
+    end_position:
+      bytes: 19
+      line: 3
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/un-op-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/un-op-1/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/un-op-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: not
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: not
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/un-op-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/un-op-2/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/un-op-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: not
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: not
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/while-1/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/while-1/tokens.snap
@@ -4,25 +4,31 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/while-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: while
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: while
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/while-2/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/while-2/tokens.snap
@@ -4,91 +4,106 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/while-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: while
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: while
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/while-3/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/while-3/tokens.snap
@@ -4,124 +4,145 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/while-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: while
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 14
-    line: 2
-    character: 1
-  end_position:
-    bytes: 15
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 15
-    line: 2
-    character: 2
-  end_position:
-    bytes: 19
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 19
-    line: 2
-    character: 6
-  end_position:
-    bytes: 20
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 20
-    line: 2
-    character: 7
-  end_position:
-    bytes: 21
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 21
-    line: 2
-    character: 8
-  end_position:
-    bytes: 21
-    line: 2
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: while
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 1
+      end_position:
+        bytes: 15
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 2
+    end_position:
+      bytes: 19
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 6
+    end_position:
+      bytes: 20
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 7
+    end_position:
+      bytes: 21
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 2
+      character: 8
+    end_position:
+      bytes: 21
+      line: 2
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/fail/parser/while-4/tokens.snap
+++ b/full-moon/tests/cases/fail/parser/while-4/tokens.snap
@@ -4,124 +4,145 @@ expression: tokens
 input_file: full-moon/tests/cases/fail/parser/while-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: while
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 11
-    line: 2
-    character: 1
-  end_position:
-    bytes: 12
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 2
-  end_position:
-    bytes: 16
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 16
-    line: 2
-    character: 6
-  end_position:
-    bytes: 17
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 2
-    character: 7
-  end_position:
-    bytes: 18
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 18
-    line: 2
-    character: 8
-  end_position:
-    bytes: 19
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 19
-    line: 3
-    character: 1
-  end_position:
-    bytes: 22
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 22
-    line: 3
-    character: 4
-  end_position:
-    bytes: 22
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: while
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 11
+        line: 2
+        character: 1
+      end_position:
+        bytes: 12
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 2
+    end_position:
+      bytes: 16
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 6
+    end_position:
+      bytes: 17
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 7
+    end_position:
+      bytes: 18
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 2
+        character: 8
+      end_position:
+        bytes: 19
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 3
+      character: 1
+    end_position:
+      bytes: 22
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 3
+      character: 4
+    end_position:
+      bytes: 22
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/anonymous-functions-1/tokens.snap
+++ b/full-moon/tests/cases/pass/anonymous-functions-1/tokens.snap
@@ -4,212 +4,248 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/anonymous-functions-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 21
-    line: 2
-    character: 1
-  end_position:
-    bytes: 22
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 22
-    line: 2
-    character: 2
-  end_position:
-    bytes: 26
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 26
-    line: 2
-    character: 6
-  end_position:
-    bytes: 27
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 27
-    line: 2
-    character: 7
-  end_position:
-    bytes: 28
-    line: 2
-    character: 8
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 28
-    line: 2
-    character: 8
-  end_position:
-    bytes: 29
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 29
-    line: 2
-    character: 9
-  end_position:
-    bytes: 30
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 30
-    line: 3
-    character: 1
-  end_position:
-    bytes: 33
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 33
-    line: 3
-    character: 4
-  end_position:
-    bytes: 34
-    line: 3
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 34
-    line: 4
-    character: 1
-  end_position:
-    bytes: 34
-    line: 4
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 1
+        character: 21
+      end_position:
+        bytes: 21
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 1
+      end_position:
+        bytes: 22
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 2
+    end_position:
+      bytes: 26
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 6
+    end_position:
+      bytes: 27
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 7
+    end_position:
+      bytes: 28
+      line: 2
+      character: 8
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 2
+      character: 8
+    end_position:
+      bytes: 29
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 29
+        line: 2
+        character: 9
+      end_position:
+        bytes: 30
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 3
+      character: 1
+    end_position:
+      bytes: 33
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 3
+        character: 4
+      end_position:
+        bytes: 34
+        line: 3
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 4
+      character: 1
+    end_position:
+      bytes: 34
+      line: 4
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/anonymous-functions-2/tokens.snap
+++ b/full-moon/tests/cases/pass/anonymous-functions-2/tokens.snap
@@ -4,169 +4,205 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/anonymous-functions-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 16
-    line: 2
-    character: 1
-  end_position:
-    bytes: 17
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 17
-    line: 2
-    character: 2
-  end_position:
-    bytes: 20
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 20
-    line: 2
-    character: 5
-  end_position:
-    bytes: 21
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 21
-    line: 2
-    character: 6
-  end_position:
-    bytes: 26
-    line: 2
-    character: 11
-  token_type:
-    type: StringLiteral
-    literal: bar
-    quote_type: Double
-- start_position:
-    bytes: 26
-    line: 2
-    character: 11
-  end_position:
-    bytes: 27
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 27
-    line: 2
-    character: 12
-  end_position:
-    bytes: 28
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 28
-    line: 3
-    character: 1
-  end_position:
-    bytes: 31
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 31
-    line: 3
-    character: 4
-  end_position:
-    bytes: 32
-    line: 3
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 32
-    line: 3
-    character: 5
-  end_position:
-    bytes: 32
-    line: 3
-    character: 5
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 16
+        line: 2
+        character: 1
+      end_position:
+        bytes: 17
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 2
+    end_position:
+      bytes: 20
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 5
+    end_position:
+      bytes: 21
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 2
+      character: 6
+    end_position:
+      bytes: 26
+      line: 2
+      character: 11
+    token_type:
+      type: StringLiteral
+      literal: bar
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 11
+    end_position:
+      bytes: 27
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 2
+        character: 12
+      end_position:
+        bytes: 28
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 3
+      character: 1
+    end_position:
+      bytes: 31
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 3
+      character: 4
+    end_position:
+      bytes: 32
+      line: 3
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 3
+      character: 5
+    end_position:
+      bytes: 32
+      line: 3
+      character: 5
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/anonymous-functions-3/tokens.snap
+++ b/full-moon/tests/cases/pass/anonymous-functions-3/tokens.snap
@@ -4,146 +4,173 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/anonymous-functions-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 23
-    line: 1
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 23
-    line: 1
-    character: 24
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 27
-    line: 1
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 27
-    line: 1
-    character: 28
-  end_position:
-    bytes: 27
-    line: 1
-    character: 28
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 22
+      line: 1
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 1
+      character: 23
+    end_position:
+      bytes: 23
+      line: 1
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 1
+        character: 24
+      end_position:
+        bytes: 24
+        line: 1
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 1
+      character: 25
+    end_position:
+      bytes: 27
+      line: 1
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 1
+      character: 28
+    end_position:
+      bytes: 27
+      line: 1
+      character: 28
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/anonymous-functions-4/tokens.snap
+++ b/full-moon/tests/cases/pass/anonymous-functions-4/tokens.snap
@@ -4,212 +4,251 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/anonymous-functions-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 23
-    line: 1
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 23
-    line: 1
-    character: 24
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 28
-    line: 1
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 28
-    line: 1
-    character: 29
-  end_position:
-    bytes: 29
-    line: 1
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 29
-    line: 1
-    character: 30
-  end_position:
-    bytes: 30
-    line: 1
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 30
-    line: 1
-    character: 31
-  end_position:
-    bytes: 33
-    line: 1
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 33
-    line: 1
-    character: 34
-  end_position:
-    bytes: 33
-    line: 1
-    character: 34
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 22
+      end_position:
+        bytes: 22
+        line: 1
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 1
+      character: 23
+    end_position:
+      bytes: 23
+      line: 1
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 1
+      character: 24
+    end_position:
+      bytes: 24
+      line: 1
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 24
+        line: 1
+        character: 25
+      end_position:
+        bytes: 25
+        line: 1
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 28
+      line: 1
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 1
+      character: 29
+    end_position:
+      bytes: 29
+      line: 1
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 29
+        line: 1
+        character: 30
+      end_position:
+        bytes: 30
+        line: 1
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 1
+      character: 31
+    end_position:
+      bytes: 33
+      line: 1
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 1
+      character: 34
+    end_position:
+      bytes: 33
+      line: 1
+      character: 34
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/assignment-1/tokens.snap
+++ b/full-moon/tests/cases/pass/assignment-1/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/assignment-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 1
+        line: 1
+        character: 2
+      end_position:
+        bytes: 2
+        line: 1
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/assignment-2/tokens.snap
+++ b/full-moon/tests/cases/pass/assignment-2/tokens.snap
@@ -4,135 +4,159 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/assignment-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1
+      line: 1
+      character: 2
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/assignment-3/tokens.snap
+++ b/full-moon/tests/cases/pass/assignment-3/tokens.snap
@@ -4,608 +4,743 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/assignment-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 48
-    line: 1
-    character: 49
-  token_type:
-    type: SingleLineComment
-    comment: " Crazy assignment code from AmaranthineCodices"
-- start_position:
-    bytes: 48
-    line: 1
-    character: 49
-  end_position:
-    bytes: 49
-    line: 1
-    character: 49
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 49
-    line: 2
-    character: 1
-  end_position:
-    bytes: 50
-    line: 2
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 50
-    line: 2
-    character: 2
-  end_position:
-    bytes: 51
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 51
-    line: 2
-    character: 3
-  end_position:
-    bytes: 52
-    line: 2
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 52
-    line: 2
-    character: 4
-  end_position:
-    bytes: 53
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 53
-    line: 2
-    character: 5
-  end_position:
-    bytes: 54
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 54
-    line: 2
-    character: 6
-  end_position:
-    bytes: 55
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 55
-    line: 2
-    character: 7
-  end_position:
-    bytes: 56
-    line: 2
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: c
-- start_position:
-    bytes: 56
-    line: 2
-    character: 8
-  end_position:
-    bytes: 57
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 57
-    line: 2
-    character: 9
-  end_position:
-    bytes: 58
-    line: 2
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: d
-- start_position:
-    bytes: 58
-    line: 2
-    character: 10
-  end_position:
-    bytes: 59
-    line: 2
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 59
-    line: 2
-    character: 11
-  end_position:
-    bytes: 60
-    line: 2
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: e
-- start_position:
-    bytes: 60
-    line: 2
-    character: 12
-  end_position:
-    bytes: 61
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 61
-    line: 2
-    character: 13
-  end_position:
-    bytes: 62
-    line: 2
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: f
-- start_position:
-    bytes: 62
-    line: 2
-    character: 14
-  end_position:
-    bytes: 63
-    line: 2
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 63
-    line: 2
-    character: 15
-  end_position:
-    bytes: 64
-    line: 2
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 64
-    line: 2
-    character: 16
-  end_position:
-    bytes: 65
-    line: 2
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: g
-- start_position:
-    bytes: 65
-    line: 2
-    character: 17
-  end_position:
-    bytes: 66
-    line: 2
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 66
-    line: 2
-    character: 18
-  end_position:
-    bytes: 67
-    line: 2
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 67
-    line: 2
-    character: 19
-  end_position:
-    bytes: 68
-    line: 2
-    character: 20
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 68
-    line: 2
-    character: 20
-  end_position:
-    bytes: 69
-    line: 2
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 69
-    line: 2
-    character: 21
-  end_position:
-    bytes: 70
-    line: 2
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 70
-    line: 2
-    character: 22
-  end_position:
-    bytes: 71
-    line: 2
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 71
-    line: 2
-    character: 23
-  end_position:
-    bytes: 72
-    line: 2
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: h
-- start_position:
-    bytes: 72
-    line: 2
-    character: 24
-  end_position:
-    bytes: 73
-    line: 2
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 73
-    line: 2
-    character: 25
-  end_position:
-    bytes: 74
-    line: 2
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: i
-- start_position:
-    bytes: 74
-    line: 2
-    character: 26
-  end_position:
-    bytes: 75
-    line: 2
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 75
-    line: 2
-    character: 27
-  end_position:
-    bytes: 76
-    line: 2
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 76
-    line: 2
-    character: 28
-  end_position:
-    bytes: 77
-    line: 2
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 77
-    line: 2
-    character: 29
-  end_position:
-    bytes: 78
-    line: 2
-    character: 30
-  token_type:
-    type: Identifier
-    identifier: j
-- start_position:
-    bytes: 78
-    line: 2
-    character: 30
-  end_position:
-    bytes: 79
-    line: 2
-    character: 31
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 79
-    line: 2
-    character: 31
-  end_position:
-    bytes: 80
-    line: 2
-    character: 32
-  token_type:
-    type: Identifier
-    identifier: k
-- start_position:
-    bytes: 80
-    line: 2
-    character: 32
-  end_position:
-    bytes: 81
-    line: 2
-    character: 33
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 81
-    line: 2
-    character: 33
-  end_position:
-    bytes: 82
-    line: 2
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 82
-    line: 2
-    character: 34
-  end_position:
-    bytes: 83
-    line: 2
-    character: 35
-  token_type:
-    type: Identifier
-    identifier: l
-- start_position:
-    bytes: 83
-    line: 2
-    character: 35
-  end_position:
-    bytes: 84
-    line: 2
-    character: 36
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 84
-    line: 2
-    character: 36
-  end_position:
-    bytes: 85
-    line: 2
-    character: 37
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 85
-    line: 2
-    character: 37
-  end_position:
-    bytes: 86
-    line: 2
-    character: 38
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 86
-    line: 2
-    character: 38
-  end_position:
-    bytes: 87
-    line: 2
-    character: 39
-  token_type:
-    type: Identifier
-    identifier: m
-- start_position:
-    bytes: 87
-    line: 2
-    character: 39
-  end_position:
-    bytes: 88
-    line: 2
-    character: 40
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 88
-    line: 2
-    character: 40
-  end_position:
-    bytes: 89
-    line: 2
-    character: 41
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 89
-    line: 2
-    character: 41
-  end_position:
-    bytes: 90
-    line: 2
-    character: 42
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 90
-    line: 2
-    character: 42
-  end_position:
-    bytes: 91
-    line: 2
-    character: 43
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 91
-    line: 2
-    character: 43
-  end_position:
-    bytes: 95
-    line: 2
-    character: 47
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 95
-    line: 2
-    character: 47
-  end_position:
-    bytes: 96
-    line: 2
-    character: 48
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 96
-    line: 2
-    character: 48
-  end_position:
-    bytes: 97
-    line: 2
-    character: 49
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 97
-    line: 2
-    character: 49
-  end_position:
-    bytes: 102
-    line: 2
-    character: 54
-  token_type:
-    type: Symbol
-    symbol: "false"
-- start_position:
-    bytes: 102
-    line: 2
-    character: 54
-  end_position:
-    bytes: 103
-    line: 2
-    character: 55
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 103
-    line: 2
-    character: 55
-  end_position:
-    bytes: 104
-    line: 2
-    character: 56
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 104
-    line: 2
-    character: 56
-  end_position:
-    bytes: 105
-    line: 2
-    character: 57
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 105
-    line: 2
-    character: 57
-  end_position:
-    bytes: 106
-    line: 2
-    character: 58
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 106
-    line: 2
-    character: 58
-  end_position:
-    bytes: 107
-    line: 2
-    character: 59
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 107
-    line: 2
-    character: 59
-  end_position:
-    bytes: 108
-    line: 2
-    character: 60
-  token_type:
-    type: Number
-    text: "4"
-- start_position:
-    bytes: 108
-    line: 2
-    character: 60
-  end_position:
-    bytes: 108
-    line: 2
-    character: 60
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 48
+        line: 1
+        character: 49
+      token_type:
+        type: SingleLineComment
+        comment: " Crazy assignment code from AmaranthineCodices"
+    - start_position:
+        bytes: 48
+        line: 1
+        character: 49
+      end_position:
+        bytes: 49
+        line: 1
+        character: 49
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 49
+      line: 2
+      character: 1
+    end_position:
+      bytes: 50
+      line: 2
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 2
+      character: 2
+    end_position:
+      bytes: 51
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 51
+        line: 2
+        character: 3
+      end_position:
+        bytes: 52
+        line: 2
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 2
+      character: 4
+    end_position:
+      bytes: 53
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 2
+      character: 5
+    end_position:
+      bytes: 54
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 54
+        line: 2
+        character: 6
+      end_position:
+        bytes: 55
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 2
+      character: 7
+    end_position:
+      bytes: 56
+      line: 2
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: c
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 56
+      line: 2
+      character: 8
+    end_position:
+      bytes: 57
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 57
+      line: 2
+      character: 9
+    end_position:
+      bytes: 58
+      line: 2
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: d
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 2
+      character: 10
+    end_position:
+      bytes: 59
+      line: 2
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 59
+      line: 2
+      character: 11
+    end_position:
+      bytes: 60
+      line: 2
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: e
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 60
+      line: 2
+      character: 12
+    end_position:
+      bytes: 61
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 61
+      line: 2
+      character: 13
+    end_position:
+      bytes: 62
+      line: 2
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: f
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 62
+      line: 2
+      character: 14
+    end_position:
+      bytes: 63
+      line: 2
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 63
+      line: 2
+      character: 15
+    end_position:
+      bytes: 64
+      line: 2
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 64
+      line: 2
+      character: 16
+    end_position:
+      bytes: 65
+      line: 2
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: g
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 65
+      line: 2
+      character: 17
+    end_position:
+      bytes: 66
+      line: 2
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 66
+      line: 2
+      character: 18
+    end_position:
+      bytes: 67
+      line: 2
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 67
+      line: 2
+      character: 19
+    end_position:
+      bytes: 68
+      line: 2
+      character: 20
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 68
+      line: 2
+      character: 20
+    end_position:
+      bytes: 69
+      line: 2
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 69
+      line: 2
+      character: 21
+    end_position:
+      bytes: 70
+      line: 2
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 70
+        line: 2
+        character: 22
+      end_position:
+        bytes: 71
+        line: 2
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 71
+      line: 2
+      character: 23
+    end_position:
+      bytes: 72
+      line: 2
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: h
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 72
+      line: 2
+      character: 24
+    end_position:
+      bytes: 73
+      line: 2
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 73
+      line: 2
+      character: 25
+    end_position:
+      bytes: 74
+      line: 2
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: i
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 2
+      character: 26
+    end_position:
+      bytes: 75
+      line: 2
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 2
+      character: 27
+    end_position:
+      bytes: 76
+      line: 2
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 76
+      line: 2
+      character: 28
+    end_position:
+      bytes: 77
+      line: 2
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 77
+      line: 2
+      character: 29
+    end_position:
+      bytes: 78
+      line: 2
+      character: 30
+    token_type:
+      type: Identifier
+      identifier: j
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 78
+      line: 2
+      character: 30
+    end_position:
+      bytes: 79
+      line: 2
+      character: 31
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 79
+      line: 2
+      character: 31
+    end_position:
+      bytes: 80
+      line: 2
+      character: 32
+    token_type:
+      type: Identifier
+      identifier: k
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 80
+      line: 2
+      character: 32
+    end_position:
+      bytes: 81
+      line: 2
+      character: 33
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 81
+      line: 2
+      character: 33
+    end_position:
+      bytes: 82
+      line: 2
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 82
+      line: 2
+      character: 34
+    end_position:
+      bytes: 83
+      line: 2
+      character: 35
+    token_type:
+      type: Identifier
+      identifier: l
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 83
+      line: 2
+      character: 35
+    end_position:
+      bytes: 84
+      line: 2
+      character: 36
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 84
+      line: 2
+      character: 36
+    end_position:
+      bytes: 85
+      line: 2
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 2
+      character: 37
+    end_position:
+      bytes: 86
+      line: 2
+      character: 38
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 86
+      line: 2
+      character: 38
+    end_position:
+      bytes: 87
+      line: 2
+      character: 39
+    token_type:
+      type: Identifier
+      identifier: m
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 87
+      line: 2
+      character: 39
+    end_position:
+      bytes: 88
+      line: 2
+      character: 40
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 88
+        line: 2
+        character: 40
+      end_position:
+        bytes: 89
+        line: 2
+        character: 41
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 89
+      line: 2
+      character: 41
+    end_position:
+      bytes: 90
+      line: 2
+      character: 42
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 90
+        line: 2
+        character: 42
+      end_position:
+        bytes: 91
+        line: 2
+        character: 43
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 91
+      line: 2
+      character: 43
+    end_position:
+      bytes: 95
+      line: 2
+      character: 47
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 95
+      line: 2
+      character: 47
+    end_position:
+      bytes: 96
+      line: 2
+      character: 48
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 96
+        line: 2
+        character: 48
+      end_position:
+        bytes: 97
+        line: 2
+        character: 49
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 97
+      line: 2
+      character: 49
+    end_position:
+      bytes: 102
+      line: 2
+      character: 54
+    token_type:
+      type: Symbol
+      symbol: "false"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 102
+      line: 2
+      character: 54
+    end_position:
+      bytes: 103
+      line: 2
+      character: 55
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 103
+        line: 2
+        character: 55
+      end_position:
+        bytes: 104
+        line: 2
+        character: 56
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 104
+      line: 2
+      character: 56
+    end_position:
+      bytes: 105
+      line: 2
+      character: 57
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 105
+      line: 2
+      character: 57
+    end_position:
+      bytes: 106
+      line: 2
+      character: 58
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 106
+        line: 2
+        character: 58
+      end_position:
+        bytes: 107
+        line: 2
+        character: 59
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 107
+      line: 2
+      character: 59
+    end_position:
+      bytes: 108
+      line: 2
+      character: 60
+    token_type:
+      type: Number
+      text: "4"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 108
+      line: 2
+      character: 60
+    end_position:
+      bytes: 108
+      line: 2
+      character: 60
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/binops/tokens.snap
+++ b/full-moon/tests/cases/pass/binops/tokens.snap
@@ -4,1422 +4,1620 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/binops
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 16
-    line: 2
-    character: 1
-  end_position:
-    bytes: 17
-    line: 2
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 17
-    line: 2
-    character: 2
-  end_position:
-    bytes: 18
-    line: 2
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 2
-    character: 3
-  end_position:
-    bytes: 19
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 19
-    line: 2
-    character: 4
-  end_position:
-    bytes: 20
-    line: 2
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 2
-    character: 5
-  end_position:
-    bytes: 23
-    line: 2
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 23
-    line: 2
-    character: 8
-  end_position:
-    bytes: 24
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 2
-    character: 9
-  end_position:
-    bytes: 27
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 27
-    line: 2
-    character: 12
-  end_position:
-    bytes: 28
-    line: 2
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 28
-    line: 2
-    character: 13
-  end_position:
-    bytes: 31
-    line: 2
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 31
-    line: 2
-    character: 16
-  end_position:
-    bytes: 32
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 32
-    line: 2
-    character: 17
-  end_position:
-    bytes: 34
-    line: 2
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: or
-- start_position:
-    bytes: 34
-    line: 2
-    character: 19
-  end_position:
-    bytes: 35
-    line: 2
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 35
-    line: 2
-    character: 20
-  end_position:
-    bytes: 38
-    line: 2
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: baz
-- start_position:
-    bytes: 38
-    line: 2
-    character: 23
-  end_position:
-    bytes: 39
-    line: 2
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 39
-    line: 3
-    character: 1
-  end_position:
-    bytes: 40
-    line: 3
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: c
-- start_position:
-    bytes: 40
-    line: 3
-    character: 2
-  end_position:
-    bytes: 41
-    line: 3
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 41
-    line: 3
-    character: 3
-  end_position:
-    bytes: 42
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 42
-    line: 3
-    character: 4
-  end_position:
-    bytes: 43
-    line: 3
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 43
-    line: 3
-    character: 5
-  end_position:
-    bytes: 44
-    line: 3
-    character: 6
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 44
-    line: 3
-    character: 6
-  end_position:
-    bytes: 45
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 45
-    line: 3
-    character: 7
-  end_position:
-    bytes: 46
-    line: 3
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 46
-    line: 3
-    character: 8
-  end_position:
-    bytes: 47
-    line: 3
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 47
-    line: 3
-    character: 9
-  end_position:
-    bytes: 48
-    line: 3
-    character: 10
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 48
-    line: 3
-    character: 10
-  end_position:
-    bytes: 49
-    line: 3
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 49
-    line: 3
-    character: 11
-  end_position:
-    bytes: 50
-    line: 3
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "*"
-- start_position:
-    bytes: 50
-    line: 3
-    character: 12
-  end_position:
-    bytes: 51
-    line: 3
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 51
-    line: 3
-    character: 13
-  end_position:
-    bytes: 52
-    line: 3
-    character: 14
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 52
-    line: 3
-    character: 14
-  end_position:
-    bytes: 53
-    line: 3
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 53
-    line: 3
-    character: 15
-  end_position:
-    bytes: 54
-    line: 3
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 54
-    line: 3
-    character: 16
-  end_position:
-    bytes: 55
-    line: 3
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 55
-    line: 3
-    character: 17
-  end_position:
-    bytes: 56
-    line: 3
-    character: 18
-  token_type:
-    type: Number
-    text: "4"
-- start_position:
-    bytes: 56
-    line: 3
-    character: 18
-  end_position:
-    bytes: 57
-    line: 3
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 57
-    line: 3
-    character: 19
-  end_position:
-    bytes: 58
-    line: 3
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: ^
-- start_position:
-    bytes: 58
-    line: 3
-    character: 20
-  end_position:
-    bytes: 59
-    line: 3
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 59
-    line: 3
-    character: 21
-  end_position:
-    bytes: 60
-    line: 3
-    character: 22
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 60
-    line: 3
-    character: 22
-  end_position:
-    bytes: 61
-    line: 3
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 61
-    line: 4
-    character: 1
-  end_position:
-    bytes: 62
-    line: 4
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: d
-- start_position:
-    bytes: 62
-    line: 4
-    character: 2
-  end_position:
-    bytes: 63
-    line: 4
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 63
-    line: 4
-    character: 3
-  end_position:
-    bytes: 64
-    line: 4
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 64
-    line: 4
-    character: 4
-  end_position:
-    bytes: 65
-    line: 4
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 65
-    line: 4
-    character: 5
-  end_position:
-    bytes: 66
-    line: 4
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 66
-    line: 4
-    character: 6
-  end_position:
-    bytes: 67
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 67
-    line: 4
-    character: 7
-  end_position:
-    bytes: 68
-    line: 4
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 68
-    line: 4
-    character: 8
-  end_position:
-    bytes: 69
-    line: 4
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 69
-    line: 4
-    character: 9
-  end_position:
-    bytes: 70
-    line: 4
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: i
-- start_position:
-    bytes: 70
-    line: 4
-    character: 10
-  end_position:
-    bytes: 71
-    line: 4
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 71
-    line: 4
-    character: 11
-  end_position:
-    bytes: 72
-    line: 4
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 72
-    line: 4
-    character: 12
-  end_position:
-    bytes: 73
-    line: 4
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 73
-    line: 4
-    character: 13
-  end_position:
-    bytes: 74
-    line: 4
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 74
-    line: 4
-    character: 14
-  end_position:
-    bytes: 75
-    line: 4
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 75
-    line: 4
-    character: 15
-  end_position:
-    bytes: 76
-    line: 4
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: /
-- start_position:
-    bytes: 76
-    line: 4
-    character: 16
-  end_position:
-    bytes: 77
-    line: 4
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 77
-    line: 4
-    character: 17
-  end_position:
-    bytes: 78
-    line: 4
-    character: 18
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 78
-    line: 4
-    character: 18
-  end_position:
-    bytes: 79
-    line: 4
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 79
-    line: 4
-    character: 19
-  end_position:
-    bytes: 80
-    line: 4
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 80
-    line: 4
-    character: 20
-  end_position:
-    bytes: 81
-    line: 4
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 81
-    line: 4
-    character: 21
-  end_position:
-    bytes: 82
-    line: 4
-    character: 22
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 82
-    line: 4
-    character: 22
-  end_position:
-    bytes: 83
-    line: 4
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 83
-    line: 5
-    character: 1
-  end_position:
-    bytes: 84
-    line: 5
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: e
-- start_position:
-    bytes: 84
-    line: 5
-    character: 2
-  end_position:
-    bytes: 85
-    line: 5
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 85
-    line: 5
-    character: 3
-  end_position:
-    bytes: 86
-    line: 5
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 86
-    line: 5
-    character: 4
-  end_position:
-    bytes: 87
-    line: 5
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 87
-    line: 5
-    character: 5
-  end_position:
-    bytes: 88
-    line: 5
-    character: 6
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 88
-    line: 5
-    character: 6
-  end_position:
-    bytes: 89
-    line: 5
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 89
-    line: 5
-    character: 7
-  end_position:
-    bytes: 90
-    line: 5
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 90
-    line: 5
-    character: 8
-  end_position:
-    bytes: 91
-    line: 5
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 91
-    line: 5
-    character: 9
-  end_position:
-    bytes: 92
-    line: 5
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 92
-    line: 5
-    character: 10
-  end_position:
-    bytes: 93
-    line: 5
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 93
-    line: 5
-    character: 11
-  end_position:
-    bytes: 94
-    line: 5
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: ^
-- start_position:
-    bytes: 94
-    line: 5
-    character: 12
-  end_position:
-    bytes: 95
-    line: 5
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 95
-    line: 5
-    character: 13
-  end_position:
-    bytes: 96
-    line: 5
-    character: 14
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 96
-    line: 5
-    character: 14
-  end_position:
-    bytes: 97
-    line: 5
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 97
-    line: 5
-    character: 15
-  end_position:
-    bytes: 98
-    line: 5
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "*"
-- start_position:
-    bytes: 98
-    line: 5
-    character: 16
-  end_position:
-    bytes: 99
-    line: 5
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 99
-    line: 5
-    character: 17
-  end_position:
-    bytes: 100
-    line: 5
-    character: 18
-  token_type:
-    type: Number
-    text: "8"
-- start_position:
-    bytes: 100
-    line: 5
-    character: 18
-  end_position:
-    bytes: 101
-    line: 5
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 101
-    line: 6
-    character: 1
-  end_position:
-    bytes: 102
-    line: 6
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: f
-- start_position:
-    bytes: 102
-    line: 6
-    character: 2
-  end_position:
-    bytes: 103
-    line: 6
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 103
-    line: 6
-    character: 3
-  end_position:
-    bytes: 104
-    line: 6
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 104
-    line: 6
-    character: 4
-  end_position:
-    bytes: 105
-    line: 6
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 105
-    line: 6
-    character: 5
-  end_position:
-    bytes: 106
-    line: 6
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 106
-    line: 6
-    character: 6
-  end_position:
-    bytes: 107
-    line: 6
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 107
-    line: 6
-    character: 7
-  end_position:
-    bytes: 108
-    line: 6
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 108
-    line: 6
-    character: 8
-  end_position:
-    bytes: 109
-    line: 6
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 109
-    line: 6
-    character: 9
-  end_position:
-    bytes: 110
-    line: 6
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 110
-    line: 6
-    character: 10
-  end_position:
-    bytes: 111
-    line: 6
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 111
-    line: 6
-    character: 11
-  end_position:
-    bytes: 114
-    line: 6
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 114
-    line: 6
-    character: 14
-  end_position:
-    bytes: 115
-    line: 6
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 115
-    line: 6
-    character: 15
-  end_position:
-    bytes: 116
-    line: 6
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 116
-    line: 6
-    character: 16
-  end_position:
-    bytes: 117
-    line: 6
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 117
-    line: 6
-    character: 17
-  end_position:
-    bytes: 119
-    line: 6
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "<="
-- start_position:
-    bytes: 119
-    line: 6
-    character: 19
-  end_position:
-    bytes: 120
-    line: 6
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 120
-    line: 6
-    character: 20
-  end_position:
-    bytes: 121
-    line: 6
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: z
-- start_position:
-    bytes: 121
-    line: 6
-    character: 21
-  end_position:
-    bytes: 122
-    line: 6
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 122
-    line: 7
-    character: 1
-  end_position:
-    bytes: 123
-    line: 7
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: g
-- start_position:
-    bytes: 123
-    line: 7
-    character: 2
-  end_position:
-    bytes: 124
-    line: 7
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 124
-    line: 7
-    character: 3
-  end_position:
-    bytes: 125
-    line: 7
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 125
-    line: 7
-    character: 4
-  end_position:
-    bytes: 126
-    line: 7
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 126
-    line: 7
-    character: 5
-  end_position:
-    bytes: 127
-    line: 7
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 127
-    line: 7
-    character: 6
-  end_position:
-    bytes: 128
-    line: 7
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 128
-    line: 7
-    character: 7
-  end_position:
-    bytes: 129
-    line: 7
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 129
-    line: 7
-    character: 8
-  end_position:
-    bytes: 130
-    line: 7
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ^
-- start_position:
-    bytes: 130
-    line: 7
-    character: 9
-  end_position:
-    bytes: 131
-    line: 7
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 131
-    line: 7
-    character: 10
-  end_position:
-    bytes: 132
-    line: 7
-    character: 11
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 132
-    line: 7
-    character: 11
-  end_position:
-    bytes: 133
-    line: 7
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 133
-    line: 8
-    character: 1
-  end_position:
-    bytes: 134
-    line: 8
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: h
-- start_position:
-    bytes: 134
-    line: 8
-    character: 2
-  end_position:
-    bytes: 135
-    line: 8
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 135
-    line: 8
-    character: 3
-  end_position:
-    bytes: 136
-    line: 8
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 136
-    line: 8
-    character: 4
-  end_position:
-    bytes: 137
-    line: 8
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 137
-    line: 8
-    character: 5
-  end_position:
-    bytes: 138
-    line: 8
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 138
-    line: 8
-    character: 6
-  end_position:
-    bytes: 139
-    line: 8
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 139
-    line: 8
-    character: 7
-  end_position:
-    bytes: 140
-    line: 8
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ^
-- start_position:
-    bytes: 140
-    line: 8
-    character: 8
-  end_position:
-    bytes: 141
-    line: 8
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 141
-    line: 8
-    character: 9
-  end_position:
-    bytes: 142
-    line: 8
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 142
-    line: 8
-    character: 10
-  end_position:
-    bytes: 143
-    line: 8
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 143
-    line: 8
-    character: 11
-  end_position:
-    bytes: 144
-    line: 8
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: ^
-- start_position:
-    bytes: 144
-    line: 8
-    character: 12
-  end_position:
-    bytes: 145
-    line: 8
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 145
-    line: 8
-    character: 13
-  end_position:
-    bytes: 146
-    line: 8
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: z
-- start_position:
-    bytes: 146
-    line: 8
-    character: 14
-  end_position:
-    bytes: 146
-    line: 8
-    character: 14
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia:
+    - start_position:
+        bytes: 1
+        line: 1
+        character: 2
+      end_position:
+        bytes: 2
+        line: 1
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 1
+    end_position:
+      bytes: 17
+      line: 2
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 2
+        character: 2
+      end_position:
+        bytes: 18
+        line: 2
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 3
+    end_position:
+      bytes: 19
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 4
+      end_position:
+        bytes: 20
+        line: 2
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 5
+    end_position:
+      bytes: 23
+      line: 2
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 2
+        character: 8
+      end_position:
+        bytes: 24
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 9
+    end_position:
+      bytes: 27
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 2
+        character: 12
+      end_position:
+        bytes: 28
+        line: 2
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 2
+      character: 13
+    end_position:
+      bytes: 31
+      line: 2
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 2
+        character: 16
+      end_position:
+        bytes: 32
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 2
+      character: 17
+    end_position:
+      bytes: 34
+      line: 2
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: or
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 2
+        character: 19
+      end_position:
+        bytes: 35
+        line: 2
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 2
+      character: 20
+    end_position:
+      bytes: 38
+      line: 2
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: baz
+  trailing_trivia:
+    - start_position:
+        bytes: 38
+        line: 2
+        character: 23
+      end_position:
+        bytes: 39
+        line: 2
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 39
+      line: 3
+      character: 1
+    end_position:
+      bytes: 40
+      line: 3
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: c
+  trailing_trivia:
+    - start_position:
+        bytes: 40
+        line: 3
+        character: 2
+      end_position:
+        bytes: 41
+        line: 3
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 3
+      character: 3
+    end_position:
+      bytes: 42
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 42
+        line: 3
+        character: 4
+      end_position:
+        bytes: 43
+        line: 3
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 43
+      line: 3
+      character: 5
+    end_position:
+      bytes: 44
+      line: 3
+      character: 6
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 44
+        line: 3
+        character: 6
+      end_position:
+        bytes: 45
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 3
+      character: 7
+    end_position:
+      bytes: 46
+      line: 3
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 3
+        character: 8
+      end_position:
+        bytes: 47
+        line: 3
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 3
+      character: 9
+    end_position:
+      bytes: 48
+      line: 3
+      character: 10
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 48
+        line: 3
+        character: 10
+      end_position:
+        bytes: 49
+        line: 3
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 49
+      line: 3
+      character: 11
+    end_position:
+      bytes: 50
+      line: 3
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "*"
+  trailing_trivia:
+    - start_position:
+        bytes: 50
+        line: 3
+        character: 12
+      end_position:
+        bytes: 51
+        line: 3
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 51
+      line: 3
+      character: 13
+    end_position:
+      bytes: 52
+      line: 3
+      character: 14
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia:
+    - start_position:
+        bytes: 52
+        line: 3
+        character: 14
+      end_position:
+        bytes: 53
+        line: 3
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 3
+      character: 15
+    end_position:
+      bytes: 54
+      line: 3
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia:
+    - start_position:
+        bytes: 54
+        line: 3
+        character: 16
+      end_position:
+        bytes: 55
+        line: 3
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 3
+      character: 17
+    end_position:
+      bytes: 56
+      line: 3
+      character: 18
+    token_type:
+      type: Number
+      text: "4"
+  trailing_trivia:
+    - start_position:
+        bytes: 56
+        line: 3
+        character: 18
+      end_position:
+        bytes: 57
+        line: 3
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 57
+      line: 3
+      character: 19
+    end_position:
+      bytes: 58
+      line: 3
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: ^
+  trailing_trivia:
+    - start_position:
+        bytes: 58
+        line: 3
+        character: 20
+      end_position:
+        bytes: 59
+        line: 3
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 59
+      line: 3
+      character: 21
+    end_position:
+      bytes: 60
+      line: 3
+      character: 22
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 60
+        line: 3
+        character: 22
+      end_position:
+        bytes: 61
+        line: 3
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 61
+      line: 4
+      character: 1
+    end_position:
+      bytes: 62
+      line: 4
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: d
+  trailing_trivia:
+    - start_position:
+        bytes: 62
+        line: 4
+        character: 2
+      end_position:
+        bytes: 63
+        line: 4
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 63
+      line: 4
+      character: 3
+    end_position:
+      bytes: 64
+      line: 4
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 64
+        line: 4
+        character: 4
+      end_position:
+        bytes: 65
+        line: 4
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 65
+      line: 4
+      character: 5
+    end_position:
+      bytes: 66
+      line: 4
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia:
+    - start_position:
+        bytes: 66
+        line: 4
+        character: 6
+      end_position:
+        bytes: 67
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 67
+      line: 4
+      character: 7
+    end_position:
+      bytes: 68
+      line: 4
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 68
+        line: 4
+        character: 8
+      end_position:
+        bytes: 69
+        line: 4
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 69
+      line: 4
+      character: 9
+    end_position:
+      bytes: 70
+      line: 4
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: i
+  trailing_trivia:
+    - start_position:
+        bytes: 70
+        line: 4
+        character: 10
+      end_position:
+        bytes: 71
+        line: 4
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 71
+      line: 4
+      character: 11
+    end_position:
+      bytes: 72
+      line: 4
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia:
+    - start_position:
+        bytes: 72
+        line: 4
+        character: 12
+      end_position:
+        bytes: 73
+        line: 4
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 73
+      line: 4
+      character: 13
+    end_position:
+      bytes: 74
+      line: 4
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia:
+    - start_position:
+        bytes: 74
+        line: 4
+        character: 14
+      end_position:
+        bytes: 75
+        line: 4
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 4
+      character: 15
+    end_position:
+      bytes: 76
+      line: 4
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: /
+  trailing_trivia:
+    - start_position:
+        bytes: 76
+        line: 4
+        character: 16
+      end_position:
+        bytes: 77
+        line: 4
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 77
+      line: 4
+      character: 17
+    end_position:
+      bytes: 78
+      line: 4
+      character: 18
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 78
+        line: 4
+        character: 18
+      end_position:
+        bytes: 79
+        line: 4
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 79
+      line: 4
+      character: 19
+    end_position:
+      bytes: 80
+      line: 4
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 80
+        line: 4
+        character: 20
+      end_position:
+        bytes: 81
+        line: 4
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 81
+      line: 4
+      character: 21
+    end_position:
+      bytes: 82
+      line: 4
+      character: 22
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 82
+        line: 4
+        character: 22
+      end_position:
+        bytes: 83
+        line: 4
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 83
+      line: 5
+      character: 1
+    end_position:
+      bytes: 84
+      line: 5
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: e
+  trailing_trivia:
+    - start_position:
+        bytes: 84
+        line: 5
+        character: 2
+      end_position:
+        bytes: 85
+        line: 5
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 5
+      character: 3
+    end_position:
+      bytes: 86
+      line: 5
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 86
+        line: 5
+        character: 4
+      end_position:
+        bytes: 87
+        line: 5
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 87
+      line: 5
+      character: 5
+    end_position:
+      bytes: 88
+      line: 5
+      character: 6
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 88
+        line: 5
+        character: 6
+      end_position:
+        bytes: 89
+        line: 5
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 89
+      line: 5
+      character: 7
+    end_position:
+      bytes: 90
+      line: 5
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 90
+        line: 5
+        character: 8
+      end_position:
+        bytes: 91
+        line: 5
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 91
+      line: 5
+      character: 9
+    end_position:
+      bytes: 92
+      line: 5
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 92
+        line: 5
+        character: 10
+      end_position:
+        bytes: 93
+        line: 5
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 93
+      line: 5
+      character: 11
+    end_position:
+      bytes: 94
+      line: 5
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: ^
+  trailing_trivia:
+    - start_position:
+        bytes: 94
+        line: 5
+        character: 12
+      end_position:
+        bytes: 95
+        line: 5
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 95
+      line: 5
+      character: 13
+    end_position:
+      bytes: 96
+      line: 5
+      character: 14
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 96
+        line: 5
+        character: 14
+      end_position:
+        bytes: 97
+        line: 5
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 97
+      line: 5
+      character: 15
+    end_position:
+      bytes: 98
+      line: 5
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "*"
+  trailing_trivia:
+    - start_position:
+        bytes: 98
+        line: 5
+        character: 16
+      end_position:
+        bytes: 99
+        line: 5
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 99
+      line: 5
+      character: 17
+    end_position:
+      bytes: 100
+      line: 5
+      character: 18
+    token_type:
+      type: Number
+      text: "8"
+  trailing_trivia:
+    - start_position:
+        bytes: 100
+        line: 5
+        character: 18
+      end_position:
+        bytes: 101
+        line: 5
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 101
+      line: 6
+      character: 1
+    end_position:
+      bytes: 102
+      line: 6
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: f
+  trailing_trivia:
+    - start_position:
+        bytes: 102
+        line: 6
+        character: 2
+      end_position:
+        bytes: 103
+        line: 6
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 103
+      line: 6
+      character: 3
+    end_position:
+      bytes: 104
+      line: 6
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 104
+        line: 6
+        character: 4
+      end_position:
+        bytes: 105
+        line: 6
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 105
+      line: 6
+      character: 5
+    end_position:
+      bytes: 106
+      line: 6
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia:
+    - start_position:
+        bytes: 106
+        line: 6
+        character: 6
+      end_position:
+        bytes: 107
+        line: 6
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 107
+      line: 6
+      character: 7
+    end_position:
+      bytes: 108
+      line: 6
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia:
+    - start_position:
+        bytes: 108
+        line: 6
+        character: 8
+      end_position:
+        bytes: 109
+        line: 6
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 109
+      line: 6
+      character: 9
+    end_position:
+      bytes: 110
+      line: 6
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 110
+        line: 6
+        character: 10
+      end_position:
+        bytes: 111
+        line: 6
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 111
+      line: 6
+      character: 11
+    end_position:
+      bytes: 114
+      line: 6
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 114
+        line: 6
+        character: 14
+      end_position:
+        bytes: 115
+        line: 6
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 115
+      line: 6
+      character: 15
+    end_position:
+      bytes: 116
+      line: 6
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 116
+        line: 6
+        character: 16
+      end_position:
+        bytes: 117
+        line: 6
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 117
+      line: 6
+      character: 17
+    end_position:
+      bytes: 119
+      line: 6
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "<="
+  trailing_trivia:
+    - start_position:
+        bytes: 119
+        line: 6
+        character: 19
+      end_position:
+        bytes: 120
+        line: 6
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 120
+      line: 6
+      character: 20
+    end_position:
+      bytes: 121
+      line: 6
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: z
+  trailing_trivia:
+    - start_position:
+        bytes: 121
+        line: 6
+        character: 21
+      end_position:
+        bytes: 122
+        line: 6
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 122
+      line: 7
+      character: 1
+    end_position:
+      bytes: 123
+      line: 7
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: g
+  trailing_trivia:
+    - start_position:
+        bytes: 123
+        line: 7
+        character: 2
+      end_position:
+        bytes: 124
+        line: 7
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 124
+      line: 7
+      character: 3
+    end_position:
+      bytes: 125
+      line: 7
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 125
+        line: 7
+        character: 4
+      end_position:
+        bytes: 126
+        line: 7
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 126
+      line: 7
+      character: 5
+    end_position:
+      bytes: 127
+      line: 7
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 127
+      line: 7
+      character: 6
+    end_position:
+      bytes: 128
+      line: 7
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 128
+        line: 7
+        character: 7
+      end_position:
+        bytes: 129
+        line: 7
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 129
+      line: 7
+      character: 8
+    end_position:
+      bytes: 130
+      line: 7
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ^
+  trailing_trivia:
+    - start_position:
+        bytes: 130
+        line: 7
+        character: 9
+      end_position:
+        bytes: 131
+        line: 7
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 131
+      line: 7
+      character: 10
+    end_position:
+      bytes: 132
+      line: 7
+      character: 11
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 132
+        line: 7
+        character: 11
+      end_position:
+        bytes: 133
+        line: 7
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 133
+      line: 8
+      character: 1
+    end_position:
+      bytes: 134
+      line: 8
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: h
+  trailing_trivia:
+    - start_position:
+        bytes: 134
+        line: 8
+        character: 2
+      end_position:
+        bytes: 135
+        line: 8
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 135
+      line: 8
+      character: 3
+    end_position:
+      bytes: 136
+      line: 8
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 136
+        line: 8
+        character: 4
+      end_position:
+        bytes: 137
+        line: 8
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 137
+      line: 8
+      character: 5
+    end_position:
+      bytes: 138
+      line: 8
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 138
+        line: 8
+        character: 6
+      end_position:
+        bytes: 139
+        line: 8
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 139
+      line: 8
+      character: 7
+    end_position:
+      bytes: 140
+      line: 8
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ^
+  trailing_trivia:
+    - start_position:
+        bytes: 140
+        line: 8
+        character: 8
+      end_position:
+        bytes: 141
+        line: 8
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 141
+      line: 8
+      character: 9
+    end_position:
+      bytes: 142
+      line: 8
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 142
+        line: 8
+        character: 10
+      end_position:
+        bytes: 143
+        line: 8
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 143
+      line: 8
+      character: 11
+    end_position:
+      bytes: 144
+      line: 8
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: ^
+  trailing_trivia:
+    - start_position:
+        bytes: 144
+        line: 8
+        character: 12
+      end_position:
+        bytes: 145
+        line: 8
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 145
+      line: 8
+      character: 13
+    end_position:
+      bytes: 146
+      line: 8
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: z
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 146
+      line: 8
+      character: 14
+    end_position:
+      bytes: 146
+      line: 8
+      character: 14
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/call-1/tokens.snap
+++ b/full-moon/tests/cases/pass/call-1/tokens.snap
@@ -4,190 +4,232 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/call-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 7
-    line: 2
-    character: 1
-  end_position:
-    bytes: 11
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 11
-    line: 2
-    character: 5
-  end_position:
-    bytes: 12
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 12
-    line: 2
-    character: 6
-  end_position:
-    bytes: 13
-    line: 2
-    character: 7
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 13
-    line: 2
-    character: 7
-  end_position:
-    bytes: 14
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 2
-    character: 8
-  end_position:
-    bytes: 15
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 3
-    character: 1
-  end_position:
-    bytes: 19
-    line: 3
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 19
-    line: 3
-    character: 5
-  end_position:
-    bytes: 20
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 20
-    line: 3
-    character: 6
-  end_position:
-    bytes: 21
-    line: 3
-    character: 7
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 21
-    line: 3
-    character: 7
-  end_position:
-    bytes: 22
-    line: 3
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 22
-    line: 3
-    character: 8
-  end_position:
-    bytes: 23
-    line: 3
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 23
-    line: 3
-    character: 9
-  end_position:
-    bytes: 24
-    line: 3
-    character: 10
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 24
-    line: 3
-    character: 10
-  end_position:
-    bytes: 25
-    line: 3
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 25
-    line: 3
-    character: 11
-  end_position:
-    bytes: 25
-    line: 3
-    character: 11
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 2
+      character: 1
+    end_position:
+      bytes: 11
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 5
+    end_position:
+      bytes: 12
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 6
+    end_position:
+      bytes: 13
+      line: 2
+      character: 7
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 7
+    end_position:
+      bytes: 14
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 8
+      end_position:
+        bytes: 15
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 3
+      character: 1
+    end_position:
+      bytes: 19
+      line: 3
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 3
+      character: 5
+    end_position:
+      bytes: 20
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 3
+      character: 6
+    end_position:
+      bytes: 21
+      line: 3
+      character: 7
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 7
+    end_position:
+      bytes: 22
+      line: 3
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 22
+        line: 3
+        character: 8
+      end_position:
+        bytes: 23
+        line: 3
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 3
+      character: 9
+    end_position:
+      bytes: 24
+      line: 3
+      character: 10
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 3
+      character: 10
+    end_position:
+      bytes: 25
+      line: 3
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 3
+      character: 11
+    end_position:
+      bytes: 25
+      line: 3
+      character: 11
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/call-2/tokens.snap
+++ b/full-moon/tests/cases/pass/call-2/tokens.snap
@@ -4,159 +4,198 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/call-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: StringLiteral
-    literal: a
-    quote_type: Double
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 11
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 11
-    line: 2
-    character: 3
-  end_position:
-    bytes: 12
-    line: 2
-    character: 4
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 12
-    line: 2
-    character: 4
-  end_position:
-    bytes: 13
-    line: 2
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 13
-    line: 2
-    character: 5
-  end_position:
-    bytes: 16
-    line: 2
-    character: 8
-  token_type:
-    type: StringLiteral
-    literal: b
-    quote_type: Double
-- start_position:
-    bytes: 16
-    line: 2
-    character: 8
-  end_position:
-    bytes: 17
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 17
-    line: 2
-    character: 9
-  end_position:
-    bytes: 17
-    line: 2
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 1
+      line: 1
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1
+      line: 1
+      character: 2
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: StringLiteral
+      literal: a
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 2
+      character: 1
+    end_position:
+      bytes: 10
+      line: 2
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 11
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 3
+    end_position:
+      bytes: 12
+      line: 2
+      character: 4
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 4
+    end_position:
+      bytes: 13
+      line: 2
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 5
+    end_position:
+      bytes: 16
+      line: 2
+      character: 8
+    token_type:
+      type: StringLiteral
+      literal: b
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 8
+    end_position:
+      bytes: 17
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 9
+    end_position:
+      bytes: 17
+      line: 2
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/do/tokens.snap
+++ b/full-moon/tests/cases/pass/do/tokens.snap
@@ -4,102 +4,120 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/do
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 3
-    line: 2
-    character: 1
-  end_position:
-    bytes: 4
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 4
-    line: 2
-    character: 2
-  end_position:
-    bytes: 8
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 8
-    line: 2
-    character: 6
-  end_position:
-    bytes: 9
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 9
-    line: 2
-    character: 7
-  end_position:
-    bytes: 10
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 10
-    line: 2
-    character: 8
-  end_position:
-    bytes: 11
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 11
-    line: 3
-    character: 1
-  end_position:
-    bytes: 14
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 14
-    line: 3
-    character: 4
-  end_position:
-    bytes: 14
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 3
+        line: 2
+        character: 1
+      end_position:
+        bytes: 4
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 4
+      line: 2
+      character: 2
+    end_position:
+      bytes: 8
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 2
+      character: 6
+    end_position:
+      bytes: 9
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 2
+      character: 7
+    end_position:
+      bytes: 10
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 2
+        character: 8
+      end_position:
+        bytes: 11
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 3
+      character: 1
+    end_position:
+      bytes: 14
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 3
+      character: 4
+    end_position:
+      bytes: 14
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/empty/tokens.snap
+++ b/full-moon/tests/cases/pass/empty/tokens.snap
@@ -4,14 +4,17 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/empty
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 0
-    line: 1
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 0
+      line: 1
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/exponents/tokens.snap
+++ b/full-moon/tests/cases/pass/exponents/tokens.snap
@@ -4,267 +4,306 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/exponents
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: num
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Number
-    text: "1e5"
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 16
-    line: 2
-    character: 1
-  end_position:
-    bytes: 21
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 21
-    line: 2
-    character: 6
-  end_position:
-    bytes: 22
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 2
-    character: 7
-  end_position:
-    bytes: 26
-    line: 2
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num2
-- start_position:
-    bytes: 26
-    line: 2
-    character: 11
-  end_position:
-    bytes: 27
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 27
-    line: 2
-    character: 12
-  end_position:
-    bytes: 28
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 28
-    line: 2
-    character: 13
-  end_position:
-    bytes: 29
-    line: 2
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 29
-    line: 2
-    character: 14
-  end_position:
-    bytes: 33
-    line: 2
-    character: 18
-  token_type:
-    type: Number
-    text: "1e-5"
-- start_position:
-    bytes: 33
-    line: 2
-    character: 18
-  end_position:
-    bytes: 34
-    line: 2
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 34
-    line: 3
-    character: 1
-  end_position:
-    bytes: 39
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 39
-    line: 3
-    character: 6
-  end_position:
-    bytes: 40
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 3
-    character: 7
-  end_position:
-    bytes: 44
-    line: 3
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num3
-- start_position:
-    bytes: 44
-    line: 3
-    character: 11
-  end_position:
-    bytes: 45
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 45
-    line: 3
-    character: 12
-  end_position:
-    bytes: 46
-    line: 3
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 46
-    line: 3
-    character: 13
-  end_position:
-    bytes: 47
-    line: 3
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 47
-    line: 3
-    character: 14
-  end_position:
-    bytes: 51
-    line: 3
-    character: 18
-  token_type:
-    type: Number
-    text: "1e+5"
-- start_position:
-    bytes: 51
-    line: 3
-    character: 18
-  end_position:
-    bytes: 51
-    line: 3
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: num
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Number
+      text: "1e5"
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 1
+    end_position:
+      bytes: 21
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 6
+      end_position:
+        bytes: 22
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 7
+    end_position:
+      bytes: 26
+      line: 2
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num2
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 11
+      end_position:
+        bytes: 27
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 12
+    end_position:
+      bytes: 28
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 28
+        line: 2
+        character: 13
+      end_position:
+        bytes: 29
+        line: 2
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 2
+      character: 14
+    end_position:
+      bytes: 33
+      line: 2
+      character: 18
+    token_type:
+      type: Number
+      text: "1e-5"
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 2
+        character: 18
+      end_position:
+        bytes: 34
+        line: 2
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 3
+      character: 1
+    end_position:
+      bytes: 39
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 3
+        character: 6
+      end_position:
+        bytes: 40
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 3
+      character: 7
+    end_position:
+      bytes: 44
+      line: 3
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num3
+  trailing_trivia:
+    - start_position:
+        bytes: 44
+        line: 3
+        character: 11
+      end_position:
+        bytes: 45
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 3
+      character: 12
+    end_position:
+      bytes: 46
+      line: 3
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 3
+        character: 13
+      end_position:
+        bytes: 47
+        line: 3
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 3
+      character: 14
+    end_position:
+      bytes: 51
+      line: 3
+      character: 18
+    token_type:
+      type: Number
+      text: "1e+5"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 51
+      line: 3
+      character: 18
+    end_position:
+      bytes: 51
+      line: 3
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/fractional-numbers/tokens.snap
+++ b/full-moon/tests/cases/pass/fractional-numbers/tokens.snap
@@ -4,454 +4,517 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/fractional-numbers
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: num
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Number
-    text: "0.5"
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 16
-    line: 2
-    character: 1
-  end_position:
-    bytes: 21
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 21
-    line: 2
-    character: 6
-  end_position:
-    bytes: 22
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 2
-    character: 7
-  end_position:
-    bytes: 26
-    line: 2
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num2
-- start_position:
-    bytes: 26
-    line: 2
-    character: 11
-  end_position:
-    bytes: 27
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 27
-    line: 2
-    character: 12
-  end_position:
-    bytes: 28
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 28
-    line: 2
-    character: 13
-  end_position:
-    bytes: 29
-    line: 2
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 29
-    line: 2
-    character: 14
-  end_position:
-    bytes: 34
-    line: 2
-    character: 19
-  token_type:
-    type: Number
-    text: "0.5e5"
-- start_position:
-    bytes: 34
-    line: 2
-    character: 19
-  end_position:
-    bytes: 35
-    line: 2
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 35
-    line: 3
-    character: 1
-  end_position:
-    bytes: 40
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 40
-    line: 3
-    character: 6
-  end_position:
-    bytes: 41
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 41
-    line: 3
-    character: 7
-  end_position:
-    bytes: 45
-    line: 3
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num3
-- start_position:
-    bytes: 45
-    line: 3
-    character: 11
-  end_position:
-    bytes: 46
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 46
-    line: 3
-    character: 12
-  end_position:
-    bytes: 47
-    line: 3
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 47
-    line: 3
-    character: 13
-  end_position:
-    bytes: 48
-    line: 3
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 48
-    line: 3
-    character: 14
-  end_position:
-    bytes: 50
-    line: 3
-    character: 16
-  token_type:
-    type: Number
-    text: ".5"
-- start_position:
-    bytes: 50
-    line: 3
-    character: 16
-  end_position:
-    bytes: 51
-    line: 3
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 51
-    line: 4
-    character: 1
-  end_position:
-    bytes: 56
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 56
-    line: 4
-    character: 6
-  end_position:
-    bytes: 57
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 57
-    line: 4
-    character: 7
-  end_position:
-    bytes: 61
-    line: 4
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num4
-- start_position:
-    bytes: 61
-    line: 4
-    character: 11
-  end_position:
-    bytes: 62
-    line: 4
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 62
-    line: 4
-    character: 12
-  end_position:
-    bytes: 63
-    line: 4
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 63
-    line: 4
-    character: 13
-  end_position:
-    bytes: 64
-    line: 4
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 64
-    line: 4
-    character: 14
-  end_position:
-    bytes: 68
-    line: 4
-    character: 18
-  token_type:
-    type: Number
-    text: ".5e5"
-- start_position:
-    bytes: 68
-    line: 4
-    character: 18
-  end_position:
-    bytes: 69
-    line: 4
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 69
-    line: 5
-    character: 1
-  end_position:
-    bytes: 74
-    line: 5
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 74
-    line: 5
-    character: 6
-  end_position:
-    bytes: 75
-    line: 5
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 75
-    line: 5
-    character: 7
-  end_position:
-    bytes: 79
-    line: 5
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num5
-- start_position:
-    bytes: 79
-    line: 5
-    character: 11
-  end_position:
-    bytes: 80
-    line: 5
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 80
-    line: 5
-    character: 12
-  end_position:
-    bytes: 81
-    line: 5
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 81
-    line: 5
-    character: 13
-  end_position:
-    bytes: 82
-    line: 5
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 82
-    line: 5
-    character: 14
-  end_position:
-    bytes: 84
-    line: 5
-    character: 16
-  token_type:
-    type: Number
-    text: "1."
-- start_position:
-    bytes: 84
-    line: 5
-    character: 16
-  end_position:
-    bytes: 85
-    line: 5
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 85
-    line: 6
-    character: 1
-  end_position:
-    bytes: 85
-    line: 6
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: num
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Number
+      text: "0.5"
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 1
+    end_position:
+      bytes: 21
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 6
+      end_position:
+        bytes: 22
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 7
+    end_position:
+      bytes: 26
+      line: 2
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num2
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 11
+      end_position:
+        bytes: 27
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 12
+    end_position:
+      bytes: 28
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 28
+        line: 2
+        character: 13
+      end_position:
+        bytes: 29
+        line: 2
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 2
+      character: 14
+    end_position:
+      bytes: 34
+      line: 2
+      character: 19
+    token_type:
+      type: Number
+      text: "0.5e5"
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 2
+        character: 19
+      end_position:
+        bytes: 35
+        line: 2
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 3
+      character: 1
+    end_position:
+      bytes: 40
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 40
+        line: 3
+        character: 6
+      end_position:
+        bytes: 41
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 3
+      character: 7
+    end_position:
+      bytes: 45
+      line: 3
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num3
+  trailing_trivia:
+    - start_position:
+        bytes: 45
+        line: 3
+        character: 11
+      end_position:
+        bytes: 46
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 46
+      line: 3
+      character: 12
+    end_position:
+      bytes: 47
+      line: 3
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 47
+        line: 3
+        character: 13
+      end_position:
+        bytes: 48
+        line: 3
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 3
+      character: 14
+    end_position:
+      bytes: 50
+      line: 3
+      character: 16
+    token_type:
+      type: Number
+      text: ".5"
+  trailing_trivia:
+    - start_position:
+        bytes: 50
+        line: 3
+        character: 16
+      end_position:
+        bytes: 51
+        line: 3
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 51
+      line: 4
+      character: 1
+    end_position:
+      bytes: 56
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 56
+        line: 4
+        character: 6
+      end_position:
+        bytes: 57
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 57
+      line: 4
+      character: 7
+    end_position:
+      bytes: 61
+      line: 4
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num4
+  trailing_trivia:
+    - start_position:
+        bytes: 61
+        line: 4
+        character: 11
+      end_position:
+        bytes: 62
+        line: 4
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 62
+      line: 4
+      character: 12
+    end_position:
+      bytes: 63
+      line: 4
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 63
+        line: 4
+        character: 13
+      end_position:
+        bytes: 64
+        line: 4
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 64
+      line: 4
+      character: 14
+    end_position:
+      bytes: 68
+      line: 4
+      character: 18
+    token_type:
+      type: Number
+      text: ".5e5"
+  trailing_trivia:
+    - start_position:
+        bytes: 68
+        line: 4
+        character: 18
+      end_position:
+        bytes: 69
+        line: 4
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 69
+      line: 5
+      character: 1
+    end_position:
+      bytes: 74
+      line: 5
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 74
+        line: 5
+        character: 6
+      end_position:
+        bytes: 75
+        line: 5
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 5
+      character: 7
+    end_position:
+      bytes: 79
+      line: 5
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num5
+  trailing_trivia:
+    - start_position:
+        bytes: 79
+        line: 5
+        character: 11
+      end_position:
+        bytes: 80
+        line: 5
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 80
+      line: 5
+      character: 12
+    end_position:
+      bytes: 81
+      line: 5
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 81
+        line: 5
+        character: 13
+      end_position:
+        bytes: 82
+        line: 5
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 82
+      line: 5
+      character: 14
+    end_position:
+      bytes: 84
+      line: 5
+      character: 16
+    token_type:
+      type: Number
+      text: "1."
+  trailing_trivia:
+    - start_position:
+        bytes: 84
+        line: 5
+        character: 16
+      end_position:
+        bytes: 85
+        line: 5
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 6
+      character: 1
+    end_position:
+      bytes: 85
+      line: 6
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/function-declaration-1/tokens.snap
+++ b/full-moon/tests/cases/pass/function-declaration-1/tokens.snap
@@ -4,146 +4,173 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/function-declaration-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 13
-    line: 2
-    character: 1
-  end_position:
-    bytes: 14
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 14
-    line: 2
-    character: 2
-  end_position:
-    bytes: 18
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 18
-    line: 2
-    character: 6
-  end_position:
-    bytes: 19
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 2
-    character: 7
-  end_position:
-    bytes: 20
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 20
-    line: 2
-    character: 8
-  end_position:
-    bytes: 21
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 21
-    line: 3
-    character: 1
-  end_position:
-    bytes: 24
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 24
-    line: 3
-    character: 4
-  end_position:
-    bytes: 24
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 1
+        character: 13
+      end_position:
+        bytes: 13
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 13
+        line: 2
+        character: 1
+      end_position:
+        bytes: 14
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 2
+    end_position:
+      bytes: 18
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 6
+    end_position:
+      bytes: 19
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 7
+    end_position:
+      bytes: 20
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 2
+        character: 8
+      end_position:
+        bytes: 21
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 1
+    end_position:
+      bytes: 24
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 3
+      character: 4
+    end_position:
+      bytes: 24
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/function-declaration-2/tokens.snap
+++ b/full-moon/tests/cases/pass/function-declaration-2/tokens.snap
@@ -4,135 +4,165 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/function-declaration-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: z
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: z
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/function-shortcuts/tokens.snap
+++ b/full-moon/tests/cases/pass/function-shortcuts/tokens.snap
@@ -4,180 +4,207 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/function-shortcuts
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 2
-    character: 1
-  end_position:
-    bytes: 19
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 19
-    line: 2
-    character: 5
-  end_position:
-    bytes: 20
-    line: 2
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 2
-    character: 6
-  end_position:
-    bytes: 27
-    line: 2
-    character: 13
-  token_type:
-    type: StringLiteral
-    literal: hello
-    quote_type: Double
-- start_position:
-    bytes: 27
-    line: 2
-    character: 13
-  end_position:
-    bytes: 27
-    line: 2
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 1
+        character: 13
+      end_position:
+        bytes: 13
+        line: 1
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 1
+    end_position:
+      bytes: 19
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 5
+      end_position:
+        bytes: 20
+        line: 2
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 6
+    end_position:
+      bytes: 27
+      line: 2
+      character: 13
+    token_type:
+      type: StringLiteral
+      literal: hello
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 13
+    end_position:
+      bytes: 27
+      line: 2
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/generic-for-loop-1/tokens.snap
+++ b/full-moon/tests/cases/pass/generic-for-loop-1/tokens.snap
@@ -4,300 +4,354 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/generic-for-loop-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: index
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: value
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: in
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: pairs
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 26
-    line: 1
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 26
-    line: 1
-    character: 27
-  end_position:
-    bytes: 30
-    line: 1
-    character: 31
-  token_type:
-    type: Identifier
-    identifier: list
-- start_position:
-    bytes: 30
-    line: 1
-    character: 31
-  end_position:
-    bytes: 31
-    line: 1
-    character: 32
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 31
-    line: 1
-    character: 32
-  end_position:
-    bytes: 32
-    line: 1
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 32
-    line: 1
-    character: 33
-  end_position:
-    bytes: 34
-    line: 1
-    character: 35
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 34
-    line: 1
-    character: 35
-  end_position:
-    bytes: 35
-    line: 1
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 35
-    line: 2
-    character: 1
-  end_position:
-    bytes: 36
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 36
-    line: 2
-    character: 2
-  end_position:
-    bytes: 40
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 40
-    line: 2
-    character: 6
-  end_position:
-    bytes: 41
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 41
-    line: 2
-    character: 7
-  end_position:
-    bytes: 46
-    line: 2
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: index
-- start_position:
-    bytes: 46
-    line: 2
-    character: 12
-  end_position:
-    bytes: 47
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 47
-    line: 2
-    character: 13
-  end_position:
-    bytes: 48
-    line: 2
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 48
-    line: 2
-    character: 14
-  end_position:
-    bytes: 53
-    line: 2
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: value
-- start_position:
-    bytes: 53
-    line: 2
-    character: 19
-  end_position:
-    bytes: 54
-    line: 2
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 54
-    line: 2
-    character: 20
-  end_position:
-    bytes: 55
-    line: 2
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 55
-    line: 3
-    character: 1
-  end_position:
-    bytes: 58
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 58
-    line: 3
-    character: 4
-  end_position:
-    bytes: 58
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: index
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: value
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: in
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: pairs
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 26
+      line: 1
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 1
+      character: 27
+    end_position:
+      bytes: 30
+      line: 1
+      character: 31
+    token_type:
+      type: Identifier
+      identifier: list
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 1
+      character: 31
+    end_position:
+      bytes: 31
+      line: 1
+      character: 32
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 1
+        character: 32
+      end_position:
+        bytes: 32
+        line: 1
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 1
+      character: 33
+    end_position:
+      bytes: 34
+      line: 1
+      character: 35
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 1
+        character: 35
+      end_position:
+        bytes: 35
+        line: 1
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 35
+        line: 2
+        character: 1
+      end_position:
+        bytes: 36
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 36
+      line: 2
+      character: 2
+    end_position:
+      bytes: 40
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 6
+    end_position:
+      bytes: 41
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 2
+      character: 7
+    end_position:
+      bytes: 46
+      line: 2
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: index
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 46
+      line: 2
+      character: 12
+    end_position:
+      bytes: 47
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 47
+        line: 2
+        character: 13
+      end_position:
+        bytes: 48
+        line: 2
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 2
+      character: 14
+    end_position:
+      bytes: 53
+      line: 2
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: value
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 2
+      character: 19
+    end_position:
+      bytes: 54
+      line: 2
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 54
+        line: 2
+        character: 20
+      end_position:
+        bytes: 55
+        line: 2
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 3
+      character: 1
+    end_position:
+      bytes: 58
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 3
+      character: 4
+    end_position:
+      bytes: 58
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/generic-for-loop-2/tokens.snap
+++ b/full-moon/tests/cases/pass/generic-for-loop-2/tokens.snap
@@ -4,300 +4,351 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/generic-for-loop-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: index
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: value
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: in
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: next
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 26
-    line: 1
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 26
-    line: 1
-    character: 27
-  end_position:
-    bytes: 30
-    line: 1
-    character: 31
-  token_type:
-    type: Identifier
-    identifier: list
-- start_position:
-    bytes: 30
-    line: 1
-    character: 31
-  end_position:
-    bytes: 31
-    line: 1
-    character: 32
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 31
-    line: 1
-    character: 32
-  end_position:
-    bytes: 33
-    line: 1
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 33
-    line: 1
-    character: 34
-  end_position:
-    bytes: 34
-    line: 1
-    character: 34
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 34
-    line: 2
-    character: 1
-  end_position:
-    bytes: 35
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 35
-    line: 2
-    character: 2
-  end_position:
-    bytes: 39
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 39
-    line: 2
-    character: 6
-  end_position:
-    bytes: 40
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 40
-    line: 2
-    character: 7
-  end_position:
-    bytes: 45
-    line: 2
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: index
-- start_position:
-    bytes: 45
-    line: 2
-    character: 12
-  end_position:
-    bytes: 46
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 46
-    line: 2
-    character: 13
-  end_position:
-    bytes: 47
-    line: 2
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 47
-    line: 2
-    character: 14
-  end_position:
-    bytes: 52
-    line: 2
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: value
-- start_position:
-    bytes: 52
-    line: 2
-    character: 19
-  end_position:
-    bytes: 53
-    line: 2
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 53
-    line: 2
-    character: 20
-  end_position:
-    bytes: 54
-    line: 2
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 54
-    line: 3
-    character: 1
-  end_position:
-    bytes: 57
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 57
-    line: 3
-    character: 4
-  end_position:
-    bytes: 57
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: index
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: value
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: in
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 24
+      line: 1
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: next
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 1
+      character: 25
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 1
+        character: 26
+      end_position:
+        bytes: 26
+        line: 1
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 1
+      character: 27
+    end_position:
+      bytes: 30
+      line: 1
+      character: 31
+    token_type:
+      type: Identifier
+      identifier: list
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 1
+        character: 31
+      end_position:
+        bytes: 31
+        line: 1
+        character: 32
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 1
+      character: 32
+    end_position:
+      bytes: 33
+      line: 1
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 1
+        character: 34
+      end_position:
+        bytes: 34
+        line: 1
+        character: 34
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 34
+        line: 2
+        character: 1
+      end_position:
+        bytes: 35
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 35
+      line: 2
+      character: 2
+    end_position:
+      bytes: 39
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 39
+      line: 2
+      character: 6
+    end_position:
+      bytes: 40
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 7
+    end_position:
+      bytes: 45
+      line: 2
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: index
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 2
+      character: 12
+    end_position:
+      bytes: 46
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 2
+        character: 13
+      end_position:
+        bytes: 47
+        line: 2
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 2
+      character: 14
+    end_position:
+      bytes: 52
+      line: 2
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: value
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 2
+      character: 19
+    end_position:
+      bytes: 53
+      line: 2
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 53
+        line: 2
+        character: 20
+      end_position:
+        bytes: 54
+        line: 2
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 3
+      character: 1
+    end_position:
+      bytes: 57
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 57
+      line: 3
+      character: 4
+    end_position:
+      bytes: 57
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/gt-lt/tokens.snap
+++ b/full-moon/tests/cases/pass/gt-lt/tokens.snap
@@ -4,498 +4,591 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/gt-lt
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 16
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 16
-    line: 2
-    character: 5
-  end_position:
-    bytes: 17
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 2
-    character: 6
-  end_position:
-    bytes: 18
-    line: 2
-    character: 7
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 18
-    line: 2
-    character: 7
-  end_position:
-    bytes: 19
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 19
-    line: 2
-    character: 8
-  end_position:
-    bytes: 21
-    line: 2
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "<="
-- start_position:
-    bytes: 21
-    line: 2
-    character: 10
-  end_position:
-    bytes: 22
-    line: 2
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 2
-    character: 11
-  end_position:
-    bytes: 23
-    line: 2
-    character: 12
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 23
-    line: 2
-    character: 12
-  end_position:
-    bytes: 24
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 24
-    line: 2
-    character: 13
-  end_position:
-    bytes: 25
-    line: 2
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 25
-    line: 3
-    character: 1
-  end_position:
-    bytes: 29
-    line: 3
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 29
-    line: 3
-    character: 5
-  end_position:
-    bytes: 30
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 30
-    line: 3
-    character: 6
-  end_position:
-    bytes: 31
-    line: 3
-    character: 7
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 31
-    line: 3
-    character: 7
-  end_position:
-    bytes: 32
-    line: 3
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 32
-    line: 3
-    character: 8
-  end_position:
-    bytes: 33
-    line: 3
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 33
-    line: 3
-    character: 9
-  end_position:
-    bytes: 34
-    line: 3
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 34
-    line: 3
-    character: 10
-  end_position:
-    bytes: 35
-    line: 3
-    character: 11
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 35
-    line: 3
-    character: 11
-  end_position:
-    bytes: 36
-    line: 3
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 36
-    line: 3
-    character: 12
-  end_position:
-    bytes: 37
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 37
-    line: 4
-    character: 1
-  end_position:
-    bytes: 41
-    line: 4
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 41
-    line: 4
-    character: 5
-  end_position:
-    bytes: 42
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 42
-    line: 4
-    character: 6
-  end_position:
-    bytes: 43
-    line: 4
-    character: 7
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 43
-    line: 4
-    character: 7
-  end_position:
-    bytes: 44
-    line: 4
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 44
-    line: 4
-    character: 8
-  end_position:
-    bytes: 46
-    line: 4
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: ">="
-- start_position:
-    bytes: 46
-    line: 4
-    character: 10
-  end_position:
-    bytes: 47
-    line: 4
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 47
-    line: 4
-    character: 11
-  end_position:
-    bytes: 48
-    line: 4
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 48
-    line: 4
-    character: 12
-  end_position:
-    bytes: 49
-    line: 4
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 49
-    line: 4
-    character: 13
-  end_position:
-    bytes: 50
-    line: 4
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 50
-    line: 5
-    character: 1
-  end_position:
-    bytes: 54
-    line: 5
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 54
-    line: 5
-    character: 5
-  end_position:
-    bytes: 55
-    line: 5
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 55
-    line: 5
-    character: 6
-  end_position:
-    bytes: 56
-    line: 5
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 56
-    line: 5
-    character: 7
-  end_position:
-    bytes: 57
-    line: 5
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 57
-    line: 5
-    character: 8
-  end_position:
-    bytes: 59
-    line: 5
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: ">="
-- start_position:
-    bytes: 59
-    line: 5
-    character: 10
-  end_position:
-    bytes: 60
-    line: 5
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 60
-    line: 5
-    character: 11
-  end_position:
-    bytes: 61
-    line: 5
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 61
-    line: 5
-    character: 12
-  end_position:
-    bytes: 62
-    line: 5
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 62
-    line: 5
-    character: 13
-  end_position:
-    bytes: 62
-    line: 5
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 1
+    end_position:
+      bytes: 16
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 5
+    end_position:
+      bytes: 17
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 6
+    end_position:
+      bytes: 18
+      line: 2
+      character: 7
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 2
+        character: 7
+      end_position:
+        bytes: 19
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 8
+    end_position:
+      bytes: 21
+      line: 2
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "<="
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 10
+      end_position:
+        bytes: 22
+        line: 2
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 11
+    end_position:
+      bytes: 23
+      line: 2
+      character: 12
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 2
+      character: 12
+    end_position:
+      bytes: 24
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 24
+        line: 2
+        character: 13
+      end_position:
+        bytes: 25
+        line: 2
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 3
+      character: 1
+    end_position:
+      bytes: 29
+      line: 3
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 3
+      character: 5
+    end_position:
+      bytes: 30
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 3
+      character: 6
+    end_position:
+      bytes: 31
+      line: 3
+      character: 7
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 3
+        character: 7
+      end_position:
+        bytes: 32
+        line: 3
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 3
+      character: 8
+    end_position:
+      bytes: 33
+      line: 3
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 3
+        character: 9
+      end_position:
+        bytes: 34
+        line: 3
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 3
+      character: 10
+    end_position:
+      bytes: 35
+      line: 3
+      character: 11
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 3
+      character: 11
+    end_position:
+      bytes: 36
+      line: 3
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 36
+        line: 3
+        character: 12
+      end_position:
+        bytes: 37
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 37
+      line: 4
+      character: 1
+    end_position:
+      bytes: 41
+      line: 4
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 4
+      character: 5
+    end_position:
+      bytes: 42
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 4
+      character: 6
+    end_position:
+      bytes: 43
+      line: 4
+      character: 7
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 43
+        line: 4
+        character: 7
+      end_position:
+        bytes: 44
+        line: 4
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 44
+      line: 4
+      character: 8
+    end_position:
+      bytes: 46
+      line: 4
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: ">="
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 4
+        character: 10
+      end_position:
+        bytes: 47
+        line: 4
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 4
+      character: 11
+    end_position:
+      bytes: 48
+      line: 4
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 4
+      character: 12
+    end_position:
+      bytes: 49
+      line: 4
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 49
+        line: 4
+        character: 13
+      end_position:
+        bytes: 50
+        line: 4
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 5
+      character: 1
+    end_position:
+      bytes: 54
+      line: 5
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 5
+      character: 5
+    end_position:
+      bytes: 55
+      line: 5
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 5
+      character: 6
+    end_position:
+      bytes: 56
+      line: 5
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 56
+        line: 5
+        character: 7
+      end_position:
+        bytes: 57
+        line: 5
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 57
+      line: 5
+      character: 8
+    end_position:
+      bytes: 59
+      line: 5
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: ">="
+  trailing_trivia:
+    - start_position:
+        bytes: 59
+        line: 5
+        character: 10
+      end_position:
+        bytes: 60
+        line: 5
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 60
+      line: 5
+      character: 11
+    end_position:
+      bytes: 61
+      line: 5
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 61
+      line: 5
+      character: 12
+    end_position:
+      bytes: 62
+      line: 5
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 62
+      line: 5
+      character: 13
+    end_position:
+      bytes: 62
+      line: 5
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/if-1/tokens.snap
+++ b/full-moon/tests/cases/pass/if-1/tokens.snap
@@ -4,146 +4,170 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/if-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 11
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 11
-    line: 2
-    character: 2
-  end_position:
-    bytes: 15
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 15
-    line: 2
-    character: 6
-  end_position:
-    bytes: 16
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 16
-    line: 2
-    character: 7
-  end_position:
-    bytes: 17
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 17
-    line: 2
-    character: 8
-  end_position:
-    bytes: 18
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 18
-    line: 3
-    character: 1
-  end_position:
-    bytes: 21
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 21
-    line: 3
-    character: 4
-  end_position:
-    bytes: 21
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 10
+        line: 2
+        character: 1
+      end_position:
+        bytes: 11
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 2
+    end_position:
+      bytes: 15
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 6
+    end_position:
+      bytes: 16
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 7
+    end_position:
+      bytes: 17
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 2
+        character: 8
+      end_position:
+        bytes: 18
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 3
+      character: 1
+    end_position:
+      bytes: 21
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 4
+    end_position:
+      bytes: 21
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/if-2/tokens.snap
+++ b/full-moon/tests/cases/pass/if-2/tokens.snap
@@ -4,223 +4,259 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/if-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 11
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 11
-    line: 2
-    character: 2
-  end_position:
-    bytes: 14
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 14
-    line: 2
-    character: 5
-  end_position:
-    bytes: 15
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 2
-    character: 6
-  end_position:
-    bytes: 16
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 16
-    line: 2
-    character: 7
-  end_position:
-    bytes: 17
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 17
-    line: 3
-    character: 1
-  end_position:
-    bytes: 21
-    line: 3
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: else
-- start_position:
-    bytes: 21
-    line: 3
-    character: 5
-  end_position:
-    bytes: 22
-    line: 3
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 22
-    line: 4
-    character: 1
-  end_position:
-    bytes: 23
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 23
-    line: 4
-    character: 2
-  end_position:
-    bytes: 26
-    line: 4
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 26
-    line: 4
-    character: 5
-  end_position:
-    bytes: 27
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 27
-    line: 4
-    character: 6
-  end_position:
-    bytes: 28
-    line: 4
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 28
-    line: 4
-    character: 7
-  end_position:
-    bytes: 29
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 29
-    line: 5
-    character: 1
-  end_position:
-    bytes: 32
-    line: 5
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 32
-    line: 5
-    character: 4
-  end_position:
-    bytes: 32
-    line: 5
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 10
+        line: 2
+        character: 1
+      end_position:
+        bytes: 11
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 2
+    end_position:
+      bytes: 14
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 5
+    end_position:
+      bytes: 15
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 6
+    end_position:
+      bytes: 16
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 2
+        character: 7
+      end_position:
+        bytes: 17
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 3
+      character: 1
+    end_position:
+      bytes: 21
+      line: 3
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: else
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 3
+        character: 5
+      end_position:
+        bytes: 22
+        line: 3
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 22
+        line: 4
+        character: 1
+      end_position:
+        bytes: 23
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 23
+      line: 4
+      character: 2
+    end_position:
+      bytes: 26
+      line: 4
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 4
+      character: 5
+    end_position:
+      bytes: 27
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 4
+      character: 6
+    end_position:
+      bytes: 28
+      line: 4
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 28
+        line: 4
+        character: 7
+      end_position:
+        bytes: 29
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 5
+      character: 1
+    end_position:
+      bytes: 32
+      line: 5
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 5
+      character: 4
+    end_position:
+      bytes: 32
+      line: 5
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/if-3/tokens.snap
+++ b/full-moon/tests/cases/pass/if-3/tokens.snap
@@ -4,267 +4,309 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/if-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 11
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 11
-    line: 2
-    character: 2
-  end_position:
-    bytes: 14
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 14
-    line: 2
-    character: 5
-  end_position:
-    bytes: 15
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 2
-    character: 6
-  end_position:
-    bytes: 16
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 16
-    line: 2
-    character: 7
-  end_position:
-    bytes: 17
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 17
-    line: 3
-    character: 1
-  end_position:
-    bytes: 23
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: elseif
-- start_position:
-    bytes: 23
-    line: 3
-    character: 7
-  end_position:
-    bytes: 24
-    line: 3
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 3
-    character: 8
-  end_position:
-    bytes: 25
-    line: 3
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 25
-    line: 3
-    character: 9
-  end_position:
-    bytes: 26
-    line: 3
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 26
-    line: 3
-    character: 10
-  end_position:
-    bytes: 30
-    line: 3
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 30
-    line: 3
-    character: 14
-  end_position:
-    bytes: 31
-    line: 3
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 31
-    line: 4
-    character: 1
-  end_position:
-    bytes: 32
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 32
-    line: 4
-    character: 2
-  end_position:
-    bytes: 35
-    line: 4
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 35
-    line: 4
-    character: 5
-  end_position:
-    bytes: 36
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 36
-    line: 4
-    character: 6
-  end_position:
-    bytes: 37
-    line: 4
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 37
-    line: 4
-    character: 7
-  end_position:
-    bytes: 38
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 38
-    line: 5
-    character: 1
-  end_position:
-    bytes: 41
-    line: 5
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 41
-    line: 5
-    character: 4
-  end_position:
-    bytes: 41
-    line: 5
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 10
+        line: 2
+        character: 1
+      end_position:
+        bytes: 11
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 2
+    end_position:
+      bytes: 14
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 5
+    end_position:
+      bytes: 15
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 6
+    end_position:
+      bytes: 16
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 2
+        character: 7
+      end_position:
+        bytes: 17
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 3
+      character: 1
+    end_position:
+      bytes: 23
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: elseif
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 3
+        character: 7
+      end_position:
+        bytes: 24
+        line: 3
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 3
+      character: 8
+    end_position:
+      bytes: 25
+      line: 3
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 3
+        character: 9
+      end_position:
+        bytes: 26
+        line: 3
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 3
+      character: 10
+    end_position:
+      bytes: 30
+      line: 3
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 3
+        character: 14
+      end_position:
+        bytes: 31
+        line: 3
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 31
+        line: 4
+        character: 1
+      end_position:
+        bytes: 32
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 32
+      line: 4
+      character: 2
+    end_position:
+      bytes: 35
+      line: 4
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 4
+      character: 5
+    end_position:
+      bytes: 36
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 4
+      character: 6
+    end_position:
+      bytes: 37
+      line: 4
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 37
+        line: 4
+        character: 7
+      end_position:
+        bytes: 38
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 5
+      character: 1
+    end_position:
+      bytes: 41
+      line: 5
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 5
+      character: 4
+    end_position:
+      bytes: 41
+      line: 5
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/if-4/tokens.snap
+++ b/full-moon/tests/cases/pass/if-4/tokens.snap
@@ -4,344 +4,398 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/if-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 1
-  end_position:
-    bytes: 11
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 11
-    line: 2
-    character: 2
-  end_position:
-    bytes: 14
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 14
-    line: 2
-    character: 5
-  end_position:
-    bytes: 15
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 2
-    character: 6
-  end_position:
-    bytes: 16
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 16
-    line: 2
-    character: 7
-  end_position:
-    bytes: 17
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 17
-    line: 3
-    character: 1
-  end_position:
-    bytes: 23
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: elseif
-- start_position:
-    bytes: 23
-    line: 3
-    character: 7
-  end_position:
-    bytes: 24
-    line: 3
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 3
-    character: 8
-  end_position:
-    bytes: 25
-    line: 3
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 25
-    line: 3
-    character: 9
-  end_position:
-    bytes: 26
-    line: 3
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 26
-    line: 3
-    character: 10
-  end_position:
-    bytes: 30
-    line: 3
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 30
-    line: 3
-    character: 14
-  end_position:
-    bytes: 31
-    line: 3
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 31
-    line: 4
-    character: 1
-  end_position:
-    bytes: 32
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 32
-    line: 4
-    character: 2
-  end_position:
-    bytes: 35
-    line: 4
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 35
-    line: 4
-    character: 5
-  end_position:
-    bytes: 36
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 36
-    line: 4
-    character: 6
-  end_position:
-    bytes: 37
-    line: 4
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 37
-    line: 4
-    character: 7
-  end_position:
-    bytes: 38
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 38
-    line: 5
-    character: 1
-  end_position:
-    bytes: 42
-    line: 5
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: else
-- start_position:
-    bytes: 42
-    line: 5
-    character: 5
-  end_position:
-    bytes: 43
-    line: 5
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 43
-    line: 6
-    character: 1
-  end_position:
-    bytes: 44
-    line: 6
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 44
-    line: 6
-    character: 2
-  end_position:
-    bytes: 47
-    line: 6
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: baz
-- start_position:
-    bytes: 47
-    line: 6
-    character: 5
-  end_position:
-    bytes: 48
-    line: 6
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 48
-    line: 6
-    character: 6
-  end_position:
-    bytes: 49
-    line: 6
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 49
-    line: 6
-    character: 7
-  end_position:
-    bytes: 50
-    line: 6
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 50
-    line: 7
-    character: 1
-  end_position:
-    bytes: 53
-    line: 7
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 53
-    line: 7
-    character: 4
-  end_position:
-    bytes: 53
-    line: 7
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 3
+      line: 1
+      character: 4
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 10
+        line: 2
+        character: 1
+      end_position:
+        bytes: 11
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 2
+    end_position:
+      bytes: 14
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 5
+    end_position:
+      bytes: 15
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 6
+    end_position:
+      bytes: 16
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 2
+        character: 7
+      end_position:
+        bytes: 17
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 3
+      character: 1
+    end_position:
+      bytes: 23
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: elseif
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 3
+        character: 7
+      end_position:
+        bytes: 24
+        line: 3
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 3
+      character: 8
+    end_position:
+      bytes: 25
+      line: 3
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 3
+        character: 9
+      end_position:
+        bytes: 26
+        line: 3
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 3
+      character: 10
+    end_position:
+      bytes: 30
+      line: 3
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 3
+        character: 14
+      end_position:
+        bytes: 31
+        line: 3
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 31
+        line: 4
+        character: 1
+      end_position:
+        bytes: 32
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 32
+      line: 4
+      character: 2
+    end_position:
+      bytes: 35
+      line: 4
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 4
+      character: 5
+    end_position:
+      bytes: 36
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 4
+      character: 6
+    end_position:
+      bytes: 37
+      line: 4
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 37
+        line: 4
+        character: 7
+      end_position:
+        bytes: 38
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 5
+      character: 1
+    end_position:
+      bytes: 42
+      line: 5
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: else
+  trailing_trivia:
+    - start_position:
+        bytes: 42
+        line: 5
+        character: 5
+      end_position:
+        bytes: 43
+        line: 5
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 43
+        line: 6
+        character: 1
+      end_position:
+        bytes: 44
+        line: 6
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 44
+      line: 6
+      character: 2
+    end_position:
+      bytes: 47
+      line: 6
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: baz
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 6
+      character: 5
+    end_position:
+      bytes: 48
+      line: 6
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 6
+      character: 6
+    end_position:
+      bytes: 49
+      line: 6
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 49
+        line: 6
+        character: 7
+      end_position:
+        bytes: 50
+        line: 6
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 7
+      character: 1
+    end_position:
+      bytes: 53
+      line: 7
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 7
+      character: 4
+    end_position:
+      bytes: 53
+      line: 7
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/index-1/tokens.snap
+++ b/full-moon/tests/cases/pass/index-1/tokens.snap
@@ -4,135 +4,162 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/index-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: c
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: c
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/index-2/tokens.snap
+++ b/full-moon/tests/cases/pass/index-2/tokens.snap
@@ -4,147 +4,177 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/index-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: StringLiteral
-    literal: a
-    quote_type: Double
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: StringLiteral
+      literal: a
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 1
+      character: 22
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/local-assignment-1/tokens.snap
+++ b/full-moon/tests/cases/pass/local-assignment-1/tokens.snap
@@ -4,47 +4,56 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/local-assignment-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/local-assignment-2/tokens.snap
+++ b/full-moon/tests/cases/pass/local-assignment-2/tokens.snap
@@ -4,91 +4,106 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/local-assignment-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/local-assignment-3/tokens.snap
+++ b/full-moon/tests/cases/pass/local-assignment-3/tokens.snap
@@ -4,465 +4,540 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/local-assignment-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 18
-    line: 2
-    character: 1
-  end_position:
-    bytes: 23
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 23
-    line: 2
-    character: 6
-  end_position:
-    bytes: 24
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 2
-    character: 7
-  end_position:
-    bytes: 25
-    line: 2
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: c
-- start_position:
-    bytes: 25
-    line: 2
-    character: 8
-  end_position:
-    bytes: 26
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 26
-    line: 2
-    character: 9
-  end_position:
-    bytes: 27
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 27
-    line: 2
-    character: 10
-  end_position:
-    bytes: 28
-    line: 2
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: d
-- start_position:
-    bytes: 28
-    line: 2
-    character: 11
-  end_position:
-    bytes: 29
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 29
-    line: 2
-    character: 12
-  end_position:
-    bytes: 30
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 30
-    line: 2
-    character: 13
-  end_position:
-    bytes: 31
-    line: 2
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 31
-    line: 2
-    character: 14
-  end_position:
-    bytes: 32
-    line: 2
-    character: 15
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 32
-    line: 2
-    character: 15
-  end_position:
-    bytes: 33
-    line: 2
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 33
-    line: 2
-    character: 16
-  end_position:
-    bytes: 34
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 34
-    line: 2
-    character: 17
-  end_position:
-    bytes: 35
-    line: 2
-    character: 18
-  token_type:
-    type: Number
-    text: "4"
-- start_position:
-    bytes: 35
-    line: 2
-    character: 18
-  end_position:
-    bytes: 36
-    line: 2
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 36
-    line: 3
-    character: 1
-  end_position:
-    bytes: 41
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 41
-    line: 3
-    character: 6
-  end_position:
-    bytes: 42
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 42
-    line: 3
-    character: 7
-  end_position:
-    bytes: 43
-    line: 3
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: e
-- start_position:
-    bytes: 43
-    line: 3
-    character: 8
-  end_position:
-    bytes: 44
-    line: 3
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 44
-    line: 3
-    character: 9
-  end_position:
-    bytes: 45
-    line: 3
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 45
-    line: 3
-    character: 10
-  end_position:
-    bytes: 46
-    line: 3
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: f
-- start_position:
-    bytes: 46
-    line: 3
-    character: 11
-  end_position:
-    bytes: 47
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 47
-    line: 3
-    character: 12
-  end_position:
-    bytes: 48
-    line: 3
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 48
-    line: 3
-    character: 13
-  end_position:
-    bytes: 49
-    line: 3
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 49
-    line: 3
-    character: 14
-  end_position:
-    bytes: 50
-    line: 3
-    character: 15
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 50
-    line: 3
-    character: 15
-  end_position:
-    bytes: 51
-    line: 3
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 51
-    line: 3
-    character: 16
-  end_position:
-    bytes: 52
-    line: 3
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 52
-    line: 3
-    character: 17
-  end_position:
-    bytes: 53
-    line: 3
-    character: 18
-  token_type:
-    type: Number
-    text: "6"
-- start_position:
-    bytes: 53
-    line: 3
-    character: 18
-  end_position:
-    bytes: 53
-    line: 3
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 1
+        character: 13
+      end_position:
+        bytes: 13
+        line: 1
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 1
+    end_position:
+      bytes: 23
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 2
+        character: 6
+      end_position:
+        bytes: 24
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 7
+    end_position:
+      bytes: 25
+      line: 2
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: c
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 8
+    end_position:
+      bytes: 26
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 9
+      end_position:
+        bytes: 27
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 10
+    end_position:
+      bytes: 28
+      line: 2
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: d
+  trailing_trivia:
+    - start_position:
+        bytes: 28
+        line: 2
+        character: 11
+      end_position:
+        bytes: 29
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 2
+      character: 12
+    end_position:
+      bytes: 30
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 2
+        character: 13
+      end_position:
+        bytes: 31
+        line: 2
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 2
+      character: 14
+    end_position:
+      bytes: 32
+      line: 2
+      character: 15
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 2
+      character: 15
+    end_position:
+      bytes: 33
+      line: 2
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 2
+        character: 16
+      end_position:
+        bytes: 34
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 2
+      character: 17
+    end_position:
+      bytes: 35
+      line: 2
+      character: 18
+    token_type:
+      type: Number
+      text: "4"
+  trailing_trivia:
+    - start_position:
+        bytes: 35
+        line: 2
+        character: 18
+      end_position:
+        bytes: 36
+        line: 2
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 3
+      character: 1
+    end_position:
+      bytes: 41
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 41
+        line: 3
+        character: 6
+      end_position:
+        bytes: 42
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 3
+      character: 7
+    end_position:
+      bytes: 43
+      line: 3
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: e
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 43
+      line: 3
+      character: 8
+    end_position:
+      bytes: 44
+      line: 3
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 44
+        line: 3
+        character: 9
+      end_position:
+        bytes: 45
+        line: 3
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 3
+      character: 10
+    end_position:
+      bytes: 46
+      line: 3
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: f
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 3
+        character: 11
+      end_position:
+        bytes: 47
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 3
+      character: 12
+    end_position:
+      bytes: 48
+      line: 3
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 48
+        line: 3
+        character: 13
+      end_position:
+        bytes: 49
+        line: 3
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 49
+      line: 3
+      character: 14
+    end_position:
+      bytes: 50
+      line: 3
+      character: 15
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 3
+      character: 15
+    end_position:
+      bytes: 51
+      line: 3
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 51
+        line: 3
+        character: 16
+      end_position:
+        bytes: 52
+        line: 3
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 3
+      character: 17
+    end_position:
+      bytes: 53
+      line: 3
+      character: 18
+    token_type:
+      type: Number
+      text: "6"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 3
+      character: 18
+    end_position:
+      bytes: 53
+      line: 3
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/local-assignment-4/tokens.snap
+++ b/full-moon/tests/cases/pass/local-assignment-4/tokens.snap
@@ -4,80 +4,95 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/local-assignment-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/local-assignment-5/tokens.snap
+++ b/full-moon/tests/cases/pass/local-assignment-5/tokens.snap
@@ -4,212 +4,239 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/local-assignment-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 29
-    line: 2
-    character: 18
-  token_type:
-    type: SingleLineComment
-    comment: " Then a comment"
-- start_position:
-    bytes: 29
-    line: 2
-    character: 18
-  end_position:
-    bytes: 30
-    line: 2
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 30
-    line: 3
-    character: 1
-  end_position:
-    bytes: 35
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 35
-    line: 3
-    character: 6
-  end_position:
-    bytes: 36
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 36
-    line: 3
-    character: 7
-  end_position:
-    bytes: 37
-    line: 3
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 37
-    line: 3
-    character: 8
-  end_position:
-    bytes: 38
-    line: 3
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 38
-    line: 3
-    character: 9
-  end_position:
-    bytes: 39
-    line: 3
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 39
-    line: 3
-    character: 10
-  end_position:
-    bytes: 40
-    line: 3
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 3
-    character: 11
-  end_position:
-    bytes: 41
-    line: 3
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 41
-    line: 3
-    character: 12
-  end_position:
-    bytes: 42
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 42
-    line: 4
-    character: 1
-  end_position:
-    bytes: 42
-    line: 4
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 12
+        line: 2
+        character: 1
+      end_position:
+        bytes: 29
+        line: 2
+        character: 18
+      token_type:
+        type: SingleLineComment
+        comment: " Then a comment"
+    - start_position:
+        bytes: 29
+        line: 2
+        character: 18
+      end_position:
+        bytes: 30
+        line: 2
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 30
+      line: 3
+      character: 1
+    end_position:
+      bytes: 35
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 35
+        line: 3
+        character: 6
+      end_position:
+        bytes: 36
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 3
+      character: 7
+    end_position:
+      bytes: 37
+      line: 3
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 37
+        line: 3
+        character: 8
+      end_position:
+        bytes: 38
+        line: 3
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 3
+      character: 9
+    end_position:
+      bytes: 39
+      line: 3
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 3
+        character: 10
+      end_position:
+        bytes: 40
+        line: 3
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 3
+      character: 11
+    end_position:
+      bytes: 41
+      line: 3
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 41
+        line: 3
+        character: 12
+      end_position:
+        bytes: 42
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 4
+      character: 1
+    end_position:
+      bytes: 42
+      line: 4
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/local-function-1/tokens.snap
+++ b/full-moon/tests/cases/pass/local-function-1/tokens.snap
@@ -4,190 +4,223 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/local-function-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 19
-    line: 2
-    character: 1
-  end_position:
-    bytes: 20
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 20
-    line: 2
-    character: 2
-  end_position:
-    bytes: 24
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 24
-    line: 2
-    character: 6
-  end_position:
-    bytes: 25
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 25
-    line: 2
-    character: 7
-  end_position:
-    bytes: 26
-    line: 2
-    character: 8
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 26
-    line: 2
-    character: 8
-  end_position:
-    bytes: 27
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 27
-    line: 2
-    character: 9
-  end_position:
-    bytes: 28
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 28
-    line: 3
-    character: 1
-  end_position:
-    bytes: 31
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 31
-    line: 3
-    character: 4
-  end_position:
-    bytes: 32
-    line: 3
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 32
-    line: 4
-    character: 1
-  end_position:
-    bytes: 32
-    line: 4
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 1
+        character: 19
+      end_position:
+        bytes: 19
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 1
+      end_position:
+        bytes: 20
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 2
+    end_position:
+      bytes: 24
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 6
+    end_position:
+      bytes: 25
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 7
+    end_position:
+      bytes: 26
+      line: 2
+      character: 8
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 8
+    end_position:
+      bytes: 27
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 2
+        character: 9
+      end_position:
+        bytes: 28
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 3
+      character: 1
+    end_position:
+      bytes: 31
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 3
+        character: 4
+      end_position:
+        bytes: 32
+        line: 3
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 4
+      character: 1
+    end_position:
+      bytes: 32
+      line: 4
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/local-function-2/tokens.snap
+++ b/full-moon/tests/cases/pass/local-function-2/tokens.snap
@@ -4,465 +4,549 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/local-function-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 23
-    line: 1
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 23
-    line: 1
-    character: 24
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 28
-    line: 1
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 28
-    line: 1
-    character: 29
-  end_position:
-    bytes: 29
-    line: 1
-    character: 29
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 29
-    line: 2
-    character: 1
-  end_position:
-    bytes: 34
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 34
-    line: 2
-    character: 6
-  end_position:
-    bytes: 35
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 35
-    line: 2
-    character: 7
-  end_position:
-    bytes: 43
-    line: 2
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 43
-    line: 2
-    character: 15
-  end_position:
-    bytes: 44
-    line: 2
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 44
-    line: 2
-    character: 16
-  end_position:
-    bytes: 47
-    line: 2
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 47
-    line: 2
-    character: 19
-  end_position:
-    bytes: 48
-    line: 2
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 48
-    line: 2
-    character: 20
-  end_position:
-    bytes: 51
-    line: 2
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 51
-    line: 2
-    character: 23
-  end_position:
-    bytes: 52
-    line: 2
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 52
-    line: 2
-    character: 24
-  end_position:
-    bytes: 53
-    line: 2
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 53
-    line: 2
-    character: 25
-  end_position:
-    bytes: 56
-    line: 2
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 56
-    line: 2
-    character: 28
-  end_position:
-    bytes: 57
-    line: 2
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 57
-    line: 3
-    character: 1
-  end_position:
-    bytes: 62
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 62
-    line: 3
-    character: 6
-  end_position:
-    bytes: 63
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 63
-    line: 3
-    character: 7
-  end_position:
-    bytes: 71
-    line: 3
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 71
-    line: 3
-    character: 15
-  end_position:
-    bytes: 72
-    line: 3
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 72
-    line: 3
-    character: 16
-  end_position:
-    bytes: 75
-    line: 3
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: baz
-- start_position:
-    bytes: 75
-    line: 3
-    character: 19
-  end_position:
-    bytes: 76
-    line: 3
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 76
-    line: 3
-    character: 20
-  end_position:
-    bytes: 77
-    line: 3
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 77
-    line: 3
-    character: 21
-  end_position:
-    bytes: 78
-    line: 3
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 78
-    line: 3
-    character: 22
-  end_position:
-    bytes: 79
-    line: 3
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 79
-    line: 3
-    character: 23
-  end_position:
-    bytes: 80
-    line: 3
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 80
-    line: 3
-    character: 24
-  end_position:
-    bytes: 81
-    line: 3
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 81
-    line: 3
-    character: 25
-  end_position:
-    bytes: 82
-    line: 3
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 82
-    line: 3
-    character: 26
-  end_position:
-    bytes: 85
-    line: 3
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 85
-    line: 3
-    character: 29
-  end_position:
-    bytes: 86
-    line: 3
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 86
-    line: 3
-    character: 30
-  end_position:
-    bytes: 87
-    line: 3
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 87
-    line: 3
-    character: 31
-  end_position:
-    bytes: 90
-    line: 3
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 90
-    line: 3
-    character: 34
-  end_position:
-    bytes: 90
-    line: 3
-    character: 34
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 22
+      end_position:
+        bytes: 22
+        line: 1
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 1
+      character: 23
+    end_position:
+      bytes: 23
+      line: 1
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 1
+      character: 24
+    end_position:
+      bytes: 24
+      line: 1
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 24
+        line: 1
+        character: 25
+      end_position:
+        bytes: 25
+        line: 1
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 28
+      line: 1
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 28
+        line: 1
+        character: 29
+      end_position:
+        bytes: 29
+        line: 1
+        character: 29
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 2
+      character: 1
+    end_position:
+      bytes: 34
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 2
+        character: 6
+      end_position:
+        bytes: 35
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 2
+      character: 7
+    end_position:
+      bytes: 43
+      line: 2
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 43
+        line: 2
+        character: 15
+      end_position:
+        bytes: 44
+        line: 2
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 44
+      line: 2
+      character: 16
+    end_position:
+      bytes: 47
+      line: 2
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 2
+      character: 19
+    end_position:
+      bytes: 48
+      line: 2
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 2
+      character: 20
+    end_position:
+      bytes: 51
+      line: 2
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 51
+      line: 2
+      character: 23
+    end_position:
+      bytes: 52
+      line: 2
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 52
+        line: 2
+        character: 24
+      end_position:
+        bytes: 53
+        line: 2
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 2
+      character: 25
+    end_position:
+      bytes: 56
+      line: 2
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 56
+        line: 2
+        character: 28
+      end_position:
+        bytes: 57
+        line: 2
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 57
+      line: 3
+      character: 1
+    end_position:
+      bytes: 62
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 62
+        line: 3
+        character: 6
+      end_position:
+        bytes: 63
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 63
+      line: 3
+      character: 7
+    end_position:
+      bytes: 71
+      line: 3
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 71
+        line: 3
+        character: 15
+      end_position:
+        bytes: 72
+        line: 3
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 72
+      line: 3
+      character: 16
+    end_position:
+      bytes: 75
+      line: 3
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: baz
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 3
+      character: 19
+    end_position:
+      bytes: 76
+      line: 3
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 76
+      line: 3
+      character: 20
+    end_position:
+      bytes: 77
+      line: 3
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 77
+      line: 3
+      character: 21
+    end_position:
+      bytes: 78
+      line: 3
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 78
+        line: 3
+        character: 22
+      end_position:
+        bytes: 79
+        line: 3
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 79
+      line: 3
+      character: 23
+    end_position:
+      bytes: 80
+      line: 3
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 80
+      line: 3
+      character: 24
+    end_position:
+      bytes: 81
+      line: 3
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 81
+        line: 3
+        character: 25
+      end_position:
+        bytes: 82
+        line: 3
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 82
+      line: 3
+      character: 26
+    end_position:
+      bytes: 85
+      line: 3
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 3
+      character: 29
+    end_position:
+      bytes: 86
+      line: 3
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 86
+        line: 3
+        character: 30
+      end_position:
+        bytes: 87
+        line: 3
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 87
+      line: 3
+      character: 31
+    end_position:
+      bytes: 90
+      line: 3
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 90
+      line: 3
+      character: 34
+    end_position:
+      bytes: 90
+      line: 3
+      character: 34
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/mixed-indented-comments/tokens.snap
+++ b/full-moon/tests/cases/pass/mixed-indented-comments/tokens.snap
@@ -4,70 +4,73 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/mixed-indented-comments
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 1
-    line: 1
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 1
-    line: 1
-    character: 2
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: SingleLineComment
-    comment: " Indented single line"
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 25
-    line: 1
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 25
-    line: 2
-    character: 1
-  end_position:
-    bytes: 26
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 26
-    line: 2
-    character: 2
-  end_position:
-    bytes: 56
-    line: 4
-    character: 4
-  token_type:
-    type: MultiLineComment
-    blocks: 0
-    comment: "\n\t\tIndented multi line\n\t"
-- start_position:
-    bytes: 56
-    line: 4
-    character: 4
-  end_position:
-    bytes: 56
-    line: 4
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 1
+        line: 1
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+    - start_position:
+        bytes: 1
+        line: 1
+        character: 2
+      end_position:
+        bytes: 24
+        line: 1
+        character: 25
+      token_type:
+        type: SingleLineComment
+        comment: " Indented single line"
+    - start_position:
+        bytes: 24
+        line: 1
+        character: 25
+      end_position:
+        bytes: 25
+        line: 1
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 25
+        line: 2
+        character: 1
+      end_position:
+        bytes: 26
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 2
+      end_position:
+        bytes: 56
+        line: 4
+        character: 4
+      token_type:
+        type: MultiLineComment
+        blocks: 0
+        comment: "\n\t\tIndented multi line\n\t"
+  token:
+    start_position:
+      bytes: 56
+      line: 4
+      character: 4
+    end_position:
+      bytes: 56
+      line: 4
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-1/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-1/tokens.snap
@@ -4,26 +4,29 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 39
-    line: 5
-    character: 3
-  token_type:
-    type: MultiLineComment
-    blocks: 0
-    comment: "\n\tsuch comments\n\tmuch lines\n\twow\n"
-- start_position:
-    bytes: 39
-    line: 5
-    character: 3
-  end_position:
-    bytes: 39
-    line: 5
-    character: 3
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 39
+        line: 5
+        character: 3
+      token_type:
+        type: MultiLineComment
+        blocks: 0
+        comment: "\n\tsuch comments\n\tmuch lines\n\twow\n"
+  token:
+    start_position:
+      bytes: 39
+      line: 5
+      character: 3
+    end_position:
+      bytes: 39
+      line: 5
+      character: 3
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-2/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-2/tokens.snap
@@ -4,26 +4,29 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 88
-    line: 4
-    character: 4
-  token_type:
-    type: MultiLineComment
-    blocks: 1
-    comment: "\n\tnever have i used these weird equals signs comments\n\tbut im sure someone does\n"
-- start_position:
-    bytes: 88
-    line: 4
-    character: 4
-  end_position:
-    bytes: 88
-    line: 4
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 88
+        line: 4
+        character: 4
+      token_type:
+        type: MultiLineComment
+        blocks: 1
+        comment: "\n\tnever have i used these weird equals signs comments\n\tbut im sure someone does\n"
+  token:
+    start_position:
+      bytes: 88
+      line: 4
+      character: 4
+    end_position:
+      bytes: 88
+      line: 4
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-3/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-3/tokens.snap
@@ -4,26 +4,29 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 14
-    line: 3
-    character: 4
-  token_type:
-    type: MultiLineComment
-    blocks: 1
-    comment: "\n--[[\n"
-- start_position:
-    bytes: 14
-    line: 3
-    character: 4
-  end_position:
-    bytes: 14
-    line: 3
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 14
+        line: 3
+        character: 4
+      token_type:
+        type: MultiLineComment
+        blocks: 1
+        comment: "\n--[[\n"
+  token:
+    start_position:
+      bytes: 14
+      line: 3
+      character: 4
+    end_position:
+      bytes: 14
+      line: 3
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-4/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-4/tokens.snap
@@ -4,26 +4,29 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 50
-    line: 5
-    character: 8
-  token_type:
-    type: MultiLineComment
-    blocks: 5
-    comment: "\n\tlua be like\n]====]\n\tstill going\n"
-- start_position:
-    bytes: 50
-    line: 5
-    character: 8
-  end_position:
-    bytes: 50
-    line: 5
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 50
+        line: 5
+        character: 8
+      token_type:
+        type: MultiLineComment
+        blocks: 5
+        comment: "\n\tlua be like\n]====]\n\tstill going\n"
+  token:
+    start_position:
+      bytes: 50
+      line: 5
+      character: 8
+    end_position:
+      bytes: 50
+      line: 5
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-5/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-5/tokens.snap
@@ -4,26 +4,29 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 146
-    line: 6
-    character: 3
-  token_type:
-    type: MultiLineComment
-    blocks: 0
-    comment: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
-- start_position:
-    bytes: 146
-    line: 6
-    character: 3
-  end_position:
-    bytes: 146
-    line: 6
-    character: 3
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 146
+        line: 6
+        character: 3
+      token_type:
+        type: MultiLineComment
+        blocks: 0
+        comment: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
+  token:
+    start_position:
+      bytes: 146
+      line: 6
+      character: 3
+    end_position:
+      bytes: 146
+      line: 6
+      character: 3
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-6/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-6/tokens.snap
@@ -4,136 +4,160 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-6
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 38
-    line: 1
-    character: 39
-  token_type:
-    type: MultiLineComment
-    blocks: 0
-    comment: comment here
-- start_position:
-    bytes: 38
-    line: 1
-    character: 39
-  end_position:
-    bytes: 39
-    line: 1
-    character: 40
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 39
-    line: 1
-    character: 40
-  end_position:
-    bytes: 40
-    line: 1
-    character: 40
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 40
-    line: 2
-    character: 1
-  end_position:
-    bytes: 43
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 43
-    line: 2
-    character: 4
-  end_position:
-    bytes: 43
-    line: 2
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 1
+        character: 21
+      end_position:
+        bytes: 38
+        line: 1
+        character: 39
+      token_type:
+        type: MultiLineComment
+        blocks: 0
+        comment: comment here
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 1
+      character: 39
+    end_position:
+      bytes: 39
+      line: 1
+      character: 40
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 1
+        character: 40
+      end_position:
+        bytes: 40
+        line: 1
+        character: 40
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 1
+    end_position:
+      bytes: 43
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 43
+      line: 2
+      character: 4
+    end_position:
+      bytes: 43
+      line: 2
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-7/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-7/tokens.snap
@@ -4,70 +4,73 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-7
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 22
-    line: 1
-    character: 17
-  token_type:
-    type: MultiLineComment
-    blocks: 1
-    comment: " μέλλον "
-- start_position:
-    bytes: 22
-    line: 1
-    character: 17
-  end_position:
-    bytes: 23
-    line: 1
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 23
-    line: 2
-    character: 1
-  end_position:
-    bytes: 24
-    line: 2
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 24
-    line: 3
-    character: 1
-  end_position:
-    bytes: 41
-    line: 3
-    character: 18
-  token_type:
-    type: SingleLineComment
-    comment: " some text here"
-- start_position:
-    bytes: 41
-    line: 3
-    character: 18
-  end_position:
-    bytes: 42
-    line: 3
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 42
-    line: 4
-    character: 1
-  end_position:
-    bytes: 42
-    line: 4
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 22
+        line: 1
+        character: 17
+      token_type:
+        type: MultiLineComment
+        blocks: 1
+        comment: " μέλλον "
+    - start_position:
+        bytes: 22
+        line: 1
+        character: 17
+      end_position:
+        bytes: 23
+        line: 1
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 23
+        line: 2
+        character: 1
+      end_position:
+        bytes: 24
+        line: 2
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 24
+        line: 3
+        character: 1
+      end_position:
+        bytes: 41
+        line: 3
+        character: 18
+      token_type:
+        type: SingleLineComment
+        comment: " some text here"
+    - start_position:
+        bytes: 41
+        line: 3
+        character: 18
+      end_position:
+        bytes: 42
+        line: 3
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 42
+      line: 4
+      character: 1
+    end_position:
+      bytes: 42
+      line: 4
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-comments-8/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-8/tokens.snap
@@ -4,125 +4,140 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-comments-8
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 21
-    line: 1
-    character: 11
-  token_type:
-    type: MultiLineComment
-    blocks: 0
-    comment: 👨🏾‍💻
-- start_position:
-    bytes: 21
-    line: 1
-    character: 11
-  end_position:
-    bytes: 22
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 22
-    line: 2
-    character: 1
-  end_position:
-    bytes: 27
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 27
-    line: 2
-    character: 6
-  end_position:
-    bytes: 28
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 28
-    line: 2
-    character: 7
-  end_position:
-    bytes: 37
-    line: 2
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: more_code
-- start_position:
-    bytes: 37
-    line: 2
-    character: 16
-  end_position:
-    bytes: 38
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 38
-    line: 2
-    character: 17
-  end_position:
-    bytes: 39
-    line: 2
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 39
-    line: 2
-    character: 18
-  end_position:
-    bytes: 40
-    line: 2
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 2
-    character: 19
-  end_position:
-    bytes: 44
-    line: 2
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: here
-- start_position:
-    bytes: 44
-    line: 2
-    character: 23
-  end_position:
-    bytes: 45
-    line: 2
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 45
-    line: 3
-    character: 1
-  end_position:
-    bytes: 45
-    line: 3
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 21
+        line: 1
+        character: 11
+      token_type:
+        type: MultiLineComment
+        blocks: 0
+        comment: 👨🏾‍💻
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 11
+      end_position:
+        bytes: 22
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 1
+    end_position:
+      bytes: 27
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 2
+        character: 6
+      end_position:
+        bytes: 28
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 2
+      character: 7
+    end_position:
+      bytes: 37
+      line: 2
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: more_code
+  trailing_trivia:
+    - start_position:
+        bytes: 37
+        line: 2
+        character: 16
+      end_position:
+        bytes: 38
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 2
+      character: 17
+    end_position:
+      bytes: 39
+      line: 2
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 2
+        character: 18
+      end_position:
+        bytes: 40
+        line: 2
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 19
+    end_position:
+      bytes: 44
+      line: 2
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: here
+  trailing_trivia:
+    - start_position:
+        bytes: 44
+        line: 2
+        character: 23
+      end_position:
+        bytes: 45
+        line: 2
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 3
+      character: 1
+    end_position:
+      bytes: 45
+      line: 3
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-string-1/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-1/tokens.snap
@@ -4,93 +4,108 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-string-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 48
-    line: 4
-    character: 13
-  token_type:
-    type: StringLiteral
-    literal: "Full Moon\nis a\nlossless\nLua parser"
-    multi_line: 0
-    quote_type: Brackets
-- start_position:
-    bytes: 48
-    line: 4
-    character: 13
-  end_position:
-    bytes: 48
-    line: 4
-    character: 13
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 48
+      line: 4
+      character: 13
+    token_type:
+      type: StringLiteral
+      literal: "Full Moon\nis a\nlossless\nLua parser"
+      multi_line: 0
+      quote_type: Brackets
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 4
+      character: 13
+    end_position:
+      bytes: 48
+      line: 4
+      character: 13
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-string-2/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-2/tokens.snap
@@ -4,93 +4,108 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-string-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 43
-    line: 3
-    character: 9
-  token_type:
-    type: StringLiteral
-    literal: "This is\nseveral equal\nsigns"
-    multi_line: 1
-    quote_type: Brackets
-- start_position:
-    bytes: 43
-    line: 3
-    character: 9
-  end_position:
-    bytes: 43
-    line: 3
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 43
+      line: 3
+      character: 9
+    token_type:
+      type: StringLiteral
+      literal: "This is\nseveral equal\nsigns"
+      multi_line: 1
+      quote_type: Brackets
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 43
+      line: 3
+      character: 9
+    end_position:
+      bytes: 43
+      line: 3
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-string-3/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-3/tokens.snap
@@ -4,93 +4,108 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-string-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 154
-    line: 6
-    character: 3
-  token_type:
-    type: StringLiteral
-    literal: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
-    multi_line: 0
-    quote_type: Brackets
-- start_position:
-    bytes: 154
-    line: 6
-    character: 3
-  end_position:
-    bytes: 154
-    line: 6
-    character: 3
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 154
+      line: 6
+      character: 3
+    token_type:
+      type: StringLiteral
+      literal: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
+      multi_line: 0
+      quote_type: Brackets
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 154
+      line: 6
+      character: 3
+    end_position:
+      bytes: 154
+      line: 6
+      character: 3
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-string-4/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-4/tokens.snap
@@ -4,60 +4,75 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-string-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: StringLiteral
-    literal: doge
-    multi_line: 0
-    quote_type: Brackets
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: StringLiteral
+      literal: doge
+      multi_line: 0
+      quote_type: Brackets
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-string-5/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-5/tokens.snap
@@ -4,192 +4,219 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-string-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: emoji
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 26
-    line: 1
-    character: 21
-  token_type:
-    type: StringLiteral
-    literal: 🧓🏽
-    multi_line: 0
-    quote_type: Brackets
-- start_position:
-    bytes: 26
-    line: 1
-    character: 21
-  end_position:
-    bytes: 27
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 27
-    line: 2
-    character: 1
-  end_position:
-    bytes: 32
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 32
-    line: 2
-    character: 6
-  end_position:
-    bytes: 33
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 33
-    line: 2
-    character: 7
-  end_position:
-    bytes: 42
-    line: 2
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: more_code
-- start_position:
-    bytes: 42
-    line: 2
-    character: 16
-  end_position:
-    bytes: 43
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 43
-    line: 2
-    character: 17
-  end_position:
-    bytes: 44
-    line: 2
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 44
-    line: 2
-    character: 18
-  end_position:
-    bytes: 45
-    line: 2
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 45
-    line: 2
-    character: 19
-  end_position:
-    bytes: 49
-    line: 2
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: here
-- start_position:
-    bytes: 49
-    line: 2
-    character: 23
-  end_position:
-    bytes: 50
-    line: 2
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 50
-    line: 3
-    character: 1
-  end_position:
-    bytes: 50
-    line: 3
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: emoji
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 26
+      line: 1
+      character: 21
+    token_type:
+      type: StringLiteral
+      literal: 🧓🏽
+      multi_line: 0
+      quote_type: Brackets
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 1
+        character: 21
+      end_position:
+        bytes: 27
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 1
+    end_position:
+      bytes: 32
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 32
+        line: 2
+        character: 6
+      end_position:
+        bytes: 33
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 2
+      character: 7
+    end_position:
+      bytes: 42
+      line: 2
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: more_code
+  trailing_trivia:
+    - start_position:
+        bytes: 42
+        line: 2
+        character: 16
+      end_position:
+        bytes: 43
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 43
+      line: 2
+      character: 17
+    end_position:
+      bytes: 44
+      line: 2
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 44
+        line: 2
+        character: 18
+      end_position:
+        bytes: 45
+        line: 2
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 2
+      character: 19
+    end_position:
+      bytes: 49
+      line: 2
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: here
+  trailing_trivia:
+    - start_position:
+        bytes: 49
+        line: 2
+        character: 23
+      end_position:
+        bytes: 50
+        line: 2
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 3
+      character: 1
+    end_position:
+      bytes: 50
+      line: 3
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/multi-line-string-6/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-6/tokens.snap
@@ -4,103 +4,118 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/multi-line-string-6
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 22
-    line: 2
-    character: 5
-  token_type:
-    type: StringLiteral
-    literal: "bar\\\nbaz"
-    quote_type: Double
-- start_position:
-    bytes: 22
-    line: 2
-    character: 5
-  end_position:
-    bytes: 23
-    line: 2
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 23
-    line: 3
-    character: 1
-  end_position:
-    bytes: 23
-    line: 3
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 22
+      line: 2
+      character: 5
+    token_type:
+      type: StringLiteral
+      literal: "bar\\\nbaz"
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 22
+        line: 2
+        character: 5
+      end_position:
+        bytes: 23
+        line: 2
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 3
+      character: 1
+    end_position:
+      bytes: 23
+      line: 3
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/negative-numbers/tokens.snap
+++ b/full-moon/tests/cases/pass/negative-numbers/tokens.snap
@@ -4,333 +4,393 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/negative-numbers
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 16
-    line: 2
-    character: 1
-  end_position:
-    bytes: 21
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 21
-    line: 2
-    character: 6
-  end_position:
-    bytes: 22
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 2
-    character: 7
-  end_position:
-    bytes: 25
-    line: 2
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 25
-    line: 2
-    character: 10
-  end_position:
-    bytes: 26
-    line: 2
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 26
-    line: 2
-    character: 11
-  end_position:
-    bytes: 27
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 27
-    line: 2
-    character: 12
-  end_position:
-    bytes: 28
-    line: 2
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 28
-    line: 2
-    character: 13
-  end_position:
-    bytes: 29
-    line: 2
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 29
-    line: 2
-    character: 14
-  end_position:
-    bytes: 30
-    line: 2
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 30
-    line: 2
-    character: 15
-  end_position:
-    bytes: 31
-    line: 2
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 31
-    line: 2
-    character: 16
-  end_position:
-    bytes: 32
-    line: 2
-    character: 17
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 32
-    line: 2
-    character: 17
-  end_position:
-    bytes: 33
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 33
-    line: 3
-    character: 1
-  end_position:
-    bytes: 38
-    line: 3
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: print
-- start_position:
-    bytes: 38
-    line: 3
-    character: 6
-  end_position:
-    bytes: 39
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 39
-    line: 3
-    character: 7
-  end_position:
-    bytes: 40
-    line: 3
-    character: 8
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 40
-    line: 3
-    character: 8
-  end_position:
-    bytes: 41
-    line: 3
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 41
-    line: 3
-    character: 9
-  end_position:
-    bytes: 42
-    line: 3
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 42
-    line: 3
-    character: 10
-  end_position:
-    bytes: 43
-    line: 3
-    character: 11
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 43
-    line: 3
-    character: 11
-  end_position:
-    bytes: 44
-    line: 3
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 44
-    line: 3
-    character: 12
-  end_position:
-    bytes: 45
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 45
-    line: 4
-    character: 1
-  end_position:
-    bytes: 45
-    line: 4
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 1
+    end_position:
+      bytes: 21
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 6
+      end_position:
+        bytes: 22
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 7
+    end_position:
+      bytes: 25
+      line: 2
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 2
+        character: 10
+      end_position:
+        bytes: 26
+        line: 2
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 11
+    end_position:
+      bytes: 27
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 2
+        character: 12
+      end_position:
+        bytes: 28
+        line: 2
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 2
+      character: 13
+    end_position:
+      bytes: 29
+      line: 2
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 29
+        line: 2
+        character: 14
+      end_position:
+        bytes: 30
+        line: 2
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 2
+      character: 15
+    end_position:
+      bytes: 31
+      line: 2
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 2
+      character: 16
+    end_position:
+      bytes: 32
+      line: 2
+      character: 17
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 32
+        line: 2
+        character: 17
+      end_position:
+        bytes: 33
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 3
+      character: 1
+    end_position:
+      bytes: 38
+      line: 3
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: print
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 3
+      character: 6
+    end_position:
+      bytes: 39
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 39
+      line: 3
+      character: 7
+    end_position:
+      bytes: 40
+      line: 3
+      character: 8
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 3
+      character: 8
+    end_position:
+      bytes: 41
+      line: 3
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 3
+      character: 9
+    end_position:
+      bytes: 42
+      line: 3
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 3
+      character: 10
+    end_position:
+      bytes: 43
+      line: 3
+      character: 11
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 43
+      line: 3
+      character: 11
+    end_position:
+      bytes: 44
+      line: 3
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 44
+        line: 3
+        character: 12
+      end_position:
+        bytes: 45
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 4
+      character: 1
+    end_position:
+      bytes: 45
+      line: 4
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/numeric-for-loop/tokens.snap
+++ b/full-moon/tests/cases/pass/numeric-for-loop/tokens.snap
@@ -4,586 +4,679 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/numeric-for-loop
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: index
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Number
-    text: "10"
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 26
-    line: 1
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 26
-    line: 1
-    character: 27
-  end_position:
-    bytes: 31
-    line: 1
-    character: 32
-  token_type:
-    type: Identifier
-    identifier: index
-- start_position:
-    bytes: 31
-    line: 1
-    character: 32
-  end_position:
-    bytes: 32
-    line: 1
-    character: 33
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 32
-    line: 1
-    character: 33
-  end_position:
-    bytes: 33
-    line: 1
-    character: 34
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 33
-    line: 1
-    character: 34
-  end_position:
-    bytes: 36
-    line: 1
-    character: 37
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 36
-    line: 1
-    character: 37
-  end_position:
-    bytes: 37
-    line: 1
-    character: 37
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 37
-    line: 2
-    character: 1
-  end_position:
-    bytes: 40
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 40
-    line: 2
-    character: 4
-  end_position:
-    bytes: 41
-    line: 2
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 41
-    line: 2
-    character: 5
-  end_position:
-    bytes: 42
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: _
-- start_position:
-    bytes: 42
-    line: 2
-    character: 6
-  end_position:
-    bytes: 43
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 43
-    line: 2
-    character: 7
-  end_position:
-    bytes: 44
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 44
-    line: 2
-    character: 8
-  end_position:
-    bytes: 45
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 45
-    line: 2
-    character: 9
-  end_position:
-    bytes: 50
-    line: 2
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: start
-- start_position:
-    bytes: 50
-    line: 2
-    character: 14
-  end_position:
-    bytes: 51
-    line: 2
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 51
-    line: 2
-    character: 15
-  end_position:
-    bytes: 52
-    line: 2
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 52
-    line: 2
-    character: 16
-  end_position:
-    bytes: 57
-    line: 2
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: final
-- start_position:
-    bytes: 57
-    line: 2
-    character: 21
-  end_position:
-    bytes: 58
-    line: 2
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 58
-    line: 2
-    character: 22
-  end_position:
-    bytes: 60
-    line: 2
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 60
-    line: 2
-    character: 24
-  end_position:
-    bytes: 61
-    line: 2
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 61
-    line: 2
-    character: 25
-  end_position:
-    bytes: 64
-    line: 2
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 64
-    line: 2
-    character: 28
-  end_position:
-    bytes: 65
-    line: 2
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 65
-    line: 3
-    character: 1
-  end_position:
-    bytes: 68
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 68
-    line: 3
-    character: 4
-  end_position:
-    bytes: 69
-    line: 3
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 69
-    line: 3
-    character: 5
-  end_position:
-    bytes: 70
-    line: 3
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: _
-- start_position:
-    bytes: 70
-    line: 3
-    character: 6
-  end_position:
-    bytes: 71
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 71
-    line: 3
-    character: 7
-  end_position:
-    bytes: 72
-    line: 3
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 72
-    line: 3
-    character: 8
-  end_position:
-    bytes: 73
-    line: 3
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 73
-    line: 3
-    character: 9
-  end_position:
-    bytes: 74
-    line: 3
-    character: 10
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 74
-    line: 3
-    character: 10
-  end_position:
-    bytes: 75
-    line: 3
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 75
-    line: 3
-    character: 11
-  end_position:
-    bytes: 76
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 76
-    line: 3
-    character: 12
-  end_position:
-    bytes: 78
-    line: 3
-    character: 14
-  token_type:
-    type: Number
-    text: "10"
-- start_position:
-    bytes: 78
-    line: 3
-    character: 14
-  end_position:
-    bytes: 79
-    line: 3
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 79
-    line: 3
-    character: 15
-  end_position:
-    bytes: 80
-    line: 3
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 80
-    line: 3
-    character: 16
-  end_position:
-    bytes: 81
-    line: 3
-    character: 17
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 81
-    line: 3
-    character: 17
-  end_position:
-    bytes: 82
-    line: 3
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 82
-    line: 3
-    character: 18
-  end_position:
-    bytes: 84
-    line: 3
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 84
-    line: 3
-    character: 20
-  end_position:
-    bytes: 85
-    line: 3
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 85
-    line: 3
-    character: 21
-  end_position:
-    bytes: 88
-    line: 3
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 88
-    line: 3
-    character: 24
-  end_position:
-    bytes: 88
-    line: 3
-    character: 24
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: index
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Number
+      text: "10"
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 1
+        character: 21
+      end_position:
+        bytes: 21
+        line: 1
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 1
+      character: 22
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 26
+      line: 1
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 1
+      character: 27
+    end_position:
+      bytes: 31
+      line: 1
+      character: 32
+    token_type:
+      type: Identifier
+      identifier: index
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 1
+      character: 32
+    end_position:
+      bytes: 32
+      line: 1
+      character: 33
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 32
+        line: 1
+        character: 33
+      end_position:
+        bytes: 33
+        line: 1
+        character: 34
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 1
+      character: 34
+    end_position:
+      bytes: 36
+      line: 1
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 36
+        line: 1
+        character: 37
+      end_position:
+        bytes: 37
+        line: 1
+        character: 37
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 37
+      line: 2
+      character: 1
+    end_position:
+      bytes: 40
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 40
+        line: 2
+        character: 4
+      end_position:
+        bytes: 41
+        line: 2
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 2
+      character: 5
+    end_position:
+      bytes: 42
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: _
+  trailing_trivia:
+    - start_position:
+        bytes: 42
+        line: 2
+        character: 6
+      end_position:
+        bytes: 43
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 43
+      line: 2
+      character: 7
+    end_position:
+      bytes: 44
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 44
+        line: 2
+        character: 8
+      end_position:
+        bytes: 45
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 2
+      character: 9
+    end_position:
+      bytes: 50
+      line: 2
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: start
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 2
+      character: 14
+    end_position:
+      bytes: 51
+      line: 2
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 51
+        line: 2
+        character: 15
+      end_position:
+        bytes: 52
+        line: 2
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 2
+      character: 16
+    end_position:
+      bytes: 57
+      line: 2
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: final
+  trailing_trivia:
+    - start_position:
+        bytes: 57
+        line: 2
+        character: 21
+      end_position:
+        bytes: 58
+        line: 2
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 2
+      character: 22
+    end_position:
+      bytes: 60
+      line: 2
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 60
+        line: 2
+        character: 24
+      end_position:
+        bytes: 61
+        line: 2
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 61
+      line: 2
+      character: 25
+    end_position:
+      bytes: 64
+      line: 2
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 64
+        line: 2
+        character: 28
+      end_position:
+        bytes: 65
+        line: 2
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 65
+      line: 3
+      character: 1
+    end_position:
+      bytes: 68
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 68
+        line: 3
+        character: 4
+      end_position:
+        bytes: 69
+        line: 3
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 69
+      line: 3
+      character: 5
+    end_position:
+      bytes: 70
+      line: 3
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: _
+  trailing_trivia:
+    - start_position:
+        bytes: 70
+        line: 3
+        character: 6
+      end_position:
+        bytes: 71
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 71
+      line: 3
+      character: 7
+    end_position:
+      bytes: 72
+      line: 3
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 72
+        line: 3
+        character: 8
+      end_position:
+        bytes: 73
+        line: 3
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 73
+      line: 3
+      character: 9
+    end_position:
+      bytes: 74
+      line: 3
+      character: 10
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 3
+      character: 10
+    end_position:
+      bytes: 75
+      line: 3
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 75
+        line: 3
+        character: 11
+      end_position:
+        bytes: 76
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 76
+      line: 3
+      character: 12
+    end_position:
+      bytes: 78
+      line: 3
+      character: 14
+    token_type:
+      type: Number
+      text: "10"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 78
+      line: 3
+      character: 14
+    end_position:
+      bytes: 79
+      line: 3
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 79
+        line: 3
+        character: 15
+      end_position:
+        bytes: 80
+        line: 3
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 80
+      line: 3
+      character: 16
+    end_position:
+      bytes: 81
+      line: 3
+      character: 17
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 81
+        line: 3
+        character: 17
+      end_position:
+        bytes: 82
+        line: 3
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 82
+      line: 3
+      character: 18
+    end_position:
+      bytes: 84
+      line: 3
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 84
+        line: 3
+        character: 20
+      end_position:
+        bytes: 85
+        line: 3
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 3
+      character: 21
+    end_position:
+      bytes: 88
+      line: 3
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 88
+      line: 3
+      character: 24
+    end_position:
+      bytes: 88
+      line: 3
+      character: 24
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/paren-expressions/tokens.snap
+++ b/full-moon/tests/cases/pass/paren-expressions/tokens.snap
@@ -4,201 +4,234 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/paren-expressions
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 1
+        character: 19
+      end_position:
+        bytes: 19
+        line: 1
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 1
+      character: 22
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/repeat-until/tokens.snap
+++ b/full-moon/tests/cases/pass/repeat-until/tokens.snap
@@ -4,124 +4,145 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/repeat-until
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: repeat
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 7
-    line: 2
-    character: 1
-  end_position:
-    bytes: 8
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 8
-    line: 2
-    character: 2
-  end_position:
-    bytes: 12
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 12
-    line: 2
-    character: 6
-  end_position:
-    bytes: 13
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 13
-    line: 2
-    character: 7
-  end_position:
-    bytes: 14
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 2
-    character: 8
-  end_position:
-    bytes: 15
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 3
-    character: 1
-  end_position:
-    bytes: 20
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: until
-- start_position:
-    bytes: 20
-    line: 3
-    character: 6
-  end_position:
-    bytes: 21
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 21
-    line: 3
-    character: 7
-  end_position:
-    bytes: 30
-    line: 3
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: condition
-- start_position:
-    bytes: 30
-    line: 3
-    character: 16
-  end_position:
-    bytes: 30
-    line: 3
-    character: 16
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: repeat
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 7
+        line: 2
+        character: 1
+      end_position:
+        bytes: 8
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 8
+      line: 2
+      character: 2
+    end_position:
+      bytes: 12
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 6
+    end_position:
+      bytes: 13
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 7
+    end_position:
+      bytes: 14
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 8
+      end_position:
+        bytes: 15
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 3
+      character: 1
+    end_position:
+      bytes: 20
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: until
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 3
+        character: 6
+      end_position:
+        bytes: 21
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 7
+    end_position:
+      bytes: 30
+      line: 3
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: condition
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 3
+      character: 16
+    end_position:
+      bytes: 30
+      line: 3
+      character: 16
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/return-break/tokens.snap
+++ b/full-moon/tests/cases/pass/return-break/tokens.snap
@@ -4,278 +4,314 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/return-break
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 3
-    line: 1
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 3
-    line: 2
-    character: 1
-  end_position:
-    bytes: 4
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 4
-    line: 2
-    character: 2
-  end_position:
-    bytes: 10
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 10
-    line: 2
-    character: 8
-  end_position:
-    bytes: 11
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 2
-    character: 9
-  end_position:
-    bytes: 12
-    line: 2
-    character: 10
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 10
-  end_position:
-    bytes: 13
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 13
-    line: 3
-    character: 1
-  end_position:
-    bytes: 16
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 16
-    line: 3
-    character: 4
-  end_position:
-    bytes: 17
-    line: 3
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 17
-    line: 4
-    character: 1
-  end_position:
-    bytes: 18
-    line: 4
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 18
-    line: 5
-    character: 1
-  end_position:
-    bytes: 20
-    line: 5
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 20
-    line: 5
-    character: 3
-  end_position:
-    bytes: 21
-    line: 5
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 21
-    line: 6
-    character: 1
-  end_position:
-    bytes: 22
-    line: 6
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 22
-    line: 6
-    character: 2
-  end_position:
-    bytes: 27
-    line: 6
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: break
-- start_position:
-    bytes: 27
-    line: 6
-    character: 7
-  end_position:
-    bytes: 28
-    line: 6
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 28
-    line: 7
-    character: 1
-  end_position:
-    bytes: 31
-    line: 7
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 31
-    line: 7
-    character: 4
-  end_position:
-    bytes: 32
-    line: 7
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 32
-    line: 8
-    character: 1
-  end_position:
-    bytes: 33
-    line: 8
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 33
-    line: 9
-    character: 1
-  end_position:
-    bytes: 39
-    line: 9
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 39
-    line: 9
-    character: 7
-  end_position:
-    bytes: 40
-    line: 9
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 9
-    character: 8
-  end_position:
-    bytes: 44
-    line: 9
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 44
-    line: 9
-    character: 12
-  end_position:
-    bytes: 45
-    line: 9
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 45
-    line: 9
-    character: 13
-  end_position:
-    bytes: 46
-    line: 9
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 46
-    line: 9
-    character: 14
-  end_position:
-    bytes: 47
-    line: 9
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 47
-    line: 10
-    character: 1
-  end_position:
-    bytes: 47
-    line: 10
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 2
+        line: 1
+        character: 3
+      end_position:
+        bytes: 3
+        line: 1
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 3
+        line: 2
+        character: 1
+      end_position:
+        bytes: 4
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 4
+      line: 2
+      character: 2
+    end_position:
+      bytes: 10
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 2
+        character: 8
+      end_position:
+        bytes: 11
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 9
+    end_position:
+      bytes: 12
+      line: 2
+      character: 10
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 2
+        character: 10
+      end_position:
+        bytes: 13
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 3
+      character: 1
+    end_position:
+      bytes: 16
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 3
+        character: 4
+      end_position:
+        bytes: 17
+        line: 3
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 17
+        line: 4
+        character: 1
+      end_position:
+        bytes: 18
+        line: 4
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 18
+      line: 5
+      character: 1
+    end_position:
+      bytes: 20
+      line: 5
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 5
+        character: 3
+      end_position:
+        bytes: 21
+        line: 5
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 21
+        line: 6
+        character: 1
+      end_position:
+        bytes: 22
+        line: 6
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 22
+      line: 6
+      character: 2
+    end_position:
+      bytes: 27
+      line: 6
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: break
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 6
+        character: 7
+      end_position:
+        bytes: 28
+        line: 6
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 7
+      character: 1
+    end_position:
+      bytes: 31
+      line: 7
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 7
+        character: 4
+      end_position:
+        bytes: 32
+        line: 7
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 32
+        line: 8
+        character: 1
+      end_position:
+        bytes: 33
+        line: 8
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 33
+      line: 9
+      character: 1
+    end_position:
+      bytes: 39
+      line: 9
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 9
+        character: 7
+      end_position:
+        bytes: 40
+        line: 9
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 9
+      character: 8
+    end_position:
+      bytes: 44
+      line: 9
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 44
+      line: 9
+      character: 12
+    end_position:
+      bytes: 45
+      line: 9
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 9
+      character: 13
+    end_position:
+      bytes: 46
+      line: 9
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 9
+        character: 14
+      end_position:
+        bytes: 47
+        line: 9
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 10
+      character: 1
+    end_position:
+      bytes: 47
+      line: 10
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/semicolons-1/tokens.snap
+++ b/full-moon/tests/cases/pass/semicolons-1/tokens.snap
@@ -4,212 +4,245 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/semicolons-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 1
+        character: 13
+      end_position:
+        bytes: 13
+        line: 1
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 1
+        character: 19
+      end_position:
+        bytes: 19
+        line: 1
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 1
+        character: 21
+      end_position:
+        bytes: 21
+        line: 1
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 1
+      character: 22
+    end_position:
+      bytes: 22
+      line: 1
+      character: 23
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 1
+      character: 23
+    end_position:
+      bytes: 22
+      line: 1
+      character: 23
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/semicolons-2/tokens.snap
+++ b/full-moon/tests/cases/pass/semicolons-2/tokens.snap
@@ -4,146 +4,170 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/semicolons-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 18
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 18
-    line: 2
-    character: 7
-  end_position:
-    bytes: 19
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 19
-    line: 2
-    character: 8
-  end_position:
-    bytes: 20
-    line: 2
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 20
-    line: 2
-    character: 9
-  end_position:
-    bytes: 21
-    line: 2
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 21
-    line: 2
-    character: 10
-  end_position:
-    bytes: 21
-    line: 2
-    character: 10
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 1
+    end_position:
+      bytes: 18
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 2
+        character: 7
+      end_position:
+        bytes: 19
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 8
+    end_position:
+      bytes: 20
+      line: 2
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 9
+    end_position:
+      bytes: 21
+      line: 2
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 2
+      character: 10
+    end_position:
+      bytes: 21
+      line: 2
+      character: 10
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/shebang/tokens.snap
+++ b/full-moon/tests/cases/pass/shebang/tokens.snap
@@ -4,103 +4,121 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/shebang
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 19
-    line: 1
-    character: 19
-  token_type:
-    type: Shebang
-    line: "#!/usr/bin/env lua\n"
-- start_position:
-    bytes: 19
-    line: 2
-    character: 1
-  end_position:
-    bytes: 20
-    line: 2
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 20
-    line: 3
-    character: 1
-  end_position:
-    bytes: 25
-    line: 3
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: print
-- start_position:
-    bytes: 25
-    line: 3
-    character: 6
-  end_position:
-    bytes: 26
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 26
-    line: 3
-    character: 7
-  end_position:
-    bytes: 39
-    line: 3
-    character: 20
-  token_type:
-    type: StringLiteral
-    literal: Hello world
-    quote_type: Double
-- start_position:
-    bytes: 39
-    line: 3
-    character: 20
-  end_position:
-    bytes: 40
-    line: 3
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 40
-    line: 3
-    character: 21
-  end_position:
-    bytes: 41
-    line: 3
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 41
-    line: 3
-    character: 22
-  end_position:
-    bytes: 42
-    line: 3
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 42
-    line: 4
-    character: 1
-  end_position:
-    bytes: 42
-    line: 4
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 19
+        line: 1
+        character: 19
+      token_type:
+        type: Shebang
+        line: "#!/usr/bin/env lua\n"
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 1
+      end_position:
+        bytes: 20
+        line: 2
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 20
+      line: 3
+      character: 1
+    end_position:
+      bytes: 25
+      line: 3
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: print
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 3
+      character: 6
+    end_position:
+      bytes: 26
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 3
+      character: 7
+    end_position:
+      bytes: 39
+      line: 3
+      character: 20
+    token_type:
+      type: StringLiteral
+      literal: Hello world
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 39
+      line: 3
+      character: 20
+    end_position:
+      bytes: 40
+      line: 3
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 3
+      character: 21
+    end_position:
+      bytes: 41
+      line: 3
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia:
+    - start_position:
+        bytes: 41
+        line: 3
+        character: 22
+      end_position:
+        bytes: 42
+        line: 3
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 4
+      character: 1
+    end_position:
+      bytes: 42
+      line: 4
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/single-line-comment-1/tokens.snap
+++ b/full-moon/tests/cases/pass/single-line-comment-1/tokens.snap
@@ -4,47 +4,50 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/single-line-comment-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: SingleLineComment
-    comment: " hello world"
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 2
-    character: 1
-  end_position:
-    bytes: 34
-    line: 2
-    character: 20
-  token_type:
-    type: SingleLineComment
-    comment: " and doge you too"
-- start_position:
-    bytes: 34
-    line: 2
-    character: 20
-  end_position:
-    bytes: 34
-    line: 2
-    character: 20
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: SingleLineComment
+        comment: " hello world"
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 15
+        line: 2
+        character: 1
+      end_position:
+        bytes: 34
+        line: 2
+        character: 20
+      token_type:
+        type: SingleLineComment
+        comment: " and doge you too"
+  token:
+    start_position:
+      bytes: 34
+      line: 2
+      character: 20
+    end_position:
+      bytes: 34
+      line: 2
+      character: 20
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/single-line-comment-2/tokens.snap
+++ b/full-moon/tests/cases/pass/single-line-comment-2/tokens.snap
@@ -4,69 +4,81 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/single-line-comment-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: SingleLineComment
-    comment: " This calls"
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 20
+        line: 1
+        character: 21
+      token_type:
+        type: SingleLineComment
+        comment: " This calls"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/single-line-comment-3/tokens.snap
+++ b/full-moon/tests/cases/pass/single-line-comment-3/tokens.snap
@@ -4,25 +4,28 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/single-line-comment-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: SingleLineComment
-    comment: " tab\tin comment"
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: SingleLineComment
+        comment: " tab\tin comment"
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/strings-escape-newline/tokens.snap
+++ b/full-moon/tests/cases/pass/strings-escape-newline/tokens.snap
@@ -4,70 +4,85 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/strings-escape-newline
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: print
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 17
-    line: 2
-    character: 6
-  token_type:
-    type: StringLiteral
-    literal: "foo\\\n\tbar"
-    quote_type: Double
-- start_position:
-    bytes: 17
-    line: 2
-    character: 6
-  end_position:
-    bytes: 18
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 18
-    line: 2
-    character: 7
-  end_position:
-    bytes: 19
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 19
-    line: 3
-    character: 1
-  end_position:
-    bytes: 19
-    line: 3
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: print
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 17
+      line: 2
+      character: 6
+    token_type:
+      type: StringLiteral
+      literal: "foo\\\n\tbar"
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 6
+    end_position:
+      bytes: 18
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 2
+        character: 7
+      end_position:
+        bytes: 19
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 3
+      character: 1
+    end_position:
+      bytes: 19
+      line: 3
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/strings/tokens.snap
+++ b/full-moon/tests/cases/pass/strings/tokens.snap
@@ -4,227 +4,278 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/strings
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: StringLiteral
-    literal: double
-    quote_type: Double
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 2
-    character: 1
-  end_position:
-    bytes: 19
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 19
-    line: 2
-    character: 5
-  end_position:
-    bytes: 20
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 20
-    line: 2
-    character: 6
-  end_position:
-    bytes: 28
-    line: 2
-    character: 14
-  token_type:
-    type: StringLiteral
-    literal: single
-    quote_type: Single
-- start_position:
-    bytes: 28
-    line: 2
-    character: 14
-  end_position:
-    bytes: 29
-    line: 2
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 29
-    line: 2
-    character: 15
-  end_position:
-    bytes: 30
-    line: 2
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 30
-    line: 3
-    character: 1
-  end_position:
-    bytes: 34
-    line: 3
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 34
-    line: 3
-    character: 5
-  end_position:
-    bytes: 35
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 35
-    line: 3
-    character: 6
-  end_position:
-    bytes: 45
-    line: 3
-    character: 16
-  token_type:
-    type: StringLiteral
-    literal: "foo\\nbar"
-    quote_type: Double
-- start_position:
-    bytes: 45
-    line: 3
-    character: 16
-  end_position:
-    bytes: 46
-    line: 3
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 46
-    line: 3
-    character: 17
-  end_position:
-    bytes: 47
-    line: 3
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 47
-    line: 4
-    character: 1
-  end_position:
-    bytes: 51
-    line: 4
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 51
-    line: 4
-    character: 5
-  end_position:
-    bytes: 52
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 52
-    line: 4
-    character: 6
-  end_position:
-    bytes: 54
-    line: 4
-    character: 8
-  token_type:
-    type: StringLiteral
-    literal: ""
-    quote_type: Double
-- start_position:
-    bytes: 54
-    line: 4
-    character: 8
-  end_position:
-    bytes: 55
-    line: 4
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 55
-    line: 4
-    character: 9
-  end_position:
-    bytes: 55
-    line: 4
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: StringLiteral
+      literal: double
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 1
+    end_position:
+      bytes: 19
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 5
+    end_position:
+      bytes: 20
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 6
+    end_position:
+      bytes: 28
+      line: 2
+      character: 14
+    token_type:
+      type: StringLiteral
+      literal: single
+      quote_type: Single
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 2
+      character: 14
+    end_position:
+      bytes: 29
+      line: 2
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 29
+        line: 2
+        character: 15
+      end_position:
+        bytes: 30
+        line: 2
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 3
+      character: 1
+    end_position:
+      bytes: 34
+      line: 3
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 3
+      character: 5
+    end_position:
+      bytes: 35
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 3
+      character: 6
+    end_position:
+      bytes: 45
+      line: 3
+      character: 16
+    token_type:
+      type: StringLiteral
+      literal: "foo\\nbar"
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 45
+      line: 3
+      character: 16
+    end_position:
+      bytes: 46
+      line: 3
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 46
+        line: 3
+        character: 17
+      end_position:
+        bytes: 47
+        line: 3
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 4
+      character: 1
+    end_position:
+      bytes: 51
+      line: 4
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 51
+      line: 4
+      character: 5
+    end_position:
+      bytes: 52
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 4
+      character: 6
+    end_position:
+      bytes: 54
+      line: 4
+      character: 8
+    token_type:
+      type: StringLiteral
+      literal: ""
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 4
+      character: 8
+    end_position:
+      bytes: 55
+      line: 4
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 4
+      character: 9
+    end_position:
+      bytes: 55
+      line: 4
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructor-1/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructor-1/tokens.snap
@@ -4,113 +4,131 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructor-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 13
-    line: 2
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 13
-    line: 2
-    character: 2
-  end_position:
-    bytes: 13
-    line: 2
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 1
+    end_position:
+      bytes: 13
+      line: 2
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 2
+    end_position:
+      bytes: 13
+      line: 2
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructor-2/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructor-2/tokens.snap
@@ -4,179 +4,212 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructor-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructor-3/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructor-3/tokens.snap
@@ -4,751 +4,853 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructor-3
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 13
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 13
-    line: 2
-    character: 2
-  end_position:
-    bytes: 14
-    line: 2
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 14
-    line: 2
-    character: 3
-  end_position:
-    bytes: 15
-    line: 2
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 15
-    line: 2
-    character: 4
-  end_position:
-    bytes: 16
-    line: 2
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 16
-    line: 2
-    character: 5
-  end_position:
-    bytes: 17
-    line: 2
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 2
-    character: 6
-  end_position:
-    bytes: 18
-    line: 2
-    character: 7
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 18
-    line: 2
-    character: 7
-  end_position:
-    bytes: 19
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 19
-    line: 2
-    character: 8
-  end_position:
-    bytes: 20
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 20
-    line: 3
-    character: 1
-  end_position:
-    bytes: 21
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 21
-    line: 3
-    character: 2
-  end_position:
-    bytes: 22
-    line: 3
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 22
-    line: 3
-    character: 3
-  end_position:
-    bytes: 23
-    line: 3
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 23
-    line: 3
-    character: 4
-  end_position:
-    bytes: 24
-    line: 3
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 24
-    line: 3
-    character: 5
-  end_position:
-    bytes: 25
-    line: 3
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 25
-    line: 3
-    character: 6
-  end_position:
-    bytes: 26
-    line: 3
-    character: 7
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 26
-    line: 3
-    character: 7
-  end_position:
-    bytes: 27
-    line: 3
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 27
-    line: 3
-    character: 8
-  end_position:
-    bytes: 28
-    line: 3
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 28
-    line: 4
-    character: 1
-  end_position:
-    bytes: 29
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 29
-    line: 4
-    character: 2
-  end_position:
-    bytes: 30
-    line: 4
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: c
-- start_position:
-    bytes: 30
-    line: 4
-    character: 3
-  end_position:
-    bytes: 31
-    line: 4
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 31
-    line: 4
-    character: 4
-  end_position:
-    bytes: 32
-    line: 4
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 32
-    line: 4
-    character: 5
-  end_position:
-    bytes: 33
-    line: 4
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 33
-    line: 4
-    character: 6
-  end_position:
-    bytes: 34
-    line: 4
-    character: 7
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 34
-    line: 4
-    character: 7
-  end_position:
-    bytes: 35
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 35
-    line: 5
-    character: 1
-  end_position:
-    bytes: 36
-    line: 5
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 36
-    line: 5
-    character: 2
-  end_position:
-    bytes: 37
-    line: 5
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 37
-    line: 6
-    character: 1
-  end_position:
-    bytes: 38
-    line: 6
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 38
-    line: 7
-    character: 1
-  end_position:
-    bytes: 43
-    line: 7
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 43
-    line: 7
-    character: 6
-  end_position:
-    bytes: 44
-    line: 7
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 44
-    line: 7
-    character: 7
-  end_position:
-    bytes: 45
-    line: 7
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 45
-    line: 7
-    character: 8
-  end_position:
-    bytes: 46
-    line: 7
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 46
-    line: 7
-    character: 9
-  end_position:
-    bytes: 47
-    line: 7
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 47
-    line: 7
-    character: 10
-  end_position:
-    bytes: 48
-    line: 7
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 48
-    line: 7
-    character: 11
-  end_position:
-    bytes: 49
-    line: 7
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 49
-    line: 7
-    character: 12
-  end_position:
-    bytes: 50
-    line: 7
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 50
-    line: 8
-    character: 1
-  end_position:
-    bytes: 51
-    line: 8
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 51
-    line: 8
-    character: 2
-  end_position:
-    bytes: 52
-    line: 8
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 52
-    line: 8
-    character: 3
-  end_position:
-    bytes: 53
-    line: 8
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 53
-    line: 8
-    character: 4
-  end_position:
-    bytes: 54
-    line: 8
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 54
-    line: 8
-    character: 5
-  end_position:
-    bytes: 55
-    line: 8
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 55
-    line: 8
-    character: 6
-  end_position:
-    bytes: 56
-    line: 8
-    character: 7
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 56
-    line: 8
-    character: 7
-  end_position:
-    bytes: 57
-    line: 8
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 57
-    line: 8
-    character: 8
-  end_position:
-    bytes: 58
-    line: 8
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 58
-    line: 9
-    character: 1
-  end_position:
-    bytes: 59
-    line: 9
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 59
-    line: 9
-    character: 2
-  end_position:
-    bytes: 60
-    line: 9
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 60
-    line: 9
-    character: 3
-  end_position:
-    bytes: 61
-    line: 9
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 61
-    line: 9
-    character: 4
-  end_position:
-    bytes: 62
-    line: 9
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 62
-    line: 9
-    character: 5
-  end_position:
-    bytes: 63
-    line: 9
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 63
-    line: 9
-    character: 6
-  end_position:
-    bytes: 64
-    line: 9
-    character: 7
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 64
-    line: 9
-    character: 7
-  end_position:
-    bytes: 65
-    line: 9
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 65
-    line: 9
-    character: 8
-  end_position:
-    bytes: 66
-    line: 9
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 66
-    line: 10
-    character: 1
-  end_position:
-    bytes: 67
-    line: 10
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 67
-    line: 10
-    character: 2
-  end_position:
-    bytes: 68
-    line: 10
-    character: 3
-  token_type:
-    type: Identifier
-    identifier: c
-- start_position:
-    bytes: 68
-    line: 10
-    character: 3
-  end_position:
-    bytes: 69
-    line: 10
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 69
-    line: 10
-    character: 4
-  end_position:
-    bytes: 70
-    line: 10
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 70
-    line: 10
-    character: 5
-  end_position:
-    bytes: 71
-    line: 10
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 71
-    line: 10
-    character: 6
-  end_position:
-    bytes: 72
-    line: 10
-    character: 7
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 72
-    line: 10
-    character: 7
-  end_position:
-    bytes: 73
-    line: 10
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 73
-    line: 10
-    character: 8
-  end_position:
-    bytes: 74
-    line: 10
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 74
-    line: 11
-    character: 1
-  end_position:
-    bytes: 75
-    line: 11
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 75
-    line: 11
-    character: 2
-  end_position:
-    bytes: 75
-    line: 11
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 12
+        line: 2
+        character: 1
+      end_position:
+        bytes: 13
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 2
+    end_position:
+      bytes: 14
+      line: 2
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 2
+        character: 3
+      end_position:
+        bytes: 15
+        line: 2
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 2
+      character: 4
+    end_position:
+      bytes: 16
+      line: 2
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 2
+        character: 5
+      end_position:
+        bytes: 17
+        line: 2
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 2
+      character: 6
+    end_position:
+      bytes: 18
+      line: 2
+      character: 7
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 7
+    end_position:
+      bytes: 19
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 8
+      end_position:
+        bytes: 20
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 20
+        line: 3
+        character: 1
+      end_position:
+        bytes: 21
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 21
+      line: 3
+      character: 2
+    end_position:
+      bytes: 22
+      line: 3
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia:
+    - start_position:
+        bytes: 22
+        line: 3
+        character: 3
+      end_position:
+        bytes: 23
+        line: 3
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 3
+      character: 4
+    end_position:
+      bytes: 24
+      line: 3
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 24
+        line: 3
+        character: 5
+      end_position:
+        bytes: 25
+        line: 3
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 3
+      character: 6
+    end_position:
+      bytes: 26
+      line: 3
+      character: 7
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 3
+      character: 7
+    end_position:
+      bytes: 27
+      line: 3
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 3
+        character: 8
+      end_position:
+        bytes: 28
+        line: 3
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 28
+        line: 4
+        character: 1
+      end_position:
+        bytes: 29
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 29
+      line: 4
+      character: 2
+    end_position:
+      bytes: 30
+      line: 4
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: c
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 4
+        character: 3
+      end_position:
+        bytes: 31
+        line: 4
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 4
+      character: 4
+    end_position:
+      bytes: 32
+      line: 4
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 32
+        line: 4
+        character: 5
+      end_position:
+        bytes: 33
+        line: 4
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 4
+      character: 6
+    end_position:
+      bytes: 34
+      line: 4
+      character: 7
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 4
+        character: 7
+      end_position:
+        bytes: 35
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 5
+      character: 1
+    end_position:
+      bytes: 36
+      line: 5
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 36
+        line: 5
+        character: 2
+      end_position:
+        bytes: 37
+        line: 5
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 37
+        line: 6
+        character: 1
+      end_position:
+        bytes: 38
+        line: 6
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 38
+      line: 7
+      character: 1
+    end_position:
+      bytes: 43
+      line: 7
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 43
+        line: 7
+        character: 6
+      end_position:
+        bytes: 44
+        line: 7
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 44
+      line: 7
+      character: 7
+    end_position:
+      bytes: 45
+      line: 7
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 45
+        line: 7
+        character: 8
+      end_position:
+        bytes: 46
+        line: 7
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 46
+      line: 7
+      character: 9
+    end_position:
+      bytes: 47
+      line: 7
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 47
+        line: 7
+        character: 10
+      end_position:
+        bytes: 48
+        line: 7
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 7
+      character: 11
+    end_position:
+      bytes: 49
+      line: 7
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 49
+        line: 7
+        character: 12
+      end_position:
+        bytes: 50
+        line: 7
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 50
+        line: 8
+        character: 1
+      end_position:
+        bytes: 51
+        line: 8
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 51
+      line: 8
+      character: 2
+    end_position:
+      bytes: 52
+      line: 8
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia:
+    - start_position:
+        bytes: 52
+        line: 8
+        character: 3
+      end_position:
+        bytes: 53
+        line: 8
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 8
+      character: 4
+    end_position:
+      bytes: 54
+      line: 8
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 54
+        line: 8
+        character: 5
+      end_position:
+        bytes: 55
+        line: 8
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 8
+      character: 6
+    end_position:
+      bytes: 56
+      line: 8
+      character: 7
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 56
+      line: 8
+      character: 7
+    end_position:
+      bytes: 57
+      line: 8
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 57
+        line: 8
+        character: 8
+      end_position:
+        bytes: 58
+        line: 8
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 58
+        line: 9
+        character: 1
+      end_position:
+        bytes: 59
+        line: 9
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 59
+      line: 9
+      character: 2
+    end_position:
+      bytes: 60
+      line: 9
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia:
+    - start_position:
+        bytes: 60
+        line: 9
+        character: 3
+      end_position:
+        bytes: 61
+        line: 9
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 61
+      line: 9
+      character: 4
+    end_position:
+      bytes: 62
+      line: 9
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 62
+        line: 9
+        character: 5
+      end_position:
+        bytes: 63
+        line: 9
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 63
+      line: 9
+      character: 6
+    end_position:
+      bytes: 64
+      line: 9
+      character: 7
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 64
+      line: 9
+      character: 7
+    end_position:
+      bytes: 65
+      line: 9
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 65
+        line: 9
+        character: 8
+      end_position:
+        bytes: 66
+        line: 9
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 66
+        line: 10
+        character: 1
+      end_position:
+        bytes: 67
+        line: 10
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 67
+      line: 10
+      character: 2
+    end_position:
+      bytes: 68
+      line: 10
+      character: 3
+    token_type:
+      type: Identifier
+      identifier: c
+  trailing_trivia:
+    - start_position:
+        bytes: 68
+        line: 10
+        character: 3
+      end_position:
+        bytes: 69
+        line: 10
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 69
+      line: 10
+      character: 4
+    end_position:
+      bytes: 70
+      line: 10
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 70
+        line: 10
+        character: 5
+      end_position:
+        bytes: 71
+        line: 10
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 71
+      line: 10
+      character: 6
+    end_position:
+      bytes: 72
+      line: 10
+      character: 7
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 72
+      line: 10
+      character: 7
+    end_position:
+      bytes: 73
+      line: 10
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 73
+        line: 10
+        character: 8
+      end_position:
+        bytes: 74
+        line: 10
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 11
+      character: 1
+    end_position:
+      bytes: 75
+      line: 11
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 11
+      character: 2
+    end_position:
+      bytes: 75
+      line: 11
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructor-4/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructor-4/tokens.snap
@@ -4,245 +4,287 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructor-4
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 13
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 13
-    line: 2
-    character: 2
-  end_position:
-    bytes: 14
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 14
-    line: 2
-    character: 3
-  end_position:
-    bytes: 18
-    line: 2
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 18
-    line: 2
-    character: 7
-  end_position:
-    bytes: 19
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 2
-    character: 8
-  end_position:
-    bytes: 20
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 20
-    line: 2
-    character: 9
-  end_position:
-    bytes: 21
-    line: 2
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 21
-    line: 2
-    character: 10
-  end_position:
-    bytes: 22
-    line: 2
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 2
-    character: 11
-  end_position:
-    bytes: 23
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 23
-    line: 2
-    character: 12
-  end_position:
-    bytes: 24
-    line: 2
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 2
-    character: 13
-  end_position:
-    bytes: 25
-    line: 2
-    character: 14
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 25
-    line: 2
-    character: 14
-  end_position:
-    bytes: 26
-    line: 2
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 26
-    line: 2
-    character: 15
-  end_position:
-    bytes: 27
-    line: 2
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 27
-    line: 3
-    character: 1
-  end_position:
-    bytes: 28
-    line: 3
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 28
-    line: 3
-    character: 2
-  end_position:
-    bytes: 28
-    line: 3
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 12
+        line: 2
+        character: 1
+      end_position:
+        bytes: 13
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 2
+    end_position:
+      bytes: 14
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 3
+    end_position:
+      bytes: 18
+      line: 2
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 7
+    end_position:
+      bytes: 19
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 8
+    end_position:
+      bytes: 20
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 9
+    end_position:
+      bytes: 21
+      line: 2
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 10
+      end_position:
+        bytes: 22
+        line: 2
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 11
+    end_position:
+      bytes: 23
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 2
+        character: 12
+      end_position:
+        bytes: 24
+        line: 2
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 13
+    end_position:
+      bytes: 25
+      line: 2
+      character: 14
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 14
+    end_position:
+      bytes: 26
+      line: 2
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 15
+      end_position:
+        bytes: 27
+        line: 2
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 3
+      character: 1
+    end_position:
+      bytes: 28
+      line: 3
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 3
+      character: 2
+    end_position:
+      bytes: 28
+      line: 3
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructor-5/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructor-5/tokens.snap
@@ -4,289 +4,337 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructor-5
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 13
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 13
-    line: 2
-    character: 2
-  end_position:
-    bytes: 14
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 14
-    line: 2
-    character: 3
-  end_position:
-    bytes: 18
-    line: 2
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 18
-    line: 2
-    character: 7
-  end_position:
-    bytes: 19
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 19
-    line: 2
-    character: 8
-  end_position:
-    bytes: 20
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 20
-    line: 2
-    character: 9
-  end_position:
-    bytes: 21
-    line: 2
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 21
-    line: 2
-    character: 10
-  end_position:
-    bytes: 22
-    line: 2
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 2
-    character: 11
-  end_position:
-    bytes: 23
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 23
-    line: 2
-    character: 12
-  end_position:
-    bytes: 24
-    line: 2
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 2
-    character: 13
-  end_position:
-    bytes: 25
-    line: 2
-    character: 14
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 25
-    line: 2
-    character: 14
-  end_position:
-    bytes: 26
-    line: 2
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 26
-    line: 2
-    character: 15
-  end_position:
-    bytes: 27
-    line: 2
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 27
-    line: 3
-    character: 1
-  end_position:
-    bytes: 28
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 28
-    line: 3
-    character: 2
-  end_position:
-    bytes: 29
-    line: 3
-    character: 3
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 29
-    line: 3
-    character: 3
-  end_position:
-    bytes: 30
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 30
-    line: 3
-    character: 4
-  end_position:
-    bytes: 31
-    line: 3
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 31
-    line: 4
-    character: 1
-  end_position:
-    bytes: 32
-    line: 4
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 32
-    line: 4
-    character: 2
-  end_position:
-    bytes: 32
-    line: 4
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 12
+        line: 2
+        character: 1
+      end_position:
+        bytes: 13
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 13
+      line: 2
+      character: 2
+    end_position:
+      bytes: 14
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 2
+      character: 3
+    end_position:
+      bytes: 18
+      line: 2
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 7
+    end_position:
+      bytes: 19
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 8
+    end_position:
+      bytes: 20
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 9
+    end_position:
+      bytes: 21
+      line: 2
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 10
+      end_position:
+        bytes: 22
+        line: 2
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 11
+    end_position:
+      bytes: 23
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 2
+        character: 12
+      end_position:
+        bytes: 24
+        line: 2
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 13
+    end_position:
+      bytes: 25
+      line: 2
+      character: 14
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 14
+    end_position:
+      bytes: 26
+      line: 2
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 15
+      end_position:
+        bytes: 27
+        line: 2
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 27
+        line: 3
+        character: 1
+      end_position:
+        bytes: 28
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 28
+      line: 3
+      character: 2
+    end_position:
+      bytes: 29
+      line: 3
+      character: 3
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 3
+      character: 3
+    end_position:
+      bytes: 30
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 3
+        character: 4
+      end_position:
+        bytes: 31
+        line: 3
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 4
+      character: 1
+    end_position:
+      bytes: 32
+      line: 4
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 4
+      character: 2
+    end_position:
+      bytes: 32
+      line: 4
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructor-6/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructor-6/tokens.snap
@@ -4,135 +4,156 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructor-6
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructors-7/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructors-7/tokens.snap
@@ -4,446 +4,518 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructors-7
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: blacklist
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 20
-    line: 2
-    character: 1
-  end_position:
-    bytes: 21
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 21
-    line: 2
-    character: 2
-  end_position:
-    bytes: 22
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 22
-    line: 2
-    character: 3
-  end_position:
-    bytes: 55
-    line: 2
-    character: 36
-  token_type:
-    type: StringLiteral
-    literal: Audio file failed to load (18).
-    quote_type: Double
-- start_position:
-    bytes: 55
-    line: 2
-    character: 36
-  end_position:
-    bytes: 56
-    line: 2
-    character: 37
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 56
-    line: 2
-    character: 37
-  end_position:
-    bytes: 57
-    line: 2
-    character: 38
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 57
-    line: 2
-    character: 38
-  end_position:
-    bytes: 58
-    line: 2
-    character: 39
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 58
-    line: 2
-    character: 39
-  end_position:
-    bytes: 59
-    line: 2
-    character: 40
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 59
-    line: 2
-    character: 40
-  end_position:
-    bytes: 63
-    line: 2
-    character: 44
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 63
-    line: 2
-    character: 44
-  end_position:
-    bytes: 64
-    line: 2
-    character: 45
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 64
-    line: 2
-    character: 45
-  end_position:
-    bytes: 65
-    line: 2
-    character: 45
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 65
-    line: 3
-    character: 1
-  end_position:
-    bytes: 66
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 66
-    line: 3
-    character: 2
-  end_position:
-    bytes: 67
-    line: 3
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 67
-    line: 3
-    character: 3
-  end_position:
-    bytes: 131
-    line: 3
-    character: 67
-  token_type:
-    type: StringLiteral
-    literal: HTTP 0 (HTTP 429 (HTTP/1.1 429 ProvisionedThroughputExceeded))
-    quote_type: Double
-- start_position:
-    bytes: 131
-    line: 3
-    character: 67
-  end_position:
-    bytes: 132
-    line: 3
-    character: 68
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 132
-    line: 3
-    character: 68
-  end_position:
-    bytes: 133
-    line: 3
-    character: 69
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 133
-    line: 3
-    character: 69
-  end_position:
-    bytes: 134
-    line: 3
-    character: 70
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 134
-    line: 3
-    character: 70
-  end_position:
-    bytes: 135
-    line: 3
-    character: 71
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 135
-    line: 3
-    character: 71
-  end_position:
-    bytes: 139
-    line: 3
-    character: 75
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 139
-    line: 3
-    character: 75
-  end_position:
-    bytes: 140
-    line: 3
-    character: 76
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 140
-    line: 3
-    character: 76
-  end_position:
-    bytes: 141
-    line: 3
-    character: 76
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 141
-    line: 4
-    character: 1
-  end_position:
-    bytes: 142
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 142
-    line: 4
-    character: 2
-  end_position:
-    bytes: 143
-    line: 4
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 143
-    line: 4
-    character: 3
-  end_position:
-    bytes: 205
-    line: 4
-    character: 65
-  token_type:
-    type: StringLiteral
-    literal: LoadCharacter can only be called when Player is in the world
-    quote_type: Double
-- start_position:
-    bytes: 205
-    line: 4
-    character: 65
-  end_position:
-    bytes: 206
-    line: 4
-    character: 66
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 206
-    line: 4
-    character: 66
-  end_position:
-    bytes: 207
-    line: 4
-    character: 67
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 207
-    line: 4
-    character: 67
-  end_position:
-    bytes: 208
-    line: 4
-    character: 68
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 208
-    line: 4
-    character: 68
-  end_position:
-    bytes: 209
-    line: 4
-    character: 69
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 209
-    line: 4
-    character: 69
-  end_position:
-    bytes: 213
-    line: 4
-    character: 73
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 213
-    line: 4
-    character: 73
-  end_position:
-    bytes: 214
-    line: 4
-    character: 74
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 214
-    line: 4
-    character: 74
-  end_position:
-    bytes: 215
-    line: 4
-    character: 74
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 215
-    line: 5
-    character: 1
-  end_position:
-    bytes: 216
-    line: 5
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 216
-    line: 5
-    character: 2
-  end_position:
-    bytes: 216
-    line: 5
-    character: 2
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: blacklist
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 20
+        line: 2
+        character: 1
+      end_position:
+        bytes: 21
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 21
+      line: 2
+      character: 2
+    end_position:
+      bytes: 22
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 3
+    end_position:
+      bytes: 55
+      line: 2
+      character: 36
+    token_type:
+      type: StringLiteral
+      literal: Audio file failed to load (18).
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 2
+      character: 36
+    end_position:
+      bytes: 56
+      line: 2
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 56
+        line: 2
+        character: 37
+      end_position:
+        bytes: 57
+        line: 2
+        character: 38
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 57
+      line: 2
+      character: 38
+    end_position:
+      bytes: 58
+      line: 2
+      character: 39
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 58
+        line: 2
+        character: 39
+      end_position:
+        bytes: 59
+        line: 2
+        character: 40
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 59
+      line: 2
+      character: 40
+    end_position:
+      bytes: 63
+      line: 2
+      character: 44
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 63
+      line: 2
+      character: 44
+    end_position:
+      bytes: 64
+      line: 2
+      character: 45
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia:
+    - start_position:
+        bytes: 64
+        line: 2
+        character: 45
+      end_position:
+        bytes: 65
+        line: 2
+        character: 45
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 65
+        line: 3
+        character: 1
+      end_position:
+        bytes: 66
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 66
+      line: 3
+      character: 2
+    end_position:
+      bytes: 67
+      line: 3
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 67
+      line: 3
+      character: 3
+    end_position:
+      bytes: 131
+      line: 3
+      character: 67
+    token_type:
+      type: StringLiteral
+      literal: HTTP 0 (HTTP 429 (HTTP/1.1 429 ProvisionedThroughputExceeded))
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 131
+      line: 3
+      character: 67
+    end_position:
+      bytes: 132
+      line: 3
+      character: 68
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 132
+        line: 3
+        character: 68
+      end_position:
+        bytes: 133
+        line: 3
+        character: 69
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 133
+      line: 3
+      character: 69
+    end_position:
+      bytes: 134
+      line: 3
+      character: 70
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 134
+        line: 3
+        character: 70
+      end_position:
+        bytes: 135
+        line: 3
+        character: 71
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 135
+      line: 3
+      character: 71
+    end_position:
+      bytes: 139
+      line: 3
+      character: 75
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 139
+      line: 3
+      character: 75
+    end_position:
+      bytes: 140
+      line: 3
+      character: 76
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia:
+    - start_position:
+        bytes: 140
+        line: 3
+        character: 76
+      end_position:
+        bytes: 141
+        line: 3
+        character: 76
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 141
+        line: 4
+        character: 1
+      end_position:
+        bytes: 142
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 142
+      line: 4
+      character: 2
+    end_position:
+      bytes: 143
+      line: 4
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 143
+      line: 4
+      character: 3
+    end_position:
+      bytes: 205
+      line: 4
+      character: 65
+    token_type:
+      type: StringLiteral
+      literal: LoadCharacter can only be called when Player is in the world
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 205
+      line: 4
+      character: 65
+    end_position:
+      bytes: 206
+      line: 4
+      character: 66
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 206
+        line: 4
+        character: 66
+      end_position:
+        bytes: 207
+        line: 4
+        character: 67
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 207
+      line: 4
+      character: 67
+    end_position:
+      bytes: 208
+      line: 4
+      character: 68
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 208
+        line: 4
+        character: 68
+      end_position:
+        bytes: 209
+        line: 4
+        character: 69
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 209
+      line: 4
+      character: 69
+    end_position:
+      bytes: 213
+      line: 4
+      character: 73
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 213
+      line: 4
+      character: 73
+    end_position:
+      bytes: 214
+      line: 4
+      character: 74
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia:
+    - start_position:
+        bytes: 214
+        line: 4
+        character: 74
+      end_position:
+        bytes: 215
+        line: 4
+        character: 74
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 215
+      line: 5
+      character: 1
+    end_position:
+      bytes: 216
+      line: 5
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 216
+      line: 5
+      character: 2
+    end_position:
+      bytes: 216
+      line: 5
+      character: 2
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/table-constructors-8/tokens.snap
+++ b/full-moon/tests/cases/pass/table-constructors-8/tokens.snap
@@ -4,304 +4,352 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/table-constructors-8
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 9
-    line: 2
-    character: 1
-  end_position:
-    bytes: 10
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 10
-    line: 2
-    character: 2
-  end_position:
-    bytes: 11
-    line: 2
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 11
-    line: 2
-    character: 3
-  end_position:
-    bytes: 36
-    line: 2
-    character: 28
-  token_type:
-    type: StringLiteral
-    literal: "Noob Attack: Periastron"
-    quote_type: Double
-- start_position:
-    bytes: 36
-    line: 2
-    character: 28
-  end_position:
-    bytes: 37
-    line: 2
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 37
-    line: 2
-    character: 29
-  end_position:
-    bytes: 38
-    line: 2
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 38
-    line: 2
-    character: 30
-  end_position:
-    bytes: 39
-    line: 2
-    character: 31
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 39
-    line: 2
-    character: 31
-  end_position:
-    bytes: 40
-    line: 2
-    character: 32
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 2
-    character: 32
-  end_position:
-    bytes: 66
-    line: 2
-    character: 58
-  token_type:
-    type: StringLiteral
-    literal: Noob Attack - Periastron
-    quote_type: Double
-- start_position:
-    bytes: 66
-    line: 2
-    character: 58
-  end_position:
-    bytes: 67
-    line: 2
-    character: 59
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 67
-    line: 2
-    character: 59
-  end_position:
-    bytes: 68
-    line: 2
-    character: 59
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 68
-    line: 3
-    character: 1
-  end_position:
-    bytes: 69
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 69
-    line: 3
-    character: 2
-  end_position:
-    bytes: 70
-    line: 3
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 70
-    line: 3
-    character: 3
-  end_position:
-    bytes: 97
-    line: 3
-    character: 28
-  token_type:
-    type: StringLiteral
-    literal: Noob Attack꞉ Periastron
-    quote_type: Double
-- start_position:
-    bytes: 97
-    line: 3
-    character: 28
-  end_position:
-    bytes: 98
-    line: 3
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 98
-    line: 3
-    character: 29
-  end_position:
-    bytes: 99
-    line: 3
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 99
-    line: 3
-    character: 30
-  end_position:
-    bytes: 100
-    line: 3
-    character: 31
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 100
-    line: 3
-    character: 31
-  end_position:
-    bytes: 101
-    line: 3
-    character: 32
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 101
-    line: 3
-    character: 32
-  end_position:
-    bytes: 127
-    line: 3
-    character: 58
-  token_type:
-    type: StringLiteral
-    literal: Noob Attack - Periastron
-    quote_type: Double
-- start_position:
-    bytes: 127
-    line: 3
-    character: 58
-  end_position:
-    bytes: 128
-    line: 3
-    character: 59
-  token_type:
-    type: Symbol
-    symbol: ;
-- start_position:
-    bytes: 128
-    line: 3
-    character: 59
-  end_position:
-    bytes: 129
-    line: 3
-    character: 59
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 129
-    line: 4
-    character: 1
-  end_position:
-    bytes: 130
-    line: 4
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 130
-    line: 4
-    character: 2
-  end_position:
-    bytes: 131
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 131
-    line: 5
-    character: 1
-  end_position:
-    bytes: 131
-    line: 5
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 9
+        line: 2
+        character: 1
+      end_position:
+        bytes: 10
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 10
+      line: 2
+      character: 2
+    end_position:
+      bytes: 11
+      line: 2
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 2
+      character: 3
+    end_position:
+      bytes: 36
+      line: 2
+      character: 28
+    token_type:
+      type: StringLiteral
+      literal: "Noob Attack: Periastron"
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 2
+      character: 28
+    end_position:
+      bytes: 37
+      line: 2
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 37
+        line: 2
+        character: 29
+      end_position:
+        bytes: 38
+        line: 2
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 2
+      character: 30
+    end_position:
+      bytes: 39
+      line: 2
+      character: 31
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 2
+        character: 31
+      end_position:
+        bytes: 40
+        line: 2
+        character: 32
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 32
+    end_position:
+      bytes: 66
+      line: 2
+      character: 58
+    token_type:
+      type: StringLiteral
+      literal: Noob Attack - Periastron
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 66
+      line: 2
+      character: 58
+    end_position:
+      bytes: 67
+      line: 2
+      character: 59
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia:
+    - start_position:
+        bytes: 67
+        line: 2
+        character: 59
+      end_position:
+        bytes: 68
+        line: 2
+        character: 59
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 68
+        line: 3
+        character: 1
+      end_position:
+        bytes: 69
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 69
+      line: 3
+      character: 2
+    end_position:
+      bytes: 70
+      line: 3
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 70
+      line: 3
+      character: 3
+    end_position:
+      bytes: 97
+      line: 3
+      character: 28
+    token_type:
+      type: StringLiteral
+      literal: Noob Attack꞉ Periastron
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 97
+      line: 3
+      character: 28
+    end_position:
+      bytes: 98
+      line: 3
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 98
+        line: 3
+        character: 29
+      end_position:
+        bytes: 99
+        line: 3
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 99
+      line: 3
+      character: 30
+    end_position:
+      bytes: 100
+      line: 3
+      character: 31
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 100
+        line: 3
+        character: 31
+      end_position:
+        bytes: 101
+        line: 3
+        character: 32
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 101
+      line: 3
+      character: 32
+    end_position:
+      bytes: 127
+      line: 3
+      character: 58
+    token_type:
+      type: StringLiteral
+      literal: Noob Attack - Periastron
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 127
+      line: 3
+      character: 58
+    end_position:
+      bytes: 128
+      line: 3
+      character: 59
+    token_type:
+      type: Symbol
+      symbol: ;
+  trailing_trivia:
+    - start_position:
+        bytes: 128
+        line: 3
+        character: 59
+      end_position:
+        bytes: 129
+        line: 3
+        character: 59
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 129
+      line: 4
+      character: 1
+    end_position:
+      bytes: 130
+      line: 4
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 130
+        line: 4
+        character: 2
+      end_position:
+        bytes: 131
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 131
+      line: 5
+      character: 1
+    end_position:
+      bytes: 131
+      line: 5
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/trivia-parsing/tokens.snap
+++ b/full-moon/tests/cases/pass/trivia-parsing/tokens.snap
@@ -4,608 +4,677 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/trivia-parsing
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 35
-    line: 1
-    character: 36
-  token_type:
-    type: SingleLineComment
-    comment: " trailing comment"
-- start_position:
-    bytes: 35
-    line: 1
-    character: 36
-  end_position:
-    bytes: 36
-    line: 1
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 36
-    line: 2
-    character: 1
-  end_position:
-    bytes: 37
-    line: 2
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 37
-    line: 3
-    character: 1
-  end_position:
-    bytes: 55
-    line: 3
-    character: 19
-  token_type:
-    type: SingleLineComment
-    comment: " leading comment"
-- start_position:
-    bytes: 55
-    line: 3
-    character: 19
-  end_position:
-    bytes: 56
-    line: 3
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 56
-    line: 4
-    character: 1
-  end_position:
-    bytes: 61
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 61
-    line: 4
-    character: 6
-  end_position:
-    bytes: 62
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 62
-    line: 4
-    character: 7
-  end_position:
-    bytes: 65
-    line: 4
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 65
-    line: 4
-    character: 10
-  end_position:
-    bytes: 66
-    line: 4
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 66
-    line: 4
-    character: 11
-  end_position:
-    bytes: 67
-    line: 4
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 67
-    line: 4
-    character: 12
-  end_position:
-    bytes: 68
-    line: 4
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 68
-    line: 4
-    character: 13
-  end_position:
-    bytes: 71
-    line: 4
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: baz
-- start_position:
-    bytes: 71
-    line: 4
-    character: 16
-  end_position:
-    bytes: 72
-    line: 4
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 72
-    line: 5
-    character: 1
-  end_position:
-    bytes: 77
-    line: 5
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 77
-    line: 5
-    character: 6
-  end_position:
-    bytes: 78
-    line: 5
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 78
-    line: 5
-    character: 7
-  end_position:
-    bytes: 81
-    line: 5
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: baz
-- start_position:
-    bytes: 81
-    line: 5
-    character: 10
-  end_position:
-    bytes: 82
-    line: 5
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 82
-    line: 5
-    character: 11
-  end_position:
-    bytes: 83
-    line: 5
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 83
-    line: 5
-    character: 12
-  end_position:
-    bytes: 84
-    line: 5
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 84
-    line: 5
-    character: 13
-  end_position:
-    bytes: 87
-    line: 5
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 87
-    line: 5
-    character: 16
-  end_position:
-    bytes: 88
-    line: 5
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 88
-    line: 6
-    character: 1
-  end_position:
-    bytes: 89
-    line: 6
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 89
-    line: 7
-    character: 1
-  end_position:
-    bytes: 91
-    line: 7
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 91
-    line: 7
-    character: 3
-  end_position:
-    bytes: 92
-    line: 7
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 92
-    line: 8
-    character: 1
-  end_position:
-    bytes: 93
-    line: 8
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 93
-    line: 8
-    character: 2
-  end_position:
-    bytes: 98
-    line: 8
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 98
-    line: 8
-    character: 7
-  end_position:
-    bytes: 99
-    line: 8
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 99
-    line: 8
-    character: 8
-  end_position:
-    bytes: 102
-    line: 8
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 102
-    line: 8
-    character: 11
-  end_position:
-    bytes: 103
-    line: 8
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 103
-    line: 8
-    character: 12
-  end_position:
-    bytes: 104
-    line: 8
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 104
-    line: 8
-    character: 13
-  end_position:
-    bytes: 105
-    line: 8
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 105
-    line: 8
-    character: 14
-  end_position:
-    bytes: 108
-    line: 8
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 108
-    line: 8
-    character: 17
-  end_position:
-    bytes: 109
-    line: 8
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 109
-    line: 9
-    character: 1
-  end_position:
-    bytes: 110
-    line: 9
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 110
-    line: 9
-    character: 2
-  end_position:
-    bytes: 120
-    line: 9
-    character: 12
-  token_type:
-    type: SingleLineComment
-    comment: " comment"
-- start_position:
-    bytes: 120
-    line: 9
-    character: 12
-  end_position:
-    bytes: 121
-    line: 9
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 121
-    line: 10
-    character: 1
-  end_position:
-    bytes: 122
-    line: 10
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 122
-    line: 10
-    character: 2
-  end_position:
-    bytes: 127
-    line: 10
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 127
-    line: 10
-    character: 7
-  end_position:
-    bytes: 128
-    line: 10
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 128
-    line: 10
-    character: 8
-  end_position:
-    bytes: 131
-    line: 10
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 131
-    line: 10
-    character: 11
-  end_position:
-    bytes: 132
-    line: 10
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 132
-    line: 10
-    character: 12
-  end_position:
-    bytes: 133
-    line: 10
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 133
-    line: 10
-    character: 13
-  end_position:
-    bytes: 134
-    line: 10
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 134
-    line: 10
-    character: 14
-  end_position:
-    bytes: 137
-    line: 10
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: baz
-- start_position:
-    bytes: 137
-    line: 10
-    character: 17
-  end_position:
-    bytes: 138
-    line: 10
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 138
-    line: 11
-    character: 1
-  end_position:
-    bytes: 141
-    line: 11
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 141
-    line: 11
-    character: 4
-  end_position:
-    bytes: 141
-    line: 11
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 35
+        line: 1
+        character: 36
+      token_type:
+        type: SingleLineComment
+        comment: " trailing comment"
+    - start_position:
+        bytes: 35
+        line: 1
+        character: 36
+      end_position:
+        bytes: 36
+        line: 1
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 36
+        line: 2
+        character: 1
+      end_position:
+        bytes: 37
+        line: 2
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 37
+        line: 3
+        character: 1
+      end_position:
+        bytes: 55
+        line: 3
+        character: 19
+      token_type:
+        type: SingleLineComment
+        comment: " leading comment"
+    - start_position:
+        bytes: 55
+        line: 3
+        character: 19
+      end_position:
+        bytes: 56
+        line: 3
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 56
+      line: 4
+      character: 1
+    end_position:
+      bytes: 61
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 61
+        line: 4
+        character: 6
+      end_position:
+        bytes: 62
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 62
+      line: 4
+      character: 7
+    end_position:
+      bytes: 65
+      line: 4
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 65
+        line: 4
+        character: 10
+      end_position:
+        bytes: 66
+        line: 4
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 66
+      line: 4
+      character: 11
+    end_position:
+      bytes: 67
+      line: 4
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 67
+        line: 4
+        character: 12
+      end_position:
+        bytes: 68
+        line: 4
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 68
+      line: 4
+      character: 13
+    end_position:
+      bytes: 71
+      line: 4
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: baz
+  trailing_trivia:
+    - start_position:
+        bytes: 71
+        line: 4
+        character: 16
+      end_position:
+        bytes: 72
+        line: 4
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 72
+      line: 5
+      character: 1
+    end_position:
+      bytes: 77
+      line: 5
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 77
+        line: 5
+        character: 6
+      end_position:
+        bytes: 78
+        line: 5
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 78
+      line: 5
+      character: 7
+    end_position:
+      bytes: 81
+      line: 5
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: baz
+  trailing_trivia:
+    - start_position:
+        bytes: 81
+        line: 5
+        character: 10
+      end_position:
+        bytes: 82
+        line: 5
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 82
+      line: 5
+      character: 11
+    end_position:
+      bytes: 83
+      line: 5
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 83
+        line: 5
+        character: 12
+      end_position:
+        bytes: 84
+        line: 5
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 84
+      line: 5
+      character: 13
+    end_position:
+      bytes: 87
+      line: 5
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 87
+        line: 5
+        character: 16
+      end_position:
+        bytes: 88
+        line: 5
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 88
+        line: 6
+        character: 1
+      end_position:
+        bytes: 89
+        line: 6
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 89
+      line: 7
+      character: 1
+    end_position:
+      bytes: 91
+      line: 7
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 91
+        line: 7
+        character: 3
+      end_position:
+        bytes: 92
+        line: 7
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 92
+        line: 8
+        character: 1
+      end_position:
+        bytes: 93
+        line: 8
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 93
+      line: 8
+      character: 2
+    end_position:
+      bytes: 98
+      line: 8
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 98
+        line: 8
+        character: 7
+      end_position:
+        bytes: 99
+        line: 8
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 99
+      line: 8
+      character: 8
+    end_position:
+      bytes: 102
+      line: 8
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 102
+        line: 8
+        character: 11
+      end_position:
+        bytes: 103
+        line: 8
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 103
+      line: 8
+      character: 12
+    end_position:
+      bytes: 104
+      line: 8
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 104
+        line: 8
+        character: 13
+      end_position:
+        bytes: 105
+        line: 8
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 105
+      line: 8
+      character: 14
+    end_position:
+      bytes: 108
+      line: 8
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 108
+        line: 8
+        character: 17
+      end_position:
+        bytes: 109
+        line: 8
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 109
+        line: 9
+        character: 1
+      end_position:
+        bytes: 110
+        line: 9
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+    - start_position:
+        bytes: 110
+        line: 9
+        character: 2
+      end_position:
+        bytes: 120
+        line: 9
+        character: 12
+      token_type:
+        type: SingleLineComment
+        comment: " comment"
+    - start_position:
+        bytes: 120
+        line: 9
+        character: 12
+      end_position:
+        bytes: 121
+        line: 9
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 121
+        line: 10
+        character: 1
+      end_position:
+        bytes: 122
+        line: 10
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 122
+      line: 10
+      character: 2
+    end_position:
+      bytes: 127
+      line: 10
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 127
+        line: 10
+        character: 7
+      end_position:
+        bytes: 128
+        line: 10
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 128
+      line: 10
+      character: 8
+    end_position:
+      bytes: 131
+      line: 10
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 131
+        line: 10
+        character: 11
+      end_position:
+        bytes: 132
+        line: 10
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 132
+      line: 10
+      character: 12
+    end_position:
+      bytes: 133
+      line: 10
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 133
+        line: 10
+        character: 13
+      end_position:
+        bytes: 134
+        line: 10
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 134
+      line: 10
+      character: 14
+    end_position:
+      bytes: 137
+      line: 10
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: baz
+  trailing_trivia:
+    - start_position:
+        bytes: 137
+        line: 10
+        character: 17
+      end_position:
+        bytes: 138
+        line: 10
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 138
+      line: 11
+      character: 1
+    end_position:
+      bytes: 141
+      line: 11
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 141
+      line: 11
+      character: 4
+    end_position:
+      bytes: 141
+      line: 11
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/unops/tokens.snap
+++ b/full-moon/tests/cases/pass/unops/tokens.snap
@@ -4,520 +4,598 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/unops
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Identifier
-    identifier: negativeLiteral
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 23
-    line: 1
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 23
-    line: 1
-    character: 24
-  end_position:
-    bytes: 24
-    line: 1
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 1
-    character: 25
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 26
-    line: 1
-    character: 27
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 26
-    line: 1
-    character: 27
-  end_position:
-    bytes: 27
-    line: 1
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 27
-    line: 2
-    character: 1
-  end_position:
-    bytes: 32
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 32
-    line: 2
-    character: 6
-  end_position:
-    bytes: 33
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 33
-    line: 2
-    character: 7
-  end_position:
-    bytes: 49
-    line: 2
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: negativeVariable
-- start_position:
-    bytes: 49
-    line: 2
-    character: 23
-  end_position:
-    bytes: 50
-    line: 2
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 50
-    line: 2
-    character: 24
-  end_position:
-    bytes: 51
-    line: 2
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 51
-    line: 2
-    character: 25
-  end_position:
-    bytes: 52
-    line: 2
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 52
-    line: 2
-    character: 26
-  end_position:
-    bytes: 53
-    line: 2
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 53
-    line: 2
-    character: 27
-  end_position:
-    bytes: 54
-    line: 2
-    character: 28
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 54
-    line: 2
-    character: 28
-  end_position:
-    bytes: 55
-    line: 2
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 55
-    line: 3
-    character: 1
-  end_position:
-    bytes: 60
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 60
-    line: 3
-    character: 6
-  end_position:
-    bytes: 61
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 61
-    line: 3
-    character: 7
-  end_position:
-    bytes: 71
-    line: 3
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: notLiteral
-- start_position:
-    bytes: 71
-    line: 3
-    character: 17
-  end_position:
-    bytes: 72
-    line: 3
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 72
-    line: 3
-    character: 18
-  end_position:
-    bytes: 73
-    line: 3
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 73
-    line: 3
-    character: 19
-  end_position:
-    bytes: 74
-    line: 3
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 74
-    line: 3
-    character: 20
-  end_position:
-    bytes: 77
-    line: 3
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: not
-- start_position:
-    bytes: 77
-    line: 3
-    character: 23
-  end_position:
-    bytes: 78
-    line: 3
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 78
-    line: 3
-    character: 24
-  end_position:
-    bytes: 82
-    line: 3
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 82
-    line: 3
-    character: 28
-  end_position:
-    bytes: 83
-    line: 3
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 83
-    line: 4
-    character: 1
-  end_position:
-    bytes: 88
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 88
-    line: 4
-    character: 6
-  end_position:
-    bytes: 89
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 89
-    line: 4
-    character: 7
-  end_position:
-    bytes: 100
-    line: 4
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: notVariable
-- start_position:
-    bytes: 100
-    line: 4
-    character: 18
-  end_position:
-    bytes: 101
-    line: 4
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 101
-    line: 4
-    character: 19
-  end_position:
-    bytes: 102
-    line: 4
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 102
-    line: 4
-    character: 20
-  end_position:
-    bytes: 103
-    line: 4
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 103
-    line: 4
-    character: 21
-  end_position:
-    bytes: 106
-    line: 4
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: not
-- start_position:
-    bytes: 106
-    line: 4
-    character: 24
-  end_position:
-    bytes: 107
-    line: 4
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 107
-    line: 4
-    character: 25
-  end_position:
-    bytes: 108
-    line: 4
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 108
-    line: 4
-    character: 26
-  end_position:
-    bytes: 109
-    line: 4
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 109
-    line: 5
-    character: 1
-  end_position:
-    bytes: 114
-    line: 5
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 114
-    line: 5
-    character: 6
-  end_position:
-    bytes: 115
-    line: 5
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 115
-    line: 5
-    character: 7
-  end_position:
-    bytes: 121
-    line: 5
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: length
-- start_position:
-    bytes: 121
-    line: 5
-    character: 13
-  end_position:
-    bytes: 122
-    line: 5
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 122
-    line: 5
-    character: 14
-  end_position:
-    bytes: 123
-    line: 5
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 123
-    line: 5
-    character: 15
-  end_position:
-    bytes: 124
-    line: 5
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 124
-    line: 5
-    character: 16
-  end_position:
-    bytes: 125
-    line: 5
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "#"
-- start_position:
-    bytes: 125
-    line: 5
-    character: 17
-  end_position:
-    bytes: 126
-    line: 5
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 126
-    line: 5
-    character: 18
-  end_position:
-    bytes: 126
-    line: 5
-    character: 18
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Identifier
+      identifier: negativeLiteral
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 22
+      end_position:
+        bytes: 22
+        line: 1
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 1
+      character: 23
+    end_position:
+      bytes: 23
+      line: 1
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 1
+        character: 24
+      end_position:
+        bytes: 24
+        line: 1
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 1
+      character: 25
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 26
+      line: 1
+      character: 27
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 1
+        character: 27
+      end_position:
+        bytes: 27
+        line: 1
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 1
+    end_position:
+      bytes: 32
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 32
+        line: 2
+        character: 6
+      end_position:
+        bytes: 33
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 2
+      character: 7
+    end_position:
+      bytes: 49
+      line: 2
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: negativeVariable
+  trailing_trivia:
+    - start_position:
+        bytes: 49
+        line: 2
+        character: 23
+      end_position:
+        bytes: 50
+        line: 2
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 2
+      character: 24
+    end_position:
+      bytes: 51
+      line: 2
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 51
+        line: 2
+        character: 25
+      end_position:
+        bytes: 52
+        line: 2
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 2
+      character: 26
+    end_position:
+      bytes: 53
+      line: 2
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 2
+      character: 27
+    end_position:
+      bytes: 54
+      line: 2
+      character: 28
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 54
+        line: 2
+        character: 28
+      end_position:
+        bytes: 55
+        line: 2
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 3
+      character: 1
+    end_position:
+      bytes: 60
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 60
+        line: 3
+        character: 6
+      end_position:
+        bytes: 61
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 61
+      line: 3
+      character: 7
+    end_position:
+      bytes: 71
+      line: 3
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: notLiteral
+  trailing_trivia:
+    - start_position:
+        bytes: 71
+        line: 3
+        character: 17
+      end_position:
+        bytes: 72
+        line: 3
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 72
+      line: 3
+      character: 18
+    end_position:
+      bytes: 73
+      line: 3
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 73
+        line: 3
+        character: 19
+      end_position:
+        bytes: 74
+        line: 3
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 3
+      character: 20
+    end_position:
+      bytes: 77
+      line: 3
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: not
+  trailing_trivia:
+    - start_position:
+        bytes: 77
+        line: 3
+        character: 23
+      end_position:
+        bytes: 78
+        line: 3
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 78
+      line: 3
+      character: 24
+    end_position:
+      bytes: 82
+      line: 3
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia:
+    - start_position:
+        bytes: 82
+        line: 3
+        character: 28
+      end_position:
+        bytes: 83
+        line: 3
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 83
+      line: 4
+      character: 1
+    end_position:
+      bytes: 88
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 88
+        line: 4
+        character: 6
+      end_position:
+        bytes: 89
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 89
+      line: 4
+      character: 7
+    end_position:
+      bytes: 100
+      line: 4
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: notVariable
+  trailing_trivia:
+    - start_position:
+        bytes: 100
+        line: 4
+        character: 18
+      end_position:
+        bytes: 101
+        line: 4
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 101
+      line: 4
+      character: 19
+    end_position:
+      bytes: 102
+      line: 4
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 102
+        line: 4
+        character: 20
+      end_position:
+        bytes: 103
+        line: 4
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 103
+      line: 4
+      character: 21
+    end_position:
+      bytes: 106
+      line: 4
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: not
+  trailing_trivia:
+    - start_position:
+        bytes: 106
+        line: 4
+        character: 24
+      end_position:
+        bytes: 107
+        line: 4
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 107
+      line: 4
+      character: 25
+    end_position:
+      bytes: 108
+      line: 4
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 108
+        line: 4
+        character: 26
+      end_position:
+        bytes: 109
+        line: 4
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 109
+      line: 5
+      character: 1
+    end_position:
+      bytes: 114
+      line: 5
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 114
+        line: 5
+        character: 6
+      end_position:
+        bytes: 115
+        line: 5
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 115
+      line: 5
+      character: 7
+    end_position:
+      bytes: 121
+      line: 5
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: length
+  trailing_trivia:
+    - start_position:
+        bytes: 121
+        line: 5
+        character: 13
+      end_position:
+        bytes: 122
+        line: 5
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 122
+      line: 5
+      character: 14
+    end_position:
+      bytes: 123
+      line: 5
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 123
+        line: 5
+        character: 15
+      end_position:
+        bytes: 124
+        line: 5
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 124
+      line: 5
+      character: 16
+    end_position:
+      bytes: 125
+      line: 5
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "#"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 125
+      line: 5
+      character: 17
+    end_position:
+      bytes: 126
+      line: 5
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 126
+      line: 5
+      character: 18
+    end_position:
+      bytes: 126
+      line: 5
+      character: 18
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/utf-8/tokens.snap
+++ b/full-moon/tests/cases/pass/utf-8/tokens.snap
@@ -4,103 +4,124 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/utf-8
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: print
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 13
-    line: 1
-    character: 11
-  token_type:
-    type: StringLiteral
-    literal: "👚 "
-    quote_type: Double
-- start_position:
-    bytes: 13
-    line: 1
-    character: 11
-  end_position:
-    bytes: 14
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 12
-  end_position:
-    bytes: 16
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ".."
-- start_position:
-    bytes: 16
-    line: 1
-    character: 14
-  end_position:
-    bytes: 17
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 15
-  end_position:
-    bytes: 24
-    line: 1
-    character: 22
-  token_type:
-    type: Identifier
-    identifier: message
-- start_position:
-    bytes: 24
-    line: 1
-    character: 22
-  end_position:
-    bytes: 25
-    line: 1
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 25
-    line: 1
-    character: 23
-  end_position:
-    bytes: 25
-    line: 1
-    character: 23
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: print
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 13
+      line: 1
+      character: 11
+    token_type:
+      type: StringLiteral
+      literal: "👚 "
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 11
+      end_position:
+        bytes: 14
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 12
+    end_position:
+      bytes: 16
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ".."
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 14
+      end_position:
+        bytes: 17
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 15
+    end_position:
+      bytes: 24
+      line: 1
+      character: 22
+    token_type:
+      type: Identifier
+      identifier: message
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 1
+      character: 22
+    end_position:
+      bytes: 25
+      line: 1
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 23
+    end_position:
+      bytes: 25
+      line: 1
+      character: 23
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/cases/pass/while/tokens.snap
+++ b/full-moon/tests/cases/pass/while/tokens.snap
@@ -4,179 +4,206 @@ expression: tokens
 input_file: full-moon/tests/cases/pass/while
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: while
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: condition
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 19
-    line: 2
-    character: 1
-  end_position:
-    bytes: 20
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 20
-    line: 2
-    character: 2
-  end_position:
-    bytes: 24
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: call
-- start_position:
-    bytes: 24
-    line: 2
-    character: 6
-  end_position:
-    bytes: 25
-    line: 2
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 25
-    line: 2
-    character: 7
-  end_position:
-    bytes: 26
-    line: 2
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 26
-    line: 2
-    character: 8
-  end_position:
-    bytes: 27
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 27
-    line: 3
-    character: 1
-  end_position:
-    bytes: 28
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 28
-    line: 3
-    character: 2
-  end_position:
-    bytes: 33
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: break
-- start_position:
-    bytes: 33
-    line: 3
-    character: 7
-  end_position:
-    bytes: 34
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 34
-    line: 4
-    character: 1
-  end_position:
-    bytes: 37
-    line: 4
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 37
-    line: 4
-    character: 4
-  end_position:
-    bytes: 37
-    line: 4
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: while
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: condition
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 1
+        character: 19
+      end_position:
+        bytes: 19
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 1
+      end_position:
+        bytes: 20
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 2
+    end_position:
+      bytes: 24
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: call
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 6
+    end_position:
+      bytes: 25
+      line: 2
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 2
+      character: 7
+    end_position:
+      bytes: 26
+      line: 2
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 8
+      end_position:
+        bytes: 27
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 27
+        line: 3
+        character: 1
+      end_position:
+        bytes: 28
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 28
+      line: 3
+      character: 2
+    end_position:
+      bytes: 33
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: break
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 3
+        character: 7
+      end_position:
+        bytes: 34
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 4
+      character: 1
+    end_position:
+      bytes: 37
+      line: 4
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 37
+      line: 4
+      character: 4
+    end_position:
+      bytes: 37
+      line: 4
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/fail_cases.rs
+++ b/full-moon/tests/fail_cases.rs
@@ -5,6 +5,15 @@ use std::fs;
 mod common;
 use common::run_test_folder;
 
+fn unpack_token_reference<'a>(token: &tokenizer::TokenReference<'a>) -> Vec<tokenizer::Token<'a>> {
+    token
+        .leading_trivia()
+        .chain(std::iter::once(token.token()))
+        .chain(token.trailing_trivia())
+        .cloned()
+        .collect()
+}
+
 #[test]
 #[cfg_attr(feature = "no-source-tests", ignore)]
 fn test_parser_fail_cases() {
@@ -13,7 +22,13 @@ fn test_parser_fail_cases() {
 
         let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
 
-        assert_yaml_snapshot!("tokens", tokens);
+        assert_yaml_snapshot!(
+            "tokens",
+            tokens
+                .iter()
+                .flat_map(unpack_token_reference)
+                .collect::<Vec<_>>()
+        );
 
         match ast::Ast::from_tokens(tokens) {
             Ok(_) => panic!("fail case passed for {:?}", path),
@@ -49,7 +64,13 @@ fn test_lua52_parser_fail_cases() {
 
         let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
 
-        assert_yaml_snapshot!("tokens", tokens);
+        assert_yaml_snapshot!(
+            "tokens",
+            tokens
+                .iter()
+                .flat_map(unpack_token_reference)
+                .collect::<Vec<_>>()
+        );
 
         match ast::Ast::from_tokens(tokens) {
             Ok(_) => panic!("fail case passed for {:?}", path),

--- a/full-moon/tests/fail_cases.rs
+++ b/full-moon/tests/fail_cases.rs
@@ -5,15 +5,6 @@ use std::fs;
 mod common;
 use common::run_test_folder;
 
-fn unpack_token_reference<'a>(token: &tokenizer::TokenReference<'a>) -> Vec<tokenizer::Token<'a>> {
-    token
-        .leading_trivia()
-        .chain(std::iter::once(token.token()))
-        .chain(token.trailing_trivia())
-        .cloned()
-        .collect()
-}
-
 #[test]
 #[cfg_attr(feature = "no-source-tests", ignore)]
 fn test_parser_fail_cases() {
@@ -22,13 +13,7 @@ fn test_parser_fail_cases() {
 
         let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
 
-        assert_yaml_snapshot!(
-            "tokens",
-            tokens
-                .iter()
-                .flat_map(unpack_token_reference)
-                .collect::<Vec<_>>()
-        );
+        assert_yaml_snapshot!("tokens", tokens);
 
         match ast::Ast::from_tokens(tokens) {
             Ok(_) => panic!("fail case passed for {:?}", path),
@@ -64,13 +49,7 @@ fn test_lua52_parser_fail_cases() {
 
         let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
 
-        assert_yaml_snapshot!(
-            "tokens",
-            tokens
-                .iter()
-                .flat_map(unpack_token_reference)
-                .collect::<Vec<_>>()
-        );
+        assert_yaml_snapshot!("tokens", tokens);
 
         match ast::Ast::from_tokens(tokens) {
             Ok(_) => panic!("fail case passed for {:?}", path),

--- a/full-moon/tests/lua52_cases/fail/parser/goto-1/tokens.snap
+++ b/full-moon/tests/lua52_cases/fail/parser/goto-1/tokens.snap
@@ -4,25 +4,31 @@ expression: tokens
 input_file: full-moon/tests/lua52_cases/fail/parser/goto-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: goto
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: goto
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/lua52_cases/fail/parser/label-1/tokens.snap
+++ b/full-moon/tests/lua52_cases/fail/parser/label-1/tokens.snap
@@ -4,36 +4,45 @@ expression: tokens
 input_file: full-moon/tests/lua52_cases/fail/parser/label-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 2
-    line: 1
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "::"
-- start_position:
-    bytes: 2
-    line: 1
-    character: 3
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: label
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 2
+      line: 1
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "::"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 2
+      line: 1
+      character: 3
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: label
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/lua52_cases/fail/parser/label-2/tokens.snap
+++ b/full-moon/tests/lua52_cases/fail/parser/label-2/tokens.snap
@@ -4,36 +4,45 @@ expression: tokens
 input_file: full-moon/tests/lua52_cases/fail/parser/label-2
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: label
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "::"
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: label
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "::"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/lua52_cases/pass/goto-1/tokens.snap
+++ b/full-moon/tests/lua52_cases/pass/goto-1/tokens.snap
@@ -4,399 +4,459 @@ expression: tokens
 input_file: full-moon/tests/lua52_cases/pass/goto-1
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: i
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "10"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 15
-    line: 2
-    character: 1
-  end_position:
-    bytes: 16
-    line: 2
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 16
-    line: 2
-    character: 2
-  end_position:
-    bytes: 18
-    line: 2
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 18
-    line: 2
-    character: 4
-  end_position:
-    bytes: 19
-    line: 2
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 19
-    line: 2
-    character: 5
-  end_position:
-    bytes: 20
-    line: 2
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: i
-- start_position:
-    bytes: 20
-    line: 2
-    character: 6
-  end_position:
-    bytes: 21
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 21
-    line: 2
-    character: 7
-  end_position:
-    bytes: 23
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "=="
-- start_position:
-    bytes: 23
-    line: 2
-    character: 9
-  end_position:
-    bytes: 24
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 24
-    line: 2
-    character: 10
-  end_position:
-    bytes: 25
-    line: 2
-    character: 11
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 25
-    line: 2
-    character: 11
-  end_position:
-    bytes: 26
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 26
-    line: 2
-    character: 12
-  end_position:
-    bytes: 30
-    line: 2
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 30
-    line: 2
-    character: 16
-  end_position:
-    bytes: 31
-    line: 2
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 31
-    line: 3
-    character: 1
-  end_position:
-    bytes: 33
-    line: 3
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\t\t"
-- start_position:
-    bytes: 33
-    line: 3
-    character: 3
-  end_position:
-    bytes: 37
-    line: 3
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: goto
-- start_position:
-    bytes: 37
-    line: 3
-    character: 7
-  end_position:
-    bytes: 38
-    line: 3
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 38
-    line: 3
-    character: 8
-  end_position:
-    bytes: 42
-    line: 3
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: done
-- start_position:
-    bytes: 42
-    line: 3
-    character: 12
-  end_position:
-    bytes: 43
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 43
-    line: 4
-    character: 1
-  end_position:
-    bytes: 44
-    line: 4
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 44
-    line: 4
-    character: 2
-  end_position:
-    bytes: 47
-    line: 4
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 47
-    line: 4
-    character: 5
-  end_position:
-    bytes: 48
-    line: 4
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 48
-    line: 5
-    character: 1
-  end_position:
-    bytes: 51
-    line: 5
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 51
-    line: 5
-    character: 4
-  end_position:
-    bytes: 52
-    line: 5
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 52
-    line: 6
-    character: 1
-  end_position:
-    bytes: 54
-    line: 6
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: "::"
-- start_position:
-    bytes: 54
-    line: 6
-    character: 3
-  end_position:
-    bytes: 58
-    line: 6
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: done
-- start_position:
-    bytes: 58
-    line: 6
-    character: 7
-  end_position:
-    bytes: 60
-    line: 6
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "::"
-- start_position:
-    bytes: 60
-    line: 6
-    character: 9
-  end_position:
-    bytes: 60
-    line: 6
-    character: 9
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: i
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "10"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 14
+        line: 1
+        character: 15
+      end_position:
+        bytes: 15
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 15
+        line: 2
+        character: 1
+      end_position:
+        bytes: 16
+        line: 2
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 16
+      line: 2
+      character: 2
+    end_position:
+      bytes: 18
+      line: 2
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 2
+        character: 4
+      end_position:
+        bytes: 19
+        line: 2
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 2
+      character: 5
+    end_position:
+      bytes: 20
+      line: 2
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: i
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 2
+        character: 6
+      end_position:
+        bytes: 21
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 2
+      character: 7
+    end_position:
+      bytes: 23
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "=="
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 2
+        character: 9
+      end_position:
+        bytes: 24
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 10
+    end_position:
+      bytes: 25
+      line: 2
+      character: 11
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 2
+        character: 11
+      end_position:
+        bytes: 26
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 12
+    end_position:
+      bytes: 30
+      line: 2
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 2
+        character: 16
+      end_position:
+        bytes: 31
+        line: 2
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 31
+        line: 3
+        character: 1
+      end_position:
+        bytes: 33
+        line: 3
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\t\t"
+  token:
+    start_position:
+      bytes: 33
+      line: 3
+      character: 3
+    end_position:
+      bytes: 37
+      line: 3
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: goto
+  trailing_trivia:
+    - start_position:
+        bytes: 37
+        line: 3
+        character: 7
+      end_position:
+        bytes: 38
+        line: 3
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 3
+      character: 8
+    end_position:
+      bytes: 42
+      line: 3
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: done
+  trailing_trivia:
+    - start_position:
+        bytes: 42
+        line: 3
+        character: 12
+      end_position:
+        bytes: 43
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 43
+        line: 4
+        character: 1
+      end_position:
+        bytes: 44
+        line: 4
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 44
+      line: 4
+      character: 2
+    end_position:
+      bytes: 47
+      line: 4
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 47
+        line: 4
+        character: 5
+      end_position:
+        bytes: 48
+        line: 4
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 5
+      character: 1
+    end_position:
+      bytes: 51
+      line: 5
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 51
+        line: 5
+        character: 4
+      end_position:
+        bytes: 52
+        line: 5
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 6
+      character: 1
+    end_position:
+      bytes: 54
+      line: 6
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: "::"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 6
+      character: 3
+    end_position:
+      bytes: 58
+      line: 6
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: done
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 6
+      character: 7
+    end_position:
+      bytes: 60
+      line: 6
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "::"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 60
+      line: 6
+      character: 9
+    end_position:
+      bytes: 60
+      line: 6
+      character: 9
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/pass_cases.rs
+++ b/full-moon/tests/pass_cases.rs
@@ -35,7 +35,13 @@ fn test_pass_case(path: &Path) {
 
     let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
 
-    assert_yaml_snapshot!("tokens", tokens);
+    assert_yaml_snapshot!(
+        "tokens",
+        tokens
+            .iter()
+            .flat_map(unpack_token_reference)
+            .collect::<Vec<_>>()
+    );
 
     let ast = ast::Ast::from_tokens(tokens)
         .unwrap_or_else(|error| panic!("couldn't make ast for {:?} - {:?}", path, error));

--- a/full-moon/tests/roblox_cases/pass/compound_assignment/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/compound_assignment/tokens.snap
@@ -4,1326 +4,1503 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/compound_assignment
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 12
-    line: 2
-    character: 1
-  end_position:
-    bytes: 17
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 17
-    line: 2
-    character: 6
-  end_position:
-    bytes: 18
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 2
-    character: 7
-  end_position:
-    bytes: 19
-    line: 2
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 19
-    line: 2
-    character: 8
-  end_position:
-    bytes: 20
-    line: 2
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 2
-    character: 9
-  end_position:
-    bytes: 21
-    line: 2
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 21
-    line: 2
-    character: 10
-  end_position:
-    bytes: 22
-    line: 2
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 2
-    character: 11
-  end_position:
-    bytes: 23
-    line: 2
-    character: 12
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 23
-    line: 2
-    character: 12
-  end_position:
-    bytes: 24
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 24
-    line: 3
-    character: 1
-  end_position:
-    bytes: 25
-    line: 3
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 25
-    line: 4
-    character: 1
-  end_position:
-    bytes: 26
-    line: 4
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 26
-    line: 4
-    character: 2
-  end_position:
-    bytes: 27
-    line: 4
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 27
-    line: 4
-    character: 3
-  end_position:
-    bytes: 29
-    line: 4
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: +=
-- start_position:
-    bytes: 29
-    line: 4
-    character: 5
-  end_position:
-    bytes: 30
-    line: 4
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 30
-    line: 4
-    character: 6
-  end_position:
-    bytes: 31
-    line: 4
-    character: 7
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 31
-    line: 4
-    character: 7
-  end_position:
-    bytes: 32
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 32
-    line: 5
-    character: 1
-  end_position:
-    bytes: 33
-    line: 5
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 33
-    line: 5
-    character: 2
-  end_position:
-    bytes: 34
-    line: 5
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 34
-    line: 5
-    character: 3
-  end_position:
-    bytes: 36
-    line: 5
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "-="
-- start_position:
-    bytes: 36
-    line: 5
-    character: 5
-  end_position:
-    bytes: 37
-    line: 5
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 37
-    line: 5
-    character: 6
-  end_position:
-    bytes: 38
-    line: 5
-    character: 7
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 38
-    line: 5
-    character: 7
-  end_position:
-    bytes: 39
-    line: 5
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 39
-    line: 6
-    character: 1
-  end_position:
-    bytes: 40
-    line: 6
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 40
-    line: 6
-    character: 2
-  end_position:
-    bytes: 41
-    line: 6
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 41
-    line: 6
-    character: 3
-  end_position:
-    bytes: 43
-    line: 6
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "*="
-- start_position:
-    bytes: 43
-    line: 6
-    character: 5
-  end_position:
-    bytes: 44
-    line: 6
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 44
-    line: 6
-    character: 6
-  end_position:
-    bytes: 45
-    line: 6
-    character: 7
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 45
-    line: 6
-    character: 7
-  end_position:
-    bytes: 46
-    line: 6
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 46
-    line: 7
-    character: 1
-  end_position:
-    bytes: 47
-    line: 7
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 47
-    line: 7
-    character: 2
-  end_position:
-    bytes: 48
-    line: 7
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 48
-    line: 7
-    character: 3
-  end_position:
-    bytes: 50
-    line: 7
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: /=
-- start_position:
-    bytes: 50
-    line: 7
-    character: 5
-  end_position:
-    bytes: 51
-    line: 7
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 51
-    line: 7
-    character: 6
-  end_position:
-    bytes: 52
-    line: 7
-    character: 7
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 52
-    line: 7
-    character: 7
-  end_position:
-    bytes: 53
-    line: 7
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 53
-    line: 8
-    character: 1
-  end_position:
-    bytes: 54
-    line: 8
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 54
-    line: 8
-    character: 2
-  end_position:
-    bytes: 55
-    line: 8
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 55
-    line: 8
-    character: 3
-  end_position:
-    bytes: 57
-    line: 8
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "%="
-- start_position:
-    bytes: 57
-    line: 8
-    character: 5
-  end_position:
-    bytes: 58
-    line: 8
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 58
-    line: 8
-    character: 6
-  end_position:
-    bytes: 59
-    line: 8
-    character: 7
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 59
-    line: 8
-    character: 7
-  end_position:
-    bytes: 60
-    line: 8
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 60
-    line: 9
-    character: 1
-  end_position:
-    bytes: 61
-    line: 9
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 61
-    line: 9
-    character: 2
-  end_position:
-    bytes: 62
-    line: 9
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 62
-    line: 9
-    character: 3
-  end_position:
-    bytes: 64
-    line: 9
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: ^=
-- start_position:
-    bytes: 64
-    line: 9
-    character: 5
-  end_position:
-    bytes: 65
-    line: 9
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 65
-    line: 9
-    character: 6
-  end_position:
-    bytes: 66
-    line: 9
-    character: 7
-  token_type:
-    type: Number
-    text: "5"
-- start_position:
-    bytes: 66
-    line: 9
-    character: 7
-  end_position:
-    bytes: 67
-    line: 9
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 67
-    line: 10
-    character: 1
-  end_position:
-    bytes: 68
-    line: 10
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 68
-    line: 11
-    character: 1
-  end_position:
-    bytes: 69
-    line: 11
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 69
-    line: 11
-    character: 2
-  end_position:
-    bytes: 70
-    line: 11
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 70
-    line: 11
-    character: 3
-  end_position:
-    bytes: 72
-    line: 11
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: +=
-- start_position:
-    bytes: 72
-    line: 11
-    character: 5
-  end_position:
-    bytes: 73
-    line: 11
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 73
-    line: 11
-    character: 6
-  end_position:
-    bytes: 74
-    line: 11
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 74
-    line: 11
-    character: 7
-  end_position:
-    bytes: 75
-    line: 11
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 75
-    line: 12
-    character: 1
-  end_position:
-    bytes: 76
-    line: 12
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 76
-    line: 12
-    character: 2
-  end_position:
-    bytes: 77
-    line: 12
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 77
-    line: 12
-    character: 3
-  end_position:
-    bytes: 79
-    line: 12
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "-="
-- start_position:
-    bytes: 79
-    line: 12
-    character: 5
-  end_position:
-    bytes: 80
-    line: 12
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 80
-    line: 12
-    character: 6
-  end_position:
-    bytes: 81
-    line: 12
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 81
-    line: 12
-    character: 7
-  end_position:
-    bytes: 82
-    line: 12
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 82
-    line: 13
-    character: 1
-  end_position:
-    bytes: 83
-    line: 13
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 83
-    line: 13
-    character: 2
-  end_position:
-    bytes: 84
-    line: 13
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 84
-    line: 13
-    character: 3
-  end_position:
-    bytes: 86
-    line: 13
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "*="
-- start_position:
-    bytes: 86
-    line: 13
-    character: 5
-  end_position:
-    bytes: 87
-    line: 13
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 87
-    line: 13
-    character: 6
-  end_position:
-    bytes: 88
-    line: 13
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 88
-    line: 13
-    character: 7
-  end_position:
-    bytes: 89
-    line: 13
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 89
-    line: 14
-    character: 1
-  end_position:
-    bytes: 90
-    line: 14
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 90
-    line: 14
-    character: 2
-  end_position:
-    bytes: 91
-    line: 14
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 91
-    line: 14
-    character: 3
-  end_position:
-    bytes: 93
-    line: 14
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: /=
-- start_position:
-    bytes: 93
-    line: 14
-    character: 5
-  end_position:
-    bytes: 94
-    line: 14
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 94
-    line: 14
-    character: 6
-  end_position:
-    bytes: 95
-    line: 14
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 95
-    line: 14
-    character: 7
-  end_position:
-    bytes: 96
-    line: 14
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 96
-    line: 15
-    character: 1
-  end_position:
-    bytes: 97
-    line: 15
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 97
-    line: 15
-    character: 2
-  end_position:
-    bytes: 98
-    line: 15
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 98
-    line: 15
-    character: 3
-  end_position:
-    bytes: 100
-    line: 15
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: "%="
-- start_position:
-    bytes: 100
-    line: 15
-    character: 5
-  end_position:
-    bytes: 101
-    line: 15
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 101
-    line: 15
-    character: 6
-  end_position:
-    bytes: 102
-    line: 15
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 102
-    line: 15
-    character: 7
-  end_position:
-    bytes: 103
-    line: 15
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 103
-    line: 16
-    character: 1
-  end_position:
-    bytes: 104
-    line: 16
-    character: 2
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 104
-    line: 16
-    character: 2
-  end_position:
-    bytes: 105
-    line: 16
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 105
-    line: 16
-    character: 3
-  end_position:
-    bytes: 107
-    line: 16
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: ^=
-- start_position:
-    bytes: 107
-    line: 16
-    character: 5
-  end_position:
-    bytes: 108
-    line: 16
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 108
-    line: 16
-    character: 6
-  end_position:
-    bytes: 109
-    line: 16
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 109
-    line: 16
-    character: 7
-  end_position:
-    bytes: 110
-    line: 16
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 110
-    line: 17
-    character: 1
-  end_position:
-    bytes: 111
-    line: 17
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 111
-    line: 18
-    character: 1
-  end_position:
-    bytes: 116
-    line: 18
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 116
-    line: 18
-    character: 6
-  end_position:
-    bytes: 117
-    line: 18
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 117
-    line: 18
-    character: 7
-  end_position:
-    bytes: 121
-    line: 18
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: str1
-- start_position:
-    bytes: 121
-    line: 18
-    character: 11
-  end_position:
-    bytes: 122
-    line: 18
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 122
-    line: 18
-    character: 12
-  end_position:
-    bytes: 123
-    line: 18
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 123
-    line: 18
-    character: 13
-  end_position:
-    bytes: 124
-    line: 18
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 124
-    line: 18
-    character: 14
-  end_position:
-    bytes: 133
-    line: 18
-    character: 23
-  token_type:
-    type: StringLiteral
-    literal: "Hello, "
-    quote_type: Double
-- start_position:
-    bytes: 133
-    line: 18
-    character: 23
-  end_position:
-    bytes: 134
-    line: 18
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 134
-    line: 19
-    character: 1
-  end_position:
-    bytes: 139
-    line: 19
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 139
-    line: 19
-    character: 6
-  end_position:
-    bytes: 140
-    line: 19
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 140
-    line: 19
-    character: 7
-  end_position:
-    bytes: 144
-    line: 19
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: str2
-- start_position:
-    bytes: 144
-    line: 19
-    character: 11
-  end_position:
-    bytes: 145
-    line: 19
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 145
-    line: 19
-    character: 12
-  end_position:
-    bytes: 146
-    line: 19
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 146
-    line: 19
-    character: 13
-  end_position:
-    bytes: 147
-    line: 19
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 147
-    line: 19
-    character: 14
-  end_position:
-    bytes: 155
-    line: 19
-    character: 22
-  token_type:
-    type: StringLiteral
-    literal: world!
-    quote_type: Double
-- start_position:
-    bytes: 155
-    line: 19
-    character: 22
-  end_position:
-    bytes: 156
-    line: 19
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 156
-    line: 20
-    character: 1
-  end_position:
-    bytes: 157
-    line: 20
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 157
-    line: 21
-    character: 1
-  end_position:
-    bytes: 161
-    line: 21
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: str1
-- start_position:
-    bytes: 161
-    line: 21
-    character: 5
-  end_position:
-    bytes: 162
-    line: 21
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 162
-    line: 21
-    character: 6
-  end_position:
-    bytes: 165
-    line: 21
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "..="
-- start_position:
-    bytes: 165
-    line: 21
-    character: 9
-  end_position:
-    bytes: 166
-    line: 21
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 166
-    line: 21
-    character: 10
-  end_position:
-    bytes: 174
-    line: 21
-    character: 18
-  token_type:
-    type: StringLiteral
-    literal: world!
-    quote_type: Double
-- start_position:
-    bytes: 174
-    line: 21
-    character: 18
-  end_position:
-    bytes: 175
-    line: 21
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 175
-    line: 22
-    character: 1
-  end_position:
-    bytes: 179
-    line: 22
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: str1
-- start_position:
-    bytes: 179
-    line: 22
-    character: 5
-  end_position:
-    bytes: 180
-    line: 22
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 180
-    line: 22
-    character: 6
-  end_position:
-    bytes: 183
-    line: 22
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: "..="
-- start_position:
-    bytes: 183
-    line: 22
-    character: 9
-  end_position:
-    bytes: 184
-    line: 22
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 184
-    line: 22
-    character: 10
-  end_position:
-    bytes: 188
-    line: 22
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: str2
-- start_position:
-    bytes: 188
-    line: 22
-    character: 14
-  end_position:
-    bytes: 188
-    line: 22
-    character: 14
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 7
+        line: 1
+        character: 8
+      end_position:
+        bytes: 8
+        line: 1
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia:
+    - start_position:
+        bytes: 11
+        line: 1
+        character: 12
+      end_position:
+        bytes: 12
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 2
+      character: 1
+    end_position:
+      bytes: 17
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 2
+        character: 6
+      end_position:
+        bytes: 18
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 2
+      character: 7
+    end_position:
+      bytes: 19
+      line: 2
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 2
+        character: 8
+      end_position:
+        bytes: 20
+        line: 2
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 2
+      character: 9
+    end_position:
+      bytes: 21
+      line: 2
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 2
+        character: 10
+      end_position:
+        bytes: 22
+        line: 2
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 11
+    end_position:
+      bytes: 23
+      line: 2
+      character: 12
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 2
+        character: 12
+      end_position:
+        bytes: 24
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 24
+        line: 3
+        character: 1
+      end_position:
+        bytes: 25
+        line: 3
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 25
+      line: 4
+      character: 1
+    end_position:
+      bytes: 26
+      line: 4
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 4
+        character: 2
+      end_position:
+        bytes: 27
+        line: 4
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 4
+      character: 3
+    end_position:
+      bytes: 29
+      line: 4
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: +=
+  trailing_trivia:
+    - start_position:
+        bytes: 29
+        line: 4
+        character: 5
+      end_position:
+        bytes: 30
+        line: 4
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 30
+      line: 4
+      character: 6
+    end_position:
+      bytes: 31
+      line: 4
+      character: 7
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 4
+        character: 7
+      end_position:
+        bytes: 32
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 5
+      character: 1
+    end_position:
+      bytes: 33
+      line: 5
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 5
+        character: 2
+      end_position:
+        bytes: 34
+        line: 5
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 5
+      character: 3
+    end_position:
+      bytes: 36
+      line: 5
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "-="
+  trailing_trivia:
+    - start_position:
+        bytes: 36
+        line: 5
+        character: 5
+      end_position:
+        bytes: 37
+        line: 5
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 37
+      line: 5
+      character: 6
+    end_position:
+      bytes: 38
+      line: 5
+      character: 7
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 38
+        line: 5
+        character: 7
+      end_position:
+        bytes: 39
+        line: 5
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 39
+      line: 6
+      character: 1
+    end_position:
+      bytes: 40
+      line: 6
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 40
+        line: 6
+        character: 2
+      end_position:
+        bytes: 41
+        line: 6
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 6
+      character: 3
+    end_position:
+      bytes: 43
+      line: 6
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "*="
+  trailing_trivia:
+    - start_position:
+        bytes: 43
+        line: 6
+        character: 5
+      end_position:
+        bytes: 44
+        line: 6
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 44
+      line: 6
+      character: 6
+    end_position:
+      bytes: 45
+      line: 6
+      character: 7
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 45
+        line: 6
+        character: 7
+      end_position:
+        bytes: 46
+        line: 6
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 46
+      line: 7
+      character: 1
+    end_position:
+      bytes: 47
+      line: 7
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 47
+        line: 7
+        character: 2
+      end_position:
+        bytes: 48
+        line: 7
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 7
+      character: 3
+    end_position:
+      bytes: 50
+      line: 7
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: /=
+  trailing_trivia:
+    - start_position:
+        bytes: 50
+        line: 7
+        character: 5
+      end_position:
+        bytes: 51
+        line: 7
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 51
+      line: 7
+      character: 6
+    end_position:
+      bytes: 52
+      line: 7
+      character: 7
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 52
+        line: 7
+        character: 7
+      end_position:
+        bytes: 53
+        line: 7
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 8
+      character: 1
+    end_position:
+      bytes: 54
+      line: 8
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 54
+        line: 8
+        character: 2
+      end_position:
+        bytes: 55
+        line: 8
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 8
+      character: 3
+    end_position:
+      bytes: 57
+      line: 8
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "%="
+  trailing_trivia:
+    - start_position:
+        bytes: 57
+        line: 8
+        character: 5
+      end_position:
+        bytes: 58
+        line: 8
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 8
+      character: 6
+    end_position:
+      bytes: 59
+      line: 8
+      character: 7
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 59
+        line: 8
+        character: 7
+      end_position:
+        bytes: 60
+        line: 8
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 60
+      line: 9
+      character: 1
+    end_position:
+      bytes: 61
+      line: 9
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 61
+        line: 9
+        character: 2
+      end_position:
+        bytes: 62
+        line: 9
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 62
+      line: 9
+      character: 3
+    end_position:
+      bytes: 64
+      line: 9
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: ^=
+  trailing_trivia:
+    - start_position:
+        bytes: 64
+        line: 9
+        character: 5
+      end_position:
+        bytes: 65
+        line: 9
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 65
+      line: 9
+      character: 6
+    end_position:
+      bytes: 66
+      line: 9
+      character: 7
+    token_type:
+      type: Number
+      text: "5"
+  trailing_trivia:
+    - start_position:
+        bytes: 66
+        line: 9
+        character: 7
+      end_position:
+        bytes: 67
+        line: 9
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 67
+        line: 10
+        character: 1
+      end_position:
+        bytes: 68
+        line: 10
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 68
+      line: 11
+      character: 1
+    end_position:
+      bytes: 69
+      line: 11
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 69
+        line: 11
+        character: 2
+      end_position:
+        bytes: 70
+        line: 11
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 70
+      line: 11
+      character: 3
+    end_position:
+      bytes: 72
+      line: 11
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: +=
+  trailing_trivia:
+    - start_position:
+        bytes: 72
+        line: 11
+        character: 5
+      end_position:
+        bytes: 73
+        line: 11
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 73
+      line: 11
+      character: 6
+    end_position:
+      bytes: 74
+      line: 11
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 74
+        line: 11
+        character: 7
+      end_position:
+        bytes: 75
+        line: 11
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 12
+      character: 1
+    end_position:
+      bytes: 76
+      line: 12
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 76
+        line: 12
+        character: 2
+      end_position:
+        bytes: 77
+        line: 12
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 77
+      line: 12
+      character: 3
+    end_position:
+      bytes: 79
+      line: 12
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "-="
+  trailing_trivia:
+    - start_position:
+        bytes: 79
+        line: 12
+        character: 5
+      end_position:
+        bytes: 80
+        line: 12
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 80
+      line: 12
+      character: 6
+    end_position:
+      bytes: 81
+      line: 12
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 81
+        line: 12
+        character: 7
+      end_position:
+        bytes: 82
+        line: 12
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 82
+      line: 13
+      character: 1
+    end_position:
+      bytes: 83
+      line: 13
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 83
+        line: 13
+        character: 2
+      end_position:
+        bytes: 84
+        line: 13
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 84
+      line: 13
+      character: 3
+    end_position:
+      bytes: 86
+      line: 13
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "*="
+  trailing_trivia:
+    - start_position:
+        bytes: 86
+        line: 13
+        character: 5
+      end_position:
+        bytes: 87
+        line: 13
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 87
+      line: 13
+      character: 6
+    end_position:
+      bytes: 88
+      line: 13
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 88
+        line: 13
+        character: 7
+      end_position:
+        bytes: 89
+        line: 13
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 89
+      line: 14
+      character: 1
+    end_position:
+      bytes: 90
+      line: 14
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 90
+        line: 14
+        character: 2
+      end_position:
+        bytes: 91
+        line: 14
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 91
+      line: 14
+      character: 3
+    end_position:
+      bytes: 93
+      line: 14
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: /=
+  trailing_trivia:
+    - start_position:
+        bytes: 93
+        line: 14
+        character: 5
+      end_position:
+        bytes: 94
+        line: 14
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 94
+      line: 14
+      character: 6
+    end_position:
+      bytes: 95
+      line: 14
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 95
+        line: 14
+        character: 7
+      end_position:
+        bytes: 96
+        line: 14
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 96
+      line: 15
+      character: 1
+    end_position:
+      bytes: 97
+      line: 15
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 97
+        line: 15
+        character: 2
+      end_position:
+        bytes: 98
+        line: 15
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 98
+      line: 15
+      character: 3
+    end_position:
+      bytes: 100
+      line: 15
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: "%="
+  trailing_trivia:
+    - start_position:
+        bytes: 100
+        line: 15
+        character: 5
+      end_position:
+        bytes: 101
+        line: 15
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 101
+      line: 15
+      character: 6
+    end_position:
+      bytes: 102
+      line: 15
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 102
+        line: 15
+        character: 7
+      end_position:
+        bytes: 103
+        line: 15
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 103
+      line: 16
+      character: 1
+    end_position:
+      bytes: 104
+      line: 16
+      character: 2
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia:
+    - start_position:
+        bytes: 104
+        line: 16
+        character: 2
+      end_position:
+        bytes: 105
+        line: 16
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 105
+      line: 16
+      character: 3
+    end_position:
+      bytes: 107
+      line: 16
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: ^=
+  trailing_trivia:
+    - start_position:
+        bytes: 107
+        line: 16
+        character: 5
+      end_position:
+        bytes: 108
+        line: 16
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 108
+      line: 16
+      character: 6
+    end_position:
+      bytes: 109
+      line: 16
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia:
+    - start_position:
+        bytes: 109
+        line: 16
+        character: 7
+      end_position:
+        bytes: 110
+        line: 16
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 110
+        line: 17
+        character: 1
+      end_position:
+        bytes: 111
+        line: 17
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 111
+      line: 18
+      character: 1
+    end_position:
+      bytes: 116
+      line: 18
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 116
+        line: 18
+        character: 6
+      end_position:
+        bytes: 117
+        line: 18
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 117
+      line: 18
+      character: 7
+    end_position:
+      bytes: 121
+      line: 18
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: str1
+  trailing_trivia:
+    - start_position:
+        bytes: 121
+        line: 18
+        character: 11
+      end_position:
+        bytes: 122
+        line: 18
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 122
+      line: 18
+      character: 12
+    end_position:
+      bytes: 123
+      line: 18
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 123
+        line: 18
+        character: 13
+      end_position:
+        bytes: 124
+        line: 18
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 124
+      line: 18
+      character: 14
+    end_position:
+      bytes: 133
+      line: 18
+      character: 23
+    token_type:
+      type: StringLiteral
+      literal: "Hello, "
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 133
+        line: 18
+        character: 23
+      end_position:
+        bytes: 134
+        line: 18
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 134
+      line: 19
+      character: 1
+    end_position:
+      bytes: 139
+      line: 19
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 139
+        line: 19
+        character: 6
+      end_position:
+        bytes: 140
+        line: 19
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 140
+      line: 19
+      character: 7
+    end_position:
+      bytes: 144
+      line: 19
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: str2
+  trailing_trivia:
+    - start_position:
+        bytes: 144
+        line: 19
+        character: 11
+      end_position:
+        bytes: 145
+        line: 19
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 145
+      line: 19
+      character: 12
+    end_position:
+      bytes: 146
+      line: 19
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 146
+        line: 19
+        character: 13
+      end_position:
+        bytes: 147
+        line: 19
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 147
+      line: 19
+      character: 14
+    end_position:
+      bytes: 155
+      line: 19
+      character: 22
+    token_type:
+      type: StringLiteral
+      literal: world!
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 155
+        line: 19
+        character: 22
+      end_position:
+        bytes: 156
+        line: 19
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 156
+        line: 20
+        character: 1
+      end_position:
+        bytes: 157
+        line: 20
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 157
+      line: 21
+      character: 1
+    end_position:
+      bytes: 161
+      line: 21
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: str1
+  trailing_trivia:
+    - start_position:
+        bytes: 161
+        line: 21
+        character: 5
+      end_position:
+        bytes: 162
+        line: 21
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 162
+      line: 21
+      character: 6
+    end_position:
+      bytes: 165
+      line: 21
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "..="
+  trailing_trivia:
+    - start_position:
+        bytes: 165
+        line: 21
+        character: 9
+      end_position:
+        bytes: 166
+        line: 21
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 166
+      line: 21
+      character: 10
+    end_position:
+      bytes: 174
+      line: 21
+      character: 18
+    token_type:
+      type: StringLiteral
+      literal: world!
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 174
+        line: 21
+        character: 18
+      end_position:
+        bytes: 175
+        line: 21
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 175
+      line: 22
+      character: 1
+    end_position:
+      bytes: 179
+      line: 22
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: str1
+  trailing_trivia:
+    - start_position:
+        bytes: 179
+        line: 22
+        character: 5
+      end_position:
+        bytes: 180
+        line: 22
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 180
+      line: 22
+      character: 6
+    end_position:
+      bytes: 183
+      line: 22
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: "..="
+  trailing_trivia:
+    - start_position:
+        bytes: 183
+        line: 22
+        character: 9
+      end_position:
+        bytes: 184
+        line: 22
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 184
+      line: 22
+      character: 10
+    end_position:
+      bytes: 188
+      line: 22
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: str2
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 188
+      line: 22
+      character: 14
+    end_position:
+      bytes: 188
+      line: 22
+      character: 14
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/continue/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/continue/tokens.snap
@@ -4,300 +4,339 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/continue
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 27
-    line: 1
-    character: 28
-  token_type:
-    type: SingleLineComment
-    comment: " Very important loop here"
-- start_position:
-    bytes: 27
-    line: 1
-    character: 28
-  end_position:
-    bytes: 28
-    line: 1
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 28
-    line: 2
-    character: 1
-  end_position:
-    bytes: 33
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: while
-- start_position:
-    bytes: 33
-    line: 2
-    character: 6
-  end_position:
-    bytes: 34
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 34
-    line: 2
-    character: 7
-  end_position:
-    bytes: 38
-    line: 2
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 38
-    line: 2
-    character: 11
-  end_position:
-    bytes: 39
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 39
-    line: 2
-    character: 12
-  end_position:
-    bytes: 41
-    line: 2
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 41
-    line: 2
-    character: 14
-  end_position:
-    bytes: 42
-    line: 2
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 42
-    line: 3
-    character: 1
-  end_position:
-    bytes: 43
-    line: 3
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 43
-    line: 3
-    character: 2
-  end_position:
-    bytes: 51
-    line: 3
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: continue
-- start_position:
-    bytes: 51
-    line: 3
-    character: 10
-  end_position:
-    bytes: 52
-    line: 3
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 52
-    line: 4
-    character: 1
-  end_position:
-    bytes: 55
-    line: 4
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 55
-    line: 4
-    character: 4
-  end_position:
-    bytes: 56
-    line: 4
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 56
-    line: 5
-    character: 1
-  end_position:
-    bytes: 57
-    line: 5
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 57
-    line: 6
-    character: 1
-  end_position:
-    bytes: 65
-    line: 6
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: continue
-- start_position:
-    bytes: 65
-    line: 6
-    character: 9
-  end_position:
-    bytes: 66
-    line: 6
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 66
-    line: 6
-    character: 10
-  end_position:
-    bytes: 67
-    line: 6
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 67
-    line: 6
-    character: 11
-  end_position:
-    bytes: 68
-    line: 6
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 68
-    line: 7
-    character: 1
-  end_position:
-    bytes: 73
-    line: 7
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 73
-    line: 7
-    character: 6
-  end_position:
-    bytes: 74
-    line: 7
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 74
-    line: 7
-    character: 7
-  end_position:
-    bytes: 82
-    line: 7
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: continue
-- start_position:
-    bytes: 82
-    line: 7
-    character: 15
-  end_position:
-    bytes: 83
-    line: 7
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 83
-    line: 7
-    character: 16
-  end_position:
-    bytes: 84
-    line: 7
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 84
-    line: 7
-    character: 17
-  end_position:
-    bytes: 85
-    line: 7
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 85
-    line: 7
-    character: 18
-  end_position:
-    bytes: 86
-    line: 7
-    character: 19
-  token_type:
-    type: Number
-    text: "4"
-- start_position:
-    bytes: 86
-    line: 7
-    character: 19
-  end_position:
-    bytes: 87
-    line: 7
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 87
-    line: 8
-    character: 1
-  end_position:
-    bytes: 87
-    line: 8
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 27
+        line: 1
+        character: 28
+      token_type:
+        type: SingleLineComment
+        comment: " Very important loop here"
+    - start_position:
+        bytes: 27
+        line: 1
+        character: 28
+      end_position:
+        bytes: 28
+        line: 1
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 28
+      line: 2
+      character: 1
+    end_position:
+      bytes: 33
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: while
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 2
+        character: 6
+      end_position:
+        bytes: 34
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 2
+      character: 7
+    end_position:
+      bytes: 38
+      line: 2
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia:
+    - start_position:
+        bytes: 38
+        line: 2
+        character: 11
+      end_position:
+        bytes: 39
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 39
+      line: 2
+      character: 12
+    end_position:
+      bytes: 41
+      line: 2
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 41
+        line: 2
+        character: 14
+      end_position:
+        bytes: 42
+        line: 2
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 42
+        line: 3
+        character: 1
+      end_position:
+        bytes: 43
+        line: 3
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 43
+      line: 3
+      character: 2
+    end_position:
+      bytes: 51
+      line: 3
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: continue
+  trailing_trivia:
+    - start_position:
+        bytes: 51
+        line: 3
+        character: 10
+      end_position:
+        bytes: 52
+        line: 3
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 4
+      character: 1
+    end_position:
+      bytes: 55
+      line: 4
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 55
+        line: 4
+        character: 4
+      end_position:
+        bytes: 56
+        line: 4
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 56
+        line: 5
+        character: 1
+      end_position:
+        bytes: 57
+        line: 5
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 57
+      line: 6
+      character: 1
+    end_position:
+      bytes: 65
+      line: 6
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: continue
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 65
+      line: 6
+      character: 9
+    end_position:
+      bytes: 66
+      line: 6
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 66
+      line: 6
+      character: 10
+    end_position:
+      bytes: 67
+      line: 6
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 67
+        line: 6
+        character: 11
+      end_position:
+        bytes: 68
+        line: 6
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 68
+      line: 7
+      character: 1
+    end_position:
+      bytes: 73
+      line: 7
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 73
+        line: 7
+        character: 6
+      end_position:
+        bytes: 74
+        line: 7
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 7
+      character: 7
+    end_position:
+      bytes: 82
+      line: 7
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: continue
+  trailing_trivia:
+    - start_position:
+        bytes: 82
+        line: 7
+        character: 15
+      end_position:
+        bytes: 83
+        line: 7
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 83
+      line: 7
+      character: 16
+    end_position:
+      bytes: 84
+      line: 7
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 84
+        line: 7
+        character: 17
+      end_position:
+        bytes: 85
+        line: 7
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 7
+      character: 18
+    end_position:
+      bytes: 86
+      line: 7
+      character: 19
+    token_type:
+      type: Number
+      text: "4"
+  trailing_trivia:
+    - start_position:
+        bytes: 86
+        line: 7
+        character: 19
+      end_position:
+        bytes: 87
+        line: 7
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 87
+      line: 8
+      character: 1
+    end_position:
+      bytes: 87
+      line: 8
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/decimal_seperators/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/decimal_seperators/tokens.snap
@@ -4,531 +4,606 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/decimal_seperators
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num1
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Number
-    text: 1_048_576
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 23
-    line: 1
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 23
-    line: 2
-    character: 1
-  end_position:
-    bytes: 28
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 28
-    line: 2
-    character: 6
-  end_position:
-    bytes: 29
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 29
-    line: 2
-    character: 7
-  end_position:
-    bytes: 33
-    line: 2
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num2
-- start_position:
-    bytes: 33
-    line: 2
-    character: 11
-  end_position:
-    bytes: 34
-    line: 2
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 34
-    line: 2
-    character: 12
-  end_position:
-    bytes: 35
-    line: 2
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 35
-    line: 2
-    character: 13
-  end_position:
-    bytes: 36
-    line: 2
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 36
-    line: 2
-    character: 14
-  end_position:
-    bytes: 47
-    line: 2
-    character: 25
-  token_type:
-    type: Number
-    text: "0xFFFF_FFFF"
-- start_position:
-    bytes: 47
-    line: 2
-    character: 25
-  end_position:
-    bytes: 48
-    line: 2
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 48
-    line: 3
-    character: 1
-  end_position:
-    bytes: 53
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 53
-    line: 3
-    character: 6
-  end_position:
-    bytes: 54
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 54
-    line: 3
-    character: 7
-  end_position:
-    bytes: 58
-    line: 3
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num3
-- start_position:
-    bytes: 58
-    line: 3
-    character: 11
-  end_position:
-    bytes: 59
-    line: 3
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 59
-    line: 3
-    character: 12
-  end_position:
-    bytes: 60
-    line: 3
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 60
-    line: 3
-    character: 13
-  end_position:
-    bytes: 61
-    line: 3
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 61
-    line: 3
-    character: 14
-  end_position:
-    bytes: 73
-    line: 3
-    character: 26
-  token_type:
-    type: Number
-    text: 0b_0101_0101
-- start_position:
-    bytes: 73
-    line: 3
-    character: 26
-  end_position:
-    bytes: 74
-    line: 3
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 74
-    line: 4
-    character: 1
-  end_position:
-    bytes: 79
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 79
-    line: 4
-    character: 6
-  end_position:
-    bytes: 80
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 80
-    line: 4
-    character: 7
-  end_position:
-    bytes: 84
-    line: 4
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num4
-- start_position:
-    bytes: 84
-    line: 4
-    character: 11
-  end_position:
-    bytes: 85
-    line: 4
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 85
-    line: 4
-    character: 12
-  end_position:
-    bytes: 86
-    line: 4
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 86
-    line: 4
-    character: 13
-  end_position:
-    bytes: 87
-    line: 4
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 87
-    line: 4
-    character: 14
-  end_position:
-    bytes: 108
-    line: 4
-    character: 35
-  token_type:
-    type: Number
-    text: 1_523_423.132_452_312
-- start_position:
-    bytes: 108
-    line: 4
-    character: 35
-  end_position:
-    bytes: 109
-    line: 4
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 109
-    line: 5
-    character: 1
-  end_position:
-    bytes: 114
-    line: 5
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 114
-    line: 5
-    character: 6
-  end_position:
-    bytes: 115
-    line: 5
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 115
-    line: 5
-    character: 7
-  end_position:
-    bytes: 119
-    line: 5
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num5
-- start_position:
-    bytes: 119
-    line: 5
-    character: 11
-  end_position:
-    bytes: 120
-    line: 5
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 120
-    line: 5
-    character: 12
-  end_position:
-    bytes: 121
-    line: 5
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 121
-    line: 5
-    character: 13
-  end_position:
-    bytes: 122
-    line: 5
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 122
-    line: 5
-    character: 14
-  end_position:
-    bytes: 131
-    line: 5
-    character: 23
-  token_type:
-    type: Number
-    text: 1e512_412
-- start_position:
-    bytes: 131
-    line: 5
-    character: 23
-  end_position:
-    bytes: 132
-    line: 5
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 132
-    line: 6
-    character: 1
-  end_position:
-    bytes: 137
-    line: 6
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 137
-    line: 6
-    character: 6
-  end_position:
-    bytes: 138
-    line: 6
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 138
-    line: 6
-    character: 7
-  end_position:
-    bytes: 142
-    line: 6
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: num6
-- start_position:
-    bytes: 142
-    line: 6
-    character: 11
-  end_position:
-    bytes: 143
-    line: 6
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 143
-    line: 6
-    character: 12
-  end_position:
-    bytes: 144
-    line: 6
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 144
-    line: 6
-    character: 13
-  end_position:
-    bytes: 145
-    line: 6
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 145
-    line: 6
-    character: 14
-  end_position:
-    bytes: 155
-    line: 6
-    character: 24
-  token_type:
-    type: Number
-    text: 1e-512_412
-- start_position:
-    bytes: 155
-    line: 6
-    character: 24
-  end_position:
-    bytes: 155
-    line: 6
-    character: 24
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num1
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 1
+        character: 13
+      end_position:
+        bytes: 13
+        line: 1
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 22
+      line: 1
+      character: 23
+    token_type:
+      type: Number
+      text: 1_048_576
+  trailing_trivia:
+    - start_position:
+        bytes: 22
+        line: 1
+        character: 23
+      end_position:
+        bytes: 23
+        line: 1
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 23
+      line: 2
+      character: 1
+    end_position:
+      bytes: 28
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 28
+        line: 2
+        character: 6
+      end_position:
+        bytes: 29
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 29
+      line: 2
+      character: 7
+    end_position:
+      bytes: 33
+      line: 2
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num2
+  trailing_trivia:
+    - start_position:
+        bytes: 33
+        line: 2
+        character: 11
+      end_position:
+        bytes: 34
+        line: 2
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 2
+      character: 12
+    end_position:
+      bytes: 35
+      line: 2
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 35
+        line: 2
+        character: 13
+      end_position:
+        bytes: 36
+        line: 2
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 2
+      character: 14
+    end_position:
+      bytes: 47
+      line: 2
+      character: 25
+    token_type:
+      type: Number
+      text: "0xFFFF_FFFF"
+  trailing_trivia:
+    - start_position:
+        bytes: 47
+        line: 2
+        character: 25
+      end_position:
+        bytes: 48
+        line: 2
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 3
+      character: 1
+    end_position:
+      bytes: 53
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 53
+        line: 3
+        character: 6
+      end_position:
+        bytes: 54
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 3
+      character: 7
+    end_position:
+      bytes: 58
+      line: 3
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num3
+  trailing_trivia:
+    - start_position:
+        bytes: 58
+        line: 3
+        character: 11
+      end_position:
+        bytes: 59
+        line: 3
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 59
+      line: 3
+      character: 12
+    end_position:
+      bytes: 60
+      line: 3
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 60
+        line: 3
+        character: 13
+      end_position:
+        bytes: 61
+        line: 3
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 61
+      line: 3
+      character: 14
+    end_position:
+      bytes: 73
+      line: 3
+      character: 26
+    token_type:
+      type: Number
+      text: 0b_0101_0101
+  trailing_trivia:
+    - start_position:
+        bytes: 73
+        line: 3
+        character: 26
+      end_position:
+        bytes: 74
+        line: 3
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 4
+      character: 1
+    end_position:
+      bytes: 79
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 79
+        line: 4
+        character: 6
+      end_position:
+        bytes: 80
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 80
+      line: 4
+      character: 7
+    end_position:
+      bytes: 84
+      line: 4
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num4
+  trailing_trivia:
+    - start_position:
+        bytes: 84
+        line: 4
+        character: 11
+      end_position:
+        bytes: 85
+        line: 4
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 4
+      character: 12
+    end_position:
+      bytes: 86
+      line: 4
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 86
+        line: 4
+        character: 13
+      end_position:
+        bytes: 87
+        line: 4
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 87
+      line: 4
+      character: 14
+    end_position:
+      bytes: 108
+      line: 4
+      character: 35
+    token_type:
+      type: Number
+      text: 1_523_423.132_452_312
+  trailing_trivia:
+    - start_position:
+        bytes: 108
+        line: 4
+        character: 35
+      end_position:
+        bytes: 109
+        line: 4
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 109
+      line: 5
+      character: 1
+    end_position:
+      bytes: 114
+      line: 5
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 114
+        line: 5
+        character: 6
+      end_position:
+        bytes: 115
+        line: 5
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 115
+      line: 5
+      character: 7
+    end_position:
+      bytes: 119
+      line: 5
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num5
+  trailing_trivia:
+    - start_position:
+        bytes: 119
+        line: 5
+        character: 11
+      end_position:
+        bytes: 120
+        line: 5
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 120
+      line: 5
+      character: 12
+    end_position:
+      bytes: 121
+      line: 5
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 121
+        line: 5
+        character: 13
+      end_position:
+        bytes: 122
+        line: 5
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 122
+      line: 5
+      character: 14
+    end_position:
+      bytes: 131
+      line: 5
+      character: 23
+    token_type:
+      type: Number
+      text: 1e512_412
+  trailing_trivia:
+    - start_position:
+        bytes: 131
+        line: 5
+        character: 23
+      end_position:
+        bytes: 132
+        line: 5
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 132
+      line: 6
+      character: 1
+    end_position:
+      bytes: 137
+      line: 6
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 137
+        line: 6
+        character: 6
+      end_position:
+        bytes: 138
+        line: 6
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 138
+      line: 6
+      character: 7
+    end_position:
+      bytes: 142
+      line: 6
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: num6
+  trailing_trivia:
+    - start_position:
+        bytes: 142
+        line: 6
+        character: 11
+      end_position:
+        bytes: 143
+        line: 6
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 143
+      line: 6
+      character: 12
+    end_position:
+      bytes: 144
+      line: 6
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 144
+        line: 6
+        character: 13
+      end_position:
+        bytes: 145
+        line: 6
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 145
+      line: 6
+      character: 14
+    end_position:
+      bytes: 155
+      line: 6
+      character: 24
+    token_type:
+      type: Number
+      text: 1e-512_412
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 155
+      line: 6
+      character: 24
+    end_position:
+      bytes: 155
+      line: 6
+      character: 24
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/no_roblox_syntax/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/no_roblox_syntax/tokens.snap
@@ -4,4245 +4,4935 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/no_roblox_syntax
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 97
-    line: 1
-    character: 98
-  token_type:
-    type: SingleLineComment
-    comment: " Taken from https://raw.githubusercontent.com/Kampfkarren/Roblox/master/Modules/LineOfSight.lua"
-- start_position:
-    bytes: 97
-    line: 1
-    character: 98
-  end_position:
-    bytes: 98
-    line: 1
-    character: 98
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 98
-    line: 2
-    character: 1
-  end_position:
-    bytes: 103
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 103
-    line: 2
-    character: 6
-  end_position:
-    bytes: 104
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 104
-    line: 2
-    character: 7
-  end_position:
-    bytes: 121
-    line: 2
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: ReplicatedStorage
-- start_position:
-    bytes: 121
-    line: 2
-    character: 24
-  end_position:
-    bytes: 122
-    line: 2
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 122
-    line: 2
-    character: 25
-  end_position:
-    bytes: 123
-    line: 2
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 123
-    line: 2
-    character: 26
-  end_position:
-    bytes: 124
-    line: 2
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 124
-    line: 2
-    character: 27
-  end_position:
-    bytes: 128
-    line: 2
-    character: 31
-  token_type:
-    type: Identifier
-    identifier: game
-- start_position:
-    bytes: 128
-    line: 2
-    character: 31
-  end_position:
-    bytes: 129
-    line: 2
-    character: 32
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 129
-    line: 2
-    character: 32
-  end_position:
-    bytes: 139
-    line: 2
-    character: 42
-  token_type:
-    type: Identifier
-    identifier: GetService
-- start_position:
-    bytes: 139
-    line: 2
-    character: 42
-  end_position:
-    bytes: 140
-    line: 2
-    character: 43
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 140
-    line: 2
-    character: 43
-  end_position:
-    bytes: 159
-    line: 2
-    character: 62
-  token_type:
-    type: StringLiteral
-    literal: ReplicatedStorage
-    quote_type: Double
-- start_position:
-    bytes: 159
-    line: 2
-    character: 62
-  end_position:
-    bytes: 160
-    line: 2
-    character: 63
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 160
-    line: 2
-    character: 63
-  end_position:
-    bytes: 161
-    line: 2
-    character: 63
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 161
-    line: 3
-    character: 1
-  end_position:
-    bytes: 166
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 166
-    line: 3
-    character: 6
-  end_position:
-    bytes: 167
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 167
-    line: 3
-    character: 7
-  end_position:
-    bytes: 177
-    line: 3
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: RunService
-- start_position:
-    bytes: 177
-    line: 3
-    character: 17
-  end_position:
-    bytes: 178
-    line: 3
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 178
-    line: 3
-    character: 18
-  end_position:
-    bytes: 179
-    line: 3
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 179
-    line: 3
-    character: 19
-  end_position:
-    bytes: 180
-    line: 3
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 180
-    line: 3
-    character: 20
-  end_position:
-    bytes: 184
-    line: 3
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: game
-- start_position:
-    bytes: 184
-    line: 3
-    character: 24
-  end_position:
-    bytes: 185
-    line: 3
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 185
-    line: 3
-    character: 25
-  end_position:
-    bytes: 195
-    line: 3
-    character: 35
-  token_type:
-    type: Identifier
-    identifier: GetService
-- start_position:
-    bytes: 195
-    line: 3
-    character: 35
-  end_position:
-    bytes: 196
-    line: 3
-    character: 36
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 196
-    line: 3
-    character: 36
-  end_position:
-    bytes: 208
-    line: 3
-    character: 48
-  token_type:
-    type: StringLiteral
-    literal: RunService
-    quote_type: Double
-- start_position:
-    bytes: 208
-    line: 3
-    character: 48
-  end_position:
-    bytes: 209
-    line: 3
-    character: 49
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 209
-    line: 3
-    character: 49
-  end_position:
-    bytes: 210
-    line: 3
-    character: 49
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 210
-    line: 4
-    character: 1
-  end_position:
-    bytes: 211
-    line: 4
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 211
-    line: 5
-    character: 1
-  end_position:
-    bytes: 216
-    line: 5
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 216
-    line: 5
-    character: 6
-  end_position:
-    bytes: 217
-    line: 5
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 217
-    line: 5
-    character: 7
-  end_position:
-    bytes: 224
-    line: 5
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: Raycast
-- start_position:
-    bytes: 224
-    line: 5
-    character: 14
-  end_position:
-    bytes: 225
-    line: 5
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 225
-    line: 5
-    character: 15
-  end_position:
-    bytes: 226
-    line: 5
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 226
-    line: 5
-    character: 16
-  end_position:
-    bytes: 227
-    line: 5
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 227
-    line: 5
-    character: 17
-  end_position:
-    bytes: 234
-    line: 5
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: require
-- start_position:
-    bytes: 234
-    line: 5
-    character: 24
-  end_position:
-    bytes: 235
-    line: 5
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 235
-    line: 5
-    character: 25
-  end_position:
-    bytes: 252
-    line: 5
-    character: 42
-  token_type:
-    type: Identifier
-    identifier: ReplicatedStorage
-- start_position:
-    bytes: 252
-    line: 5
-    character: 42
-  end_position:
-    bytes: 253
-    line: 5
-    character: 43
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 253
-    line: 5
-    character: 43
-  end_position:
-    bytes: 260
-    line: 5
-    character: 50
-  token_type:
-    type: Identifier
-    identifier: Modules
-- start_position:
-    bytes: 260
-    line: 5
-    character: 50
-  end_position:
-    bytes: 261
-    line: 5
-    character: 51
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 261
-    line: 5
-    character: 51
-  end_position:
-    bytes: 268
-    line: 5
-    character: 58
-  token_type:
-    type: Identifier
-    identifier: Raycast
-- start_position:
-    bytes: 268
-    line: 5
-    character: 58
-  end_position:
-    bytes: 269
-    line: 5
-    character: 59
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 269
-    line: 5
-    character: 59
-  end_position:
-    bytes: 270
-    line: 5
-    character: 59
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 270
-    line: 6
-    character: 1
-  end_position:
-    bytes: 271
-    line: 6
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 271
-    line: 7
-    character: 1
-  end_position:
-    bytes: 276
-    line: 7
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 276
-    line: 7
-    character: 6
-  end_position:
-    bytes: 277
-    line: 7
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 277
-    line: 7
-    character: 7
-  end_position:
-    bytes: 282
-    line: 7
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: DEBUG
-- start_position:
-    bytes: 282
-    line: 7
-    character: 12
-  end_position:
-    bytes: 283
-    line: 7
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 283
-    line: 7
-    character: 13
-  end_position:
-    bytes: 284
-    line: 7
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 284
-    line: 7
-    character: 14
-  end_position:
-    bytes: 285
-    line: 7
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 285
-    line: 7
-    character: 15
-  end_position:
-    bytes: 289
-    line: 7
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 289
-    line: 7
-    character: 19
-  end_position:
-    bytes: 290
-    line: 7
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 290
-    line: 8
-    character: 1
-  end_position:
-    bytes: 295
-    line: 8
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: DEBUG
-- start_position:
-    bytes: 295
-    line: 8
-    character: 6
-  end_position:
-    bytes: 296
-    line: 8
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 296
-    line: 8
-    character: 7
-  end_position:
-    bytes: 297
-    line: 8
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 297
-    line: 8
-    character: 8
-  end_position:
-    bytes: 298
-    line: 8
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 298
-    line: 8
-    character: 9
-  end_position:
-    bytes: 303
-    line: 8
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: DEBUG
-- start_position:
-    bytes: 303
-    line: 8
-    character: 14
-  end_position:
-    bytes: 304
-    line: 8
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 304
-    line: 8
-    character: 15
-  end_position:
-    bytes: 307
-    line: 8
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 307
-    line: 8
-    character: 18
-  end_position:
-    bytes: 308
-    line: 8
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 308
-    line: 8
-    character: 19
-  end_position:
-    bytes: 318
-    line: 8
-    character: 29
-  token_type:
-    type: Identifier
-    identifier: RunService
-- start_position:
-    bytes: 318
-    line: 8
-    character: 29
-  end_position:
-    bytes: 319
-    line: 8
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 319
-    line: 8
-    character: 30
-  end_position:
-    bytes: 327
-    line: 8
-    character: 38
-  token_type:
-    type: Identifier
-    identifier: IsStudio
-- start_position:
-    bytes: 327
-    line: 8
-    character: 38
-  end_position:
-    bytes: 328
-    line: 8
-    character: 39
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 328
-    line: 8
-    character: 39
-  end_position:
-    bytes: 329
-    line: 8
-    character: 40
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 329
-    line: 8
-    character: 40
-  end_position:
-    bytes: 330
-    line: 8
-    character: 40
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 330
-    line: 9
-    character: 1
-  end_position:
-    bytes: 331
-    line: 9
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 331
-    line: 10
-    character: 1
-  end_position:
-    bytes: 336
-    line: 10
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 336
-    line: 10
-    character: 6
-  end_position:
-    bytes: 337
-    line: 10
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 337
-    line: 10
-    character: 7
-  end_position:
-    bytes: 342
-    line: 10
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: debug
-- start_position:
-    bytes: 342
-    line: 10
-    character: 12
-  end_position:
-    bytes: 343
-    line: 10
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 343
-    line: 11
-    character: 1
-  end_position:
-    bytes: 344
-    line: 11
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 344
-    line: 12
-    character: 1
-  end_position:
-    bytes: 346
-    line: 12
-    character: 3
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 346
-    line: 12
-    character: 3
-  end_position:
-    bytes: 347
-    line: 12
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 347
-    line: 12
-    character: 4
-  end_position:
-    bytes: 352
-    line: 12
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: DEBUG
-- start_position:
-    bytes: 352
-    line: 12
-    character: 9
-  end_position:
-    bytes: 353
-    line: 12
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 353
-    line: 12
-    character: 10
-  end_position:
-    bytes: 357
-    line: 12
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 357
-    line: 12
-    character: 14
-  end_position:
-    bytes: 358
-    line: 12
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 358
-    line: 13
-    character: 1
-  end_position:
-    bytes: 359
-    line: 13
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 359
-    line: 13
-    character: 2
-  end_position:
-    bytes: 367
-    line: 13
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 367
-    line: 13
-    character: 10
-  end_position:
-    bytes: 368
-    line: 13
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 368
-    line: 13
-    character: 11
-  end_position:
-    bytes: 373
-    line: 13
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: debug
-- start_position:
-    bytes: 373
-    line: 13
-    character: 16
-  end_position:
-    bytes: 374
-    line: 13
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 374
-    line: 13
-    character: 17
-  end_position:
-    bytes: 377
-    line: 13
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 377
-    line: 13
-    character: 20
-  end_position:
-    bytes: 378
-    line: 13
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 378
-    line: 13
-    character: 21
-  end_position:
-    bytes: 379
-    line: 13
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 379
-    line: 14
-    character: 1
-  end_position:
-    bytes: 381
-    line: 14
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\t\t"
-- start_position:
-    bytes: 381
-    line: 14
-    character: 3
-  end_position:
-    bytes: 386
-    line: 14
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: print
-- start_position:
-    bytes: 386
-    line: 14
-    character: 8
-  end_position:
-    bytes: 387
-    line: 14
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 387
-    line: 14
-    character: 9
-  end_position:
-    bytes: 402
-    line: 14
-    character: 24
-  token_type:
-    type: StringLiteral
-    literal: "[LineOfSight]"
-    quote_type: Double
-- start_position:
-    bytes: 402
-    line: 14
-    character: 24
-  end_position:
-    bytes: 403
-    line: 14
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 403
-    line: 14
-    character: 25
-  end_position:
-    bytes: 404
-    line: 14
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 404
-    line: 14
-    character: 26
-  end_position:
-    bytes: 407
-    line: 14
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 407
-    line: 14
-    character: 29
-  end_position:
-    bytes: 408
-    line: 14
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 408
-    line: 14
-    character: 30
-  end_position:
-    bytes: 409
-    line: 14
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 409
-    line: 15
-    character: 1
-  end_position:
-    bytes: 410
-    line: 15
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 410
-    line: 15
-    character: 2
-  end_position:
-    bytes: 413
-    line: 15
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 413
-    line: 15
-    character: 5
-  end_position:
-    bytes: 414
-    line: 15
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 414
-    line: 16
-    character: 1
-  end_position:
-    bytes: 418
-    line: 16
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: else
-- start_position:
-    bytes: 418
-    line: 16
-    character: 5
-  end_position:
-    bytes: 419
-    line: 16
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 419
-    line: 17
-    character: 1
-  end_position:
-    bytes: 420
-    line: 17
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 420
-    line: 17
-    character: 2
-  end_position:
-    bytes: 428
-    line: 17
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 428
-    line: 17
-    character: 10
-  end_position:
-    bytes: 429
-    line: 17
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 429
-    line: 17
-    character: 11
-  end_position:
-    bytes: 434
-    line: 17
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: debug
-- start_position:
-    bytes: 434
-    line: 17
-    character: 16
-  end_position:
-    bytes: 435
-    line: 17
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 435
-    line: 17
-    character: 17
-  end_position:
-    bytes: 436
-    line: 17
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 436
-    line: 17
-    character: 18
-  end_position:
-    bytes: 437
-    line: 17
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 437
-    line: 18
-    character: 1
-  end_position:
-    bytes: 438
-    line: 18
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 438
-    line: 18
-    character: 2
-  end_position:
-    bytes: 441
-    line: 18
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 441
-    line: 18
-    character: 5
-  end_position:
-    bytes: 442
-    line: 18
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 442
-    line: 19
-    character: 1
-  end_position:
-    bytes: 445
-    line: 19
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 445
-    line: 19
-    character: 4
-  end_position:
-    bytes: 446
-    line: 19
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 446
-    line: 20
-    character: 1
-  end_position:
-    bytes: 447
-    line: 20
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 447
-    line: 21
-    character: 1
-  end_position:
-    bytes: 453
-    line: 21
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 453
-    line: 21
-    character: 7
-  end_position:
-    bytes: 454
-    line: 21
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 454
-    line: 21
-    character: 8
-  end_position:
-    bytes: 462
-    line: 21
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 462
-    line: 21
-    character: 16
-  end_position:
-    bytes: 463
-    line: 21
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 463
-    line: 21
-    character: 17
-  end_position:
-    bytes: 469
-    line: 21
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 469
-    line: 21
-    character: 23
-  end_position:
-    bytes: 470
-    line: 21
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 470
-    line: 21
-    character: 24
-  end_position:
-    bytes: 471
-    line: 21
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 471
-    line: 21
-    character: 25
-  end_position:
-    bytes: 480
-    line: 21
-    character: 34
-  token_type:
-    type: Identifier
-    identifier: character
-- start_position:
-    bytes: 480
-    line: 21
-    character: 34
-  end_position:
-    bytes: 481
-    line: 21
-    character: 35
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 481
-    line: 21
-    character: 35
-  end_position:
-    bytes: 482
-    line: 21
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 482
-    line: 21
-    character: 36
-  end_position:
-    bytes: 487
-    line: 21
-    character: 41
-  token_type:
-    type: Identifier
-    identifier: range
-- start_position:
-    bytes: 487
-    line: 21
-    character: 41
-  end_position:
-    bytes: 488
-    line: 21
-    character: 42
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 488
-    line: 21
-    character: 42
-  end_position:
-    bytes: 489
-    line: 21
-    character: 43
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 489
-    line: 21
-    character: 43
-  end_position:
-    bytes: 497
-    line: 21
-    character: 51
-  token_type:
-    type: Identifier
-    identifier: ignoreIf
-- start_position:
-    bytes: 497
-    line: 21
-    character: 51
-  end_position:
-    bytes: 498
-    line: 21
-    character: 52
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 498
-    line: 21
-    character: 52
-  end_position:
-    bytes: 499
-    line: 21
-    character: 53
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 499
-    line: 21
-    character: 53
-  end_position:
-    bytes: 508
-    line: 21
-    character: 62
-  token_type:
-    type: Identifier
-    identifier: blacklist
-- start_position:
-    bytes: 508
-    line: 21
-    character: 62
-  end_position:
-    bytes: 509
-    line: 21
-    character: 63
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 509
-    line: 21
-    character: 63
-  end_position:
-    bytes: 510
-    line: 21
-    character: 63
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 510
-    line: 22
-    character: 1
-  end_position:
-    bytes: 511
-    line: 22
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 511
-    line: 22
-    character: 2
-  end_position:
-    bytes: 513
-    line: 22
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 513
-    line: 22
-    character: 4
-  end_position:
-    bytes: 514
-    line: 22
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 514
-    line: 22
-    character: 5
-  end_position:
-    bytes: 520
-    line: 22
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: typeof
-- start_position:
-    bytes: 520
-    line: 22
-    character: 11
-  end_position:
-    bytes: 521
-    line: 22
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 521
-    line: 22
-    character: 12
-  end_position:
-    bytes: 527
-    line: 22
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 527
-    line: 22
-    character: 18
-  end_position:
-    bytes: 528
-    line: 22
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 528
-    line: 22
-    character: 19
-  end_position:
-    bytes: 529
-    line: 22
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 529
-    line: 22
-    character: 20
-  end_position:
-    bytes: 531
-    line: 22
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: "=="
-- start_position:
-    bytes: 531
-    line: 22
-    character: 22
-  end_position:
-    bytes: 532
-    line: 22
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 532
-    line: 22
-    character: 23
-  end_position:
-    bytes: 542
-    line: 22
-    character: 33
-  token_type:
-    type: StringLiteral
-    literal: Instance
-    quote_type: Double
-- start_position:
-    bytes: 542
-    line: 22
-    character: 33
-  end_position:
-    bytes: 543
-    line: 22
-    character: 34
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 543
-    line: 22
-    character: 34
-  end_position:
-    bytes: 547
-    line: 22
-    character: 38
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 547
-    line: 22
-    character: 38
-  end_position:
-    bytes: 548
-    line: 22
-    character: 38
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 548
-    line: 23
-    character: 1
-  end_position:
-    bytes: 550
-    line: 23
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\t\t"
-- start_position:
-    bytes: 550
-    line: 23
-    character: 3
-  end_position:
-    bytes: 552
-    line: 23
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 552
-    line: 23
-    character: 5
-  end_position:
-    bytes: 553
-    line: 23
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 553
-    line: 23
-    character: 6
-  end_position:
-    bytes: 559
-    line: 23
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 559
-    line: 23
-    character: 12
-  end_position:
-    bytes: 560
-    line: 23
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 560
-    line: 23
-    character: 13
-  end_position:
-    bytes: 568
-    line: 23
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: Position
-- start_position:
-    bytes: 568
-    line: 23
-    character: 21
-  end_position:
-    bytes: 569
-    line: 23
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 569
-    line: 23
-    character: 22
-  end_position:
-    bytes: 576
-    line: 23
-    character: 29
-  token_type:
-    type: Identifier
-    identifier: FuzzyEq
-- start_position:
-    bytes: 576
-    line: 23
-    character: 29
-  end_position:
-    bytes: 577
-    line: 23
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 577
-    line: 23
-    character: 30
-  end_position:
-    bytes: 586
-    line: 23
-    character: 39
-  token_type:
-    type: Identifier
-    identifier: character
-- start_position:
-    bytes: 586
-    line: 23
-    character: 39
-  end_position:
-    bytes: 587
-    line: 23
-    character: 40
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 587
-    line: 23
-    character: 40
-  end_position:
-    bytes: 598
-    line: 23
-    character: 51
-  token_type:
-    type: Identifier
-    identifier: PrimaryPart
-- start_position:
-    bytes: 598
-    line: 23
-    character: 51
-  end_position:
-    bytes: 599
-    line: 23
-    character: 52
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 599
-    line: 23
-    character: 52
-  end_position:
-    bytes: 607
-    line: 23
-    character: 60
-  token_type:
-    type: Identifier
-    identifier: Position
-- start_position:
-    bytes: 607
-    line: 23
-    character: 60
-  end_position:
-    bytes: 608
-    line: 23
-    character: 61
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 608
-    line: 23
-    character: 61
-  end_position:
-    bytes: 609
-    line: 23
-    character: 62
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 609
-    line: 23
-    character: 62
-  end_position:
-    bytes: 613
-    line: 23
-    character: 66
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 613
-    line: 23
-    character: 66
-  end_position:
-    bytes: 614
-    line: 23
-    character: 66
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 614
-    line: 24
-    character: 1
-  end_position:
-    bytes: 617
-    line: 24
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t"
-- start_position:
-    bytes: 617
-    line: 24
-    character: 4
-  end_position:
-    bytes: 622
-    line: 24
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: debug
-- start_position:
-    bytes: 622
-    line: 24
-    character: 9
-  end_position:
-    bytes: 623
-    line: 24
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 623
-    line: 24
-    character: 10
-  end_position:
-    bytes: 645
-    line: 24
-    character: 32
-  token_type:
-    type: StringLiteral
-    literal: ORIGIN WAS CHARACTER
-    quote_type: Double
-- start_position:
-    bytes: 645
-    line: 24
-    character: 32
-  end_position:
-    bytes: 646
-    line: 24
-    character: 33
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 646
-    line: 24
-    character: 33
-  end_position:
-    bytes: 647
-    line: 24
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 647
-    line: 25
-    character: 1
-  end_position:
-    bytes: 650
-    line: 25
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t"
-- start_position:
-    bytes: 650
-    line: 25
-    character: 4
-  end_position:
-    bytes: 656
-    line: 25
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 656
-    line: 25
-    character: 10
-  end_position:
-    bytes: 657
-    line: 25
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 657
-    line: 25
-    character: 11
-  end_position:
-    bytes: 663
-    line: 25
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 663
-    line: 25
-    character: 17
-  end_position:
-    bytes: 664
-    line: 25
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 664
-    line: 25
-    character: 18
-  end_position:
-    bytes: 665
-    line: 25
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 665
-    line: 25
-    character: 19
-  end_position:
-    bytes: 671
-    line: 25
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 671
-    line: 25
-    character: 25
-  end_position:
-    bytes: 672
-    line: 25
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 672
-    line: 25
-    character: 26
-  end_position:
-    bytes: 680
-    line: 25
-    character: 34
-  token_type:
-    type: Identifier
-    identifier: Position
-- start_position:
-    bytes: 680
-    line: 25
-    character: 34
-  end_position:
-    bytes: 681
-    line: 25
-    character: 34
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 681
-    line: 26
-    character: 1
-  end_position:
-    bytes: 683
-    line: 26
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\t\t"
-- start_position:
-    bytes: 683
-    line: 26
-    character: 3
-  end_position:
-    bytes: 686
-    line: 26
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 686
-    line: 26
-    character: 6
-  end_position:
-    bytes: 687
-    line: 26
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 687
-    line: 27
-    character: 1
-  end_position:
-    bytes: 688
-    line: 27
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 688
-    line: 28
-    character: 1
-  end_position:
-    bytes: 690
-    line: 28
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\t\t"
-- start_position:
-    bytes: 690
-    line: 28
-    character: 3
-  end_position:
-    bytes: 696
-    line: 28
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 696
-    line: 28
-    character: 9
-  end_position:
-    bytes: 697
-    line: 28
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 697
-    line: 28
-    character: 10
-  end_position:
-    bytes: 698
-    line: 28
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 698
-    line: 28
-    character: 11
-  end_position:
-    bytes: 699
-    line: 28
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 699
-    line: 28
-    character: 12
-  end_position:
-    bytes: 705
-    line: 28
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 705
-    line: 28
-    character: 18
-  end_position:
-    bytes: 706
-    line: 28
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 706
-    line: 28
-    character: 19
-  end_position:
-    bytes: 714
-    line: 28
-    character: 27
-  token_type:
-    type: Identifier
-    identifier: Position
-- start_position:
-    bytes: 714
-    line: 28
-    character: 27
-  end_position:
-    bytes: 715
-    line: 28
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 715
-    line: 29
-    character: 1
-  end_position:
-    bytes: 716
-    line: 29
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 716
-    line: 29
-    character: 2
-  end_position:
-    bytes: 719
-    line: 29
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 719
-    line: 29
-    character: 5
-  end_position:
-    bytes: 720
-    line: 29
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 720
-    line: 30
-    character: 1
-  end_position:
-    bytes: 721
-    line: 30
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 721
-    line: 31
-    character: 1
-  end_position:
-    bytes: 722
-    line: 31
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 722
-    line: 31
-    character: 2
-  end_position:
-    bytes: 731
-    line: 31
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: blacklist
-- start_position:
-    bytes: 731
-    line: 31
-    character: 11
-  end_position:
-    bytes: 732
-    line: 31
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 732
-    line: 31
-    character: 12
-  end_position:
-    bytes: 733
-    line: 31
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 733
-    line: 31
-    character: 13
-  end_position:
-    bytes: 734
-    line: 31
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 734
-    line: 31
-    character: 14
-  end_position:
-    bytes: 743
-    line: 31
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: blacklist
-- start_position:
-    bytes: 743
-    line: 31
-    character: 23
-  end_position:
-    bytes: 744
-    line: 31
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 744
-    line: 31
-    character: 24
-  end_position:
-    bytes: 746
-    line: 31
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: or
-- start_position:
-    bytes: 746
-    line: 31
-    character: 26
-  end_position:
-    bytes: 747
-    line: 31
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 747
-    line: 31
-    character: 27
-  end_position:
-    bytes: 748
-    line: 31
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 748
-    line: 31
-    character: 28
-  end_position:
-    bytes: 749
-    line: 31
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 749
-    line: 31
-    character: 29
-  end_position:
-    bytes: 750
-    line: 31
-    character: 29
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 750
-    line: 32
-    character: 1
-  end_position:
-    bytes: 751
-    line: 32
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 751
-    line: 33
-    character: 1
-  end_position:
-    bytes: 752
-    line: 33
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 752
-    line: 33
-    character: 2
-  end_position:
-    bytes: 757
-    line: 33
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 757
-    line: 33
-    character: 7
-  end_position:
-    bytes: 758
-    line: 33
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 758
-    line: 33
-    character: 8
-  end_position:
-    bytes: 761
-    line: 33
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 761
-    line: 33
-    character: 11
-  end_position:
-    bytes: 762
-    line: 33
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 762
-    line: 33
-    character: 12
-  end_position:
-    bytes: 763
-    line: 33
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 763
-    line: 33
-    character: 13
-  end_position:
-    bytes: 768
-    line: 33
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: point
-- start_position:
-    bytes: 768
-    line: 33
-    character: 18
-  end_position:
-    bytes: 769
-    line: 33
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 769
-    line: 33
-    character: 19
-  end_position:
-    bytes: 771
-    line: 33
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 771
-    line: 33
-    character: 21
-  end_position:
-    bytes: 772
-    line: 33
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 772
-    line: 34
-    character: 1
-  end_position:
-    bytes: 774
-    line: 34
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\t\t"
-- start_position:
-    bytes: 774
-    line: 34
-    character: 3
-  end_position:
-    bytes: 779
-    line: 34
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: while
-- start_position:
-    bytes: 779
-    line: 34
-    character: 8
-  end_position:
-    bytes: 780
-    line: 34
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 780
-    line: 34
-    character: 9
-  end_position:
-    bytes: 784
-    line: 34
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "true"
-- start_position:
-    bytes: 784
-    line: 34
-    character: 13
-  end_position:
-    bytes: 785
-    line: 34
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 785
-    line: 34
-    character: 14
-  end_position:
-    bytes: 787
-    line: 34
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 787
-    line: 34
-    character: 16
-  end_position:
-    bytes: 788
-    line: 34
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 788
-    line: 35
-    character: 1
-  end_position:
-    bytes: 791
-    line: 35
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t"
-- start_position:
-    bytes: 791
-    line: 35
-    character: 4
-  end_position:
-    bytes: 794
-    line: 35
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 794
-    line: 35
-    character: 7
-  end_position:
-    bytes: 795
-    line: 35
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 795
-    line: 35
-    character: 8
-  end_position:
-    bytes: 796
-    line: 35
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 796
-    line: 35
-    character: 9
-  end_position:
-    bytes: 801
-    line: 35
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: point
-- start_position:
-    bytes: 801
-    line: 35
-    character: 14
-  end_position:
-    bytes: 802
-    line: 35
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 802
-    line: 35
-    character: 15
-  end_position:
-    bytes: 803
-    line: 35
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 803
-    line: 35
-    character: 16
-  end_position:
-    bytes: 804
-    line: 35
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 804
-    line: 35
-    character: 17
-  end_position:
-    bytes: 811
-    line: 35
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: Raycast
-- start_position:
-    bytes: 811
-    line: 35
-    character: 24
-  end_position:
-    bytes: 812
-    line: 35
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 812
-    line: 35
-    character: 25
-  end_position:
-    bytes: 815
-    line: 35
-    character: 28
-  token_type:
-    type: Identifier
-    identifier: Ray
-- start_position:
-    bytes: 815
-    line: 35
-    character: 28
-  end_position:
-    bytes: 816
-    line: 35
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 816
-    line: 35
-    character: 29
-  end_position:
-    bytes: 819
-    line: 35
-    character: 32
-  token_type:
-    type: Identifier
-    identifier: new
-- start_position:
-    bytes: 819
-    line: 35
-    character: 32
-  end_position:
-    bytes: 820
-    line: 35
-    character: 33
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 820
-    line: 35
-    character: 33
-  end_position:
-    bytes: 826
-    line: 35
-    character: 39
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 826
-    line: 35
-    character: 39
-  end_position:
-    bytes: 827
-    line: 35
-    character: 40
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 827
-    line: 35
-    character: 40
-  end_position:
-    bytes: 828
-    line: 35
-    character: 41
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 828
-    line: 35
-    character: 41
-  end_position:
-    bytes: 829
-    line: 35
-    character: 42
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 829
-    line: 35
-    character: 42
-  end_position:
-    bytes: 835
-    line: 35
-    character: 48
-  token_type:
-    type: Identifier
-    identifier: origin
-- start_position:
-    bytes: 835
-    line: 35
-    character: 48
-  end_position:
-    bytes: 836
-    line: 35
-    character: 49
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 836
-    line: 35
-    character: 49
-  end_position:
-    bytes: 837
-    line: 35
-    character: 50
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 837
-    line: 35
-    character: 50
-  end_position:
-    bytes: 838
-    line: 35
-    character: 51
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 838
-    line: 35
-    character: 51
-  end_position:
-    bytes: 847
-    line: 35
-    character: 60
-  token_type:
-    type: Identifier
-    identifier: character
-- start_position:
-    bytes: 847
-    line: 35
-    character: 60
-  end_position:
-    bytes: 848
-    line: 35
-    character: 61
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 848
-    line: 35
-    character: 61
-  end_position:
-    bytes: 859
-    line: 35
-    character: 72
-  token_type:
-    type: Identifier
-    identifier: PrimaryPart
-- start_position:
-    bytes: 859
-    line: 35
-    character: 72
-  end_position:
-    bytes: 860
-    line: 35
-    character: 73
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 860
-    line: 35
-    character: 73
-  end_position:
-    bytes: 868
-    line: 35
-    character: 81
-  token_type:
-    type: Identifier
-    identifier: Position
-- start_position:
-    bytes: 868
-    line: 35
-    character: 81
-  end_position:
-    bytes: 869
-    line: 35
-    character: 82
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 869
-    line: 35
-    character: 82
-  end_position:
-    bytes: 870
-    line: 35
-    character: 83
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 870
-    line: 35
-    character: 83
-  end_position:
-    bytes: 874
-    line: 35
-    character: 87
-  token_type:
-    type: Identifier
-    identifier: Unit
-- start_position:
-    bytes: 874
-    line: 35
-    character: 87
-  end_position:
-    bytes: 875
-    line: 35
-    character: 88
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 875
-    line: 35
-    character: 88
-  end_position:
-    bytes: 876
-    line: 35
-    character: 89
-  token_type:
-    type: Symbol
-    symbol: "*"
-- start_position:
-    bytes: 876
-    line: 35
-    character: 89
-  end_position:
-    bytes: 877
-    line: 35
-    character: 90
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 877
-    line: 35
-    character: 90
-  end_position:
-    bytes: 878
-    line: 35
-    character: 91
-  token_type:
-    type: Symbol
-    symbol: "-"
-- start_position:
-    bytes: 878
-    line: 35
-    character: 91
-  end_position:
-    bytes: 883
-    line: 35
-    character: 96
-  token_type:
-    type: Identifier
-    identifier: range
-- start_position:
-    bytes: 883
-    line: 35
-    character: 96
-  end_position:
-    bytes: 884
-    line: 35
-    character: 97
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 884
-    line: 35
-    character: 97
-  end_position:
-    bytes: 885
-    line: 35
-    character: 98
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 885
-    line: 35
-    character: 98
-  end_position:
-    bytes: 886
-    line: 35
-    character: 99
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 886
-    line: 35
-    character: 99
-  end_position:
-    bytes: 895
-    line: 35
-    character: 108
-  token_type:
-    type: Identifier
-    identifier: blacklist
-- start_position:
-    bytes: 895
-    line: 35
-    character: 108
-  end_position:
-    bytes: 896
-    line: 35
-    character: 109
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 896
-    line: 35
-    character: 109
-  end_position:
-    bytes: 897
-    line: 35
-    character: 109
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 897
-    line: 36
-    character: 1
-  end_position:
-    bytes: 898
-    line: 36
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 898
-    line: 37
-    character: 1
-  end_position:
-    bytes: 901
-    line: 37
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t"
-- start_position:
-    bytes: 901
-    line: 37
-    character: 4
-  end_position:
-    bytes: 903
-    line: 37
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: if
-- start_position:
-    bytes: 903
-    line: 37
-    character: 6
-  end_position:
-    bytes: 904
-    line: 37
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 904
-    line: 37
-    character: 7
-  end_position:
-    bytes: 907
-    line: 37
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 907
-    line: 37
-    character: 10
-  end_position:
-    bytes: 908
-    line: 37
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 908
-    line: 37
-    character: 11
-  end_position:
-    bytes: 911
-    line: 37
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 911
-    line: 37
-    character: 14
-  end_position:
-    bytes: 912
-    line: 37
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 912
-    line: 37
-    character: 15
-  end_position:
-    bytes: 915
-    line: 37
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 915
-    line: 37
-    character: 18
-  end_position:
-    bytes: 916
-    line: 37
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 916
-    line: 37
-    character: 19
-  end_position:
-    bytes: 930
-    line: 37
-    character: 33
-  token_type:
-    type: Identifier
-    identifier: IsDescendantOf
-- start_position:
-    bytes: 930
-    line: 37
-    character: 33
-  end_position:
-    bytes: 931
-    line: 37
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 931
-    line: 37
-    character: 34
-  end_position:
-    bytes: 940
-    line: 37
-    character: 43
-  token_type:
-    type: Identifier
-    identifier: character
-- start_position:
-    bytes: 940
-    line: 37
-    character: 43
-  end_position:
-    bytes: 941
-    line: 37
-    character: 44
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 941
-    line: 37
-    character: 44
-  end_position:
-    bytes: 942
-    line: 37
-    character: 45
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 942
-    line: 37
-    character: 45
-  end_position:
-    bytes: 946
-    line: 37
-    character: 49
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 946
-    line: 37
-    character: 49
-  end_position:
-    bytes: 947
-    line: 37
-    character: 49
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 947
-    line: 38
-    character: 1
-  end_position:
-    bytes: 951
-    line: 38
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t\t"
-- start_position:
-    bytes: 951
-    line: 38
-    character: 5
-  end_position:
-    bytes: 956
-    line: 38
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: break
-- start_position:
-    bytes: 956
-    line: 38
-    character: 10
-  end_position:
-    bytes: 957
-    line: 38
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 957
-    line: 39
-    character: 1
-  end_position:
-    bytes: 960
-    line: 39
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t"
-- start_position:
-    bytes: 960
-    line: 39
-    character: 4
-  end_position:
-    bytes: 966
-    line: 39
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: elseif
-- start_position:
-    bytes: 966
-    line: 39
-    character: 10
-  end_position:
-    bytes: 967
-    line: 39
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 967
-    line: 39
-    character: 11
-  end_position:
-    bytes: 970
-    line: 39
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 970
-    line: 39
-    character: 14
-  end_position:
-    bytes: 971
-    line: 39
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 971
-    line: 39
-    character: 15
-  end_position:
-    bytes: 974
-    line: 39
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 974
-    line: 39
-    character: 18
-  end_position:
-    bytes: 975
-    line: 39
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 975
-    line: 39
-    character: 19
-  end_position:
-    bytes: 983
-    line: 39
-    character: 27
-  token_type:
-    type: Identifier
-    identifier: ignoreIf
-- start_position:
-    bytes: 983
-    line: 39
-    character: 27
-  end_position:
-    bytes: 984
-    line: 39
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 984
-    line: 39
-    character: 28
-  end_position:
-    bytes: 987
-    line: 39
-    character: 31
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 987
-    line: 39
-    character: 31
-  end_position:
-    bytes: 988
-    line: 39
-    character: 32
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 988
-    line: 39
-    character: 32
-  end_position:
-    bytes: 989
-    line: 39
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 989
-    line: 39
-    character: 33
-  end_position:
-    bytes: 993
-    line: 39
-    character: 37
-  token_type:
-    type: Symbol
-    symbol: then
-- start_position:
-    bytes: 993
-    line: 39
-    character: 37
-  end_position:
-    bytes: 994
-    line: 39
-    character: 37
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 994
-    line: 40
-    character: 1
-  end_position:
-    bytes: 998
-    line: 40
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t\t"
-- start_position:
-    bytes: 998
-    line: 40
-    character: 5
-  end_position:
-    bytes: 1003
-    line: 40
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: debug
-- start_position:
-    bytes: 1003
-    line: 40
-    character: 10
-  end_position:
-    bytes: 1004
-    line: 40
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 1004
-    line: 40
-    character: 11
-  end_position:
-    bytes: 1021
-    line: 40
-    character: 28
-  token_type:
-    type: StringLiteral
-    literal: IGNORING OFF IF
-    quote_type: Double
-- start_position:
-    bytes: 1021
-    line: 40
-    character: 28
-  end_position:
-    bytes: 1022
-    line: 40
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 1022
-    line: 40
-    character: 29
-  end_position:
-    bytes: 1023
-    line: 40
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1023
-    line: 40
-    character: 30
-  end_position:
-    bytes: 1026
-    line: 40
-    character: 33
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 1026
-    line: 40
-    character: 33
-  end_position:
-    bytes: 1027
-    line: 40
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 1027
-    line: 40
-    character: 34
-  end_position:
-    bytes: 1038
-    line: 40
-    character: 45
-  token_type:
-    type: Identifier
-    identifier: GetFullName
-- start_position:
-    bytes: 1038
-    line: 40
-    character: 45
-  end_position:
-    bytes: 1039
-    line: 40
-    character: 46
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 1039
-    line: 40
-    character: 46
-  end_position:
-    bytes: 1040
-    line: 40
-    character: 47
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 1040
-    line: 40
-    character: 47
-  end_position:
-    bytes: 1041
-    line: 40
-    character: 48
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 1041
-    line: 40
-    character: 48
-  end_position:
-    bytes: 1042
-    line: 40
-    character: 48
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1042
-    line: 41
-    character: 1
-  end_position:
-    bytes: 1046
-    line: 41
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t\t"
-- start_position:
-    bytes: 1046
-    line: 41
-    character: 5
-  end_position:
-    bytes: 1055
-    line: 41
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: blacklist
-- start_position:
-    bytes: 1055
-    line: 41
-    character: 14
-  end_position:
-    bytes: 1056
-    line: 41
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 1056
-    line: 41
-    character: 15
-  end_position:
-    bytes: 1057
-    line: 41
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "#"
-- start_position:
-    bytes: 1057
-    line: 41
-    character: 16
-  end_position:
-    bytes: 1066
-    line: 41
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: blacklist
-- start_position:
-    bytes: 1066
-    line: 41
-    character: 25
-  end_position:
-    bytes: 1067
-    line: 41
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1067
-    line: 41
-    character: 26
-  end_position:
-    bytes: 1068
-    line: 41
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 1068
-    line: 41
-    character: 27
-  end_position:
-    bytes: 1069
-    line: 41
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1069
-    line: 41
-    character: 28
-  end_position:
-    bytes: 1070
-    line: 41
-    character: 29
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 1070
-    line: 41
-    character: 29
-  end_position:
-    bytes: 1071
-    line: 41
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 1071
-    line: 41
-    character: 30
-  end_position:
-    bytes: 1072
-    line: 41
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1072
-    line: 41
-    character: 31
-  end_position:
-    bytes: 1073
-    line: 41
-    character: 32
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 1073
-    line: 41
-    character: 32
-  end_position:
-    bytes: 1074
-    line: 41
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1074
-    line: 41
-    character: 33
-  end_position:
-    bytes: 1077
-    line: 41
-    character: 36
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 1077
-    line: 41
-    character: 36
-  end_position:
-    bytes: 1078
-    line: 41
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1078
-    line: 42
-    character: 1
-  end_position:
-    bytes: 1081
-    line: 42
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t"
-- start_position:
-    bytes: 1081
-    line: 42
-    character: 4
-  end_position:
-    bytes: 1085
-    line: 42
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: else
-- start_position:
-    bytes: 1085
-    line: 42
-    character: 8
-  end_position:
-    bytes: 1086
-    line: 42
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1086
-    line: 43
-    character: 1
-  end_position:
-    bytes: 1090
-    line: 43
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t\t"
-- start_position:
-    bytes: 1090
-    line: 43
-    character: 5
-  end_position:
-    bytes: 1095
-    line: 43
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: break
-- start_position:
-    bytes: 1095
-    line: 43
-    character: 10
-  end_position:
-    bytes: 1096
-    line: 43
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1096
-    line: 44
-    character: 1
-  end_position:
-    bytes: 1099
-    line: 44
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\t\t\t"
-- start_position:
-    bytes: 1099
-    line: 44
-    character: 4
-  end_position:
-    bytes: 1102
-    line: 44
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 1102
-    line: 44
-    character: 7
-  end_position:
-    bytes: 1103
-    line: 44
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1103
-    line: 45
-    character: 1
-  end_position:
-    bytes: 1105
-    line: 45
-    character: 3
-  token_type:
-    type: Whitespace
-    characters: "\t\t"
-- start_position:
-    bytes: 1105
-    line: 45
-    character: 3
-  end_position:
-    bytes: 1108
-    line: 45
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 1108
-    line: 45
-    character: 6
-  end_position:
-    bytes: 1109
-    line: 45
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1109
-    line: 46
-    character: 1
-  end_position:
-    bytes: 1110
-    line: 46
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 1110
-    line: 46
-    character: 2
-  end_position:
-    bytes: 1113
-    line: 46
-    character: 5
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 1113
-    line: 46
-    character: 5
-  end_position:
-    bytes: 1114
-    line: 46
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1114
-    line: 47
-    character: 1
-  end_position:
-    bytes: 1115
-    line: 47
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1115
-    line: 48
-    character: 1
-  end_position:
-    bytes: 1116
-    line: 48
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 1116
-    line: 48
-    character: 2
-  end_position:
-    bytes: 1121
-    line: 48
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: debug
-- start_position:
-    bytes: 1121
-    line: 48
-    character: 7
-  end_position:
-    bytes: 1122
-    line: 48
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 1122
-    line: 48
-    character: 8
-  end_position:
-    bytes: 1134
-    line: 48
-    character: 20
-  token_type:
-    type: StringLiteral
-    literal: LOS RESULT
-    quote_type: Double
-- start_position:
-    bytes: 1134
-    line: 48
-    character: 20
-  end_position:
-    bytes: 1135
-    line: 48
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 1135
-    line: 48
-    character: 21
-  end_position:
-    bytes: 1136
-    line: 48
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1136
-    line: 48
-    character: 22
-  end_position:
-    bytes: 1139
-    line: 48
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 1139
-    line: 48
-    character: 25
-  end_position:
-    bytes: 1140
-    line: 48
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1140
-    line: 48
-    character: 26
-  end_position:
-    bytes: 1143
-    line: 48
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 1143
-    line: 48
-    character: 29
-  end_position:
-    bytes: 1144
-    line: 48
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1144
-    line: 48
-    character: 30
-  end_position:
-    bytes: 1147
-    line: 48
-    character: 33
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 1147
-    line: 48
-    character: 33
-  end_position:
-    bytes: 1148
-    line: 48
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 1148
-    line: 48
-    character: 34
-  end_position:
-    bytes: 1159
-    line: 48
-    character: 45
-  token_type:
-    type: Identifier
-    identifier: GetFullName
-- start_position:
-    bytes: 1159
-    line: 48
-    character: 45
-  end_position:
-    bytes: 1160
-    line: 48
-    character: 46
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 1160
-    line: 48
-    character: 46
-  end_position:
-    bytes: 1161
-    line: 48
-    character: 47
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 1161
-    line: 48
-    character: 47
-  end_position:
-    bytes: 1162
-    line: 48
-    character: 48
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 1162
-    line: 48
-    character: 48
-  end_position:
-    bytes: 1163
-    line: 48
-    character: 48
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1163
-    line: 49
-    character: 1
-  end_position:
-    bytes: 1164
-    line: 49
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1164
-    line: 50
-    character: 1
-  end_position:
-    bytes: 1165
-    line: 50
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 1165
-    line: 50
-    character: 2
-  end_position:
-    bytes: 1171
-    line: 50
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 1171
-    line: 50
-    character: 8
-  end_position:
-    bytes: 1172
-    line: 50
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1172
-    line: 50
-    character: 9
-  end_position:
-    bytes: 1175
-    line: 50
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 1175
-    line: 50
-    character: 12
-  end_position:
-    bytes: 1176
-    line: 50
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1176
-    line: 50
-    character: 13
-  end_position:
-    bytes: 1179
-    line: 50
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: and
-- start_position:
-    bytes: 1179
-    line: 50
-    character: 16
-  end_position:
-    bytes: 1180
-    line: 50
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1180
-    line: 50
-    character: 17
-  end_position:
-    bytes: 1183
-    line: 50
-    character: 20
-  token_type:
-    type: Identifier
-    identifier: hit
-- start_position:
-    bytes: 1183
-    line: 50
-    character: 20
-  end_position:
-    bytes: 1184
-    line: 50
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 1184
-    line: 50
-    character: 21
-  end_position:
-    bytes: 1198
-    line: 50
-    character: 35
-  token_type:
-    type: Identifier
-    identifier: IsDescendantOf
-- start_position:
-    bytes: 1198
-    line: 50
-    character: 35
-  end_position:
-    bytes: 1199
-    line: 50
-    character: 36
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 1199
-    line: 50
-    character: 36
-  end_position:
-    bytes: 1208
-    line: 50
-    character: 45
-  token_type:
-    type: Identifier
-    identifier: character
-- start_position:
-    bytes: 1208
-    line: 50
-    character: 45
-  end_position:
-    bytes: 1209
-    line: 50
-    character: 46
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 1209
-    line: 50
-    character: 46
-  end_position:
-    bytes: 1210
-    line: 50
-    character: 47
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 1210
-    line: 50
-    character: 47
-  end_position:
-    bytes: 1211
-    line: 50
-    character: 48
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 1211
-    line: 50
-    character: 48
-  end_position:
-    bytes: 1216
-    line: 50
-    character: 53
-  token_type:
-    type: Identifier
-    identifier: point
-- start_position:
-    bytes: 1216
-    line: 50
-    character: 53
-  end_position:
-    bytes: 1217
-    line: 50
-    character: 53
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1217
-    line: 51
-    character: 1
-  end_position:
-    bytes: 1220
-    line: 51
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 1220
-    line: 51
-    character: 4
-  end_position:
-    bytes: 1221
-    line: 51
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 1221
-    line: 52
-    character: 1
-  end_position:
-    bytes: 1221
-    line: 52
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia:
+    - start_position:
+        bytes: 0
+        line: 1
+        character: 1
+      end_position:
+        bytes: 97
+        line: 1
+        character: 98
+      token_type:
+        type: SingleLineComment
+        comment: " Taken from https://raw.githubusercontent.com/Kampfkarren/Roblox/master/Modules/LineOfSight.lua"
+    - start_position:
+        bytes: 97
+        line: 1
+        character: 98
+      end_position:
+        bytes: 98
+        line: 1
+        character: 98
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 98
+      line: 2
+      character: 1
+    end_position:
+      bytes: 103
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 103
+        line: 2
+        character: 6
+      end_position:
+        bytes: 104
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 104
+      line: 2
+      character: 7
+    end_position:
+      bytes: 121
+      line: 2
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: ReplicatedStorage
+  trailing_trivia:
+    - start_position:
+        bytes: 121
+        line: 2
+        character: 24
+      end_position:
+        bytes: 122
+        line: 2
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 122
+      line: 2
+      character: 25
+    end_position:
+      bytes: 123
+      line: 2
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 123
+        line: 2
+        character: 26
+      end_position:
+        bytes: 124
+        line: 2
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 124
+      line: 2
+      character: 27
+    end_position:
+      bytes: 128
+      line: 2
+      character: 31
+    token_type:
+      type: Identifier
+      identifier: game
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 128
+      line: 2
+      character: 31
+    end_position:
+      bytes: 129
+      line: 2
+      character: 32
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 129
+      line: 2
+      character: 32
+    end_position:
+      bytes: 139
+      line: 2
+      character: 42
+    token_type:
+      type: Identifier
+      identifier: GetService
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 139
+      line: 2
+      character: 42
+    end_position:
+      bytes: 140
+      line: 2
+      character: 43
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 140
+      line: 2
+      character: 43
+    end_position:
+      bytes: 159
+      line: 2
+      character: 62
+    token_type:
+      type: StringLiteral
+      literal: ReplicatedStorage
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 159
+      line: 2
+      character: 62
+    end_position:
+      bytes: 160
+      line: 2
+      character: 63
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 160
+        line: 2
+        character: 63
+      end_position:
+        bytes: 161
+        line: 2
+        character: 63
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 161
+      line: 3
+      character: 1
+    end_position:
+      bytes: 166
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 166
+        line: 3
+        character: 6
+      end_position:
+        bytes: 167
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 167
+      line: 3
+      character: 7
+    end_position:
+      bytes: 177
+      line: 3
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: RunService
+  trailing_trivia:
+    - start_position:
+        bytes: 177
+        line: 3
+        character: 17
+      end_position:
+        bytes: 178
+        line: 3
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 178
+      line: 3
+      character: 18
+    end_position:
+      bytes: 179
+      line: 3
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 179
+        line: 3
+        character: 19
+      end_position:
+        bytes: 180
+        line: 3
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 180
+      line: 3
+      character: 20
+    end_position:
+      bytes: 184
+      line: 3
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: game
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 184
+      line: 3
+      character: 24
+    end_position:
+      bytes: 185
+      line: 3
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 185
+      line: 3
+      character: 25
+    end_position:
+      bytes: 195
+      line: 3
+      character: 35
+    token_type:
+      type: Identifier
+      identifier: GetService
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 195
+      line: 3
+      character: 35
+    end_position:
+      bytes: 196
+      line: 3
+      character: 36
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 196
+      line: 3
+      character: 36
+    end_position:
+      bytes: 208
+      line: 3
+      character: 48
+    token_type:
+      type: StringLiteral
+      literal: RunService
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 208
+      line: 3
+      character: 48
+    end_position:
+      bytes: 209
+      line: 3
+      character: 49
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 209
+        line: 3
+        character: 49
+      end_position:
+        bytes: 210
+        line: 3
+        character: 49
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 210
+        line: 4
+        character: 1
+      end_position:
+        bytes: 211
+        line: 4
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 211
+      line: 5
+      character: 1
+    end_position:
+      bytes: 216
+      line: 5
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 216
+        line: 5
+        character: 6
+      end_position:
+        bytes: 217
+        line: 5
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 217
+      line: 5
+      character: 7
+    end_position:
+      bytes: 224
+      line: 5
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: Raycast
+  trailing_trivia:
+    - start_position:
+        bytes: 224
+        line: 5
+        character: 14
+      end_position:
+        bytes: 225
+        line: 5
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 225
+      line: 5
+      character: 15
+    end_position:
+      bytes: 226
+      line: 5
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 226
+        line: 5
+        character: 16
+      end_position:
+        bytes: 227
+        line: 5
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 227
+      line: 5
+      character: 17
+    end_position:
+      bytes: 234
+      line: 5
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: require
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 234
+      line: 5
+      character: 24
+    end_position:
+      bytes: 235
+      line: 5
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 235
+      line: 5
+      character: 25
+    end_position:
+      bytes: 252
+      line: 5
+      character: 42
+    token_type:
+      type: Identifier
+      identifier: ReplicatedStorage
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 252
+      line: 5
+      character: 42
+    end_position:
+      bytes: 253
+      line: 5
+      character: 43
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 253
+      line: 5
+      character: 43
+    end_position:
+      bytes: 260
+      line: 5
+      character: 50
+    token_type:
+      type: Identifier
+      identifier: Modules
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 260
+      line: 5
+      character: 50
+    end_position:
+      bytes: 261
+      line: 5
+      character: 51
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 261
+      line: 5
+      character: 51
+    end_position:
+      bytes: 268
+      line: 5
+      character: 58
+    token_type:
+      type: Identifier
+      identifier: Raycast
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 268
+      line: 5
+      character: 58
+    end_position:
+      bytes: 269
+      line: 5
+      character: 59
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 269
+        line: 5
+        character: 59
+      end_position:
+        bytes: 270
+        line: 5
+        character: 59
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 270
+        line: 6
+        character: 1
+      end_position:
+        bytes: 271
+        line: 6
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 271
+      line: 7
+      character: 1
+    end_position:
+      bytes: 276
+      line: 7
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 276
+        line: 7
+        character: 6
+      end_position:
+        bytes: 277
+        line: 7
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 277
+      line: 7
+      character: 7
+    end_position:
+      bytes: 282
+      line: 7
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: DEBUG
+  trailing_trivia:
+    - start_position:
+        bytes: 282
+        line: 7
+        character: 12
+      end_position:
+        bytes: 283
+        line: 7
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 283
+      line: 7
+      character: 13
+    end_position:
+      bytes: 284
+      line: 7
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 284
+        line: 7
+        character: 14
+      end_position:
+        bytes: 285
+        line: 7
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 285
+      line: 7
+      character: 15
+    end_position:
+      bytes: 289
+      line: 7
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia:
+    - start_position:
+        bytes: 289
+        line: 7
+        character: 19
+      end_position:
+        bytes: 290
+        line: 7
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 290
+      line: 8
+      character: 1
+    end_position:
+      bytes: 295
+      line: 8
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: DEBUG
+  trailing_trivia:
+    - start_position:
+        bytes: 295
+        line: 8
+        character: 6
+      end_position:
+        bytes: 296
+        line: 8
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 296
+      line: 8
+      character: 7
+    end_position:
+      bytes: 297
+      line: 8
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 297
+        line: 8
+        character: 8
+      end_position:
+        bytes: 298
+        line: 8
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 298
+      line: 8
+      character: 9
+    end_position:
+      bytes: 303
+      line: 8
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: DEBUG
+  trailing_trivia:
+    - start_position:
+        bytes: 303
+        line: 8
+        character: 14
+      end_position:
+        bytes: 304
+        line: 8
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 304
+      line: 8
+      character: 15
+    end_position:
+      bytes: 307
+      line: 8
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 307
+        line: 8
+        character: 18
+      end_position:
+        bytes: 308
+        line: 8
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 308
+      line: 8
+      character: 19
+    end_position:
+      bytes: 318
+      line: 8
+      character: 29
+    token_type:
+      type: Identifier
+      identifier: RunService
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 318
+      line: 8
+      character: 29
+    end_position:
+      bytes: 319
+      line: 8
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 319
+      line: 8
+      character: 30
+    end_position:
+      bytes: 327
+      line: 8
+      character: 38
+    token_type:
+      type: Identifier
+      identifier: IsStudio
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 327
+      line: 8
+      character: 38
+    end_position:
+      bytes: 328
+      line: 8
+      character: 39
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 328
+      line: 8
+      character: 39
+    end_position:
+      bytes: 329
+      line: 8
+      character: 40
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 329
+        line: 8
+        character: 40
+      end_position:
+        bytes: 330
+        line: 8
+        character: 40
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 330
+        line: 9
+        character: 1
+      end_position:
+        bytes: 331
+        line: 9
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 331
+      line: 10
+      character: 1
+    end_position:
+      bytes: 336
+      line: 10
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 336
+        line: 10
+        character: 6
+      end_position:
+        bytes: 337
+        line: 10
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 337
+      line: 10
+      character: 7
+    end_position:
+      bytes: 342
+      line: 10
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: debug
+  trailing_trivia:
+    - start_position:
+        bytes: 342
+        line: 10
+        character: 12
+      end_position:
+        bytes: 343
+        line: 10
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 343
+        line: 11
+        character: 1
+      end_position:
+        bytes: 344
+        line: 11
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 344
+      line: 12
+      character: 1
+    end_position:
+      bytes: 346
+      line: 12
+      character: 3
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 346
+        line: 12
+        character: 3
+      end_position:
+        bytes: 347
+        line: 12
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 347
+      line: 12
+      character: 4
+    end_position:
+      bytes: 352
+      line: 12
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: DEBUG
+  trailing_trivia:
+    - start_position:
+        bytes: 352
+        line: 12
+        character: 9
+      end_position:
+        bytes: 353
+        line: 12
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 353
+      line: 12
+      character: 10
+    end_position:
+      bytes: 357
+      line: 12
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 357
+        line: 12
+        character: 14
+      end_position:
+        bytes: 358
+        line: 12
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 358
+        line: 13
+        character: 1
+      end_position:
+        bytes: 359
+        line: 13
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 359
+      line: 13
+      character: 2
+    end_position:
+      bytes: 367
+      line: 13
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 367
+        line: 13
+        character: 10
+      end_position:
+        bytes: 368
+        line: 13
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 368
+      line: 13
+      character: 11
+    end_position:
+      bytes: 373
+      line: 13
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: debug
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 373
+      line: 13
+      character: 16
+    end_position:
+      bytes: 374
+      line: 13
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 374
+      line: 13
+      character: 17
+    end_position:
+      bytes: 377
+      line: 13
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 377
+      line: 13
+      character: 20
+    end_position:
+      bytes: 378
+      line: 13
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 378
+        line: 13
+        character: 21
+      end_position:
+        bytes: 379
+        line: 13
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 379
+        line: 14
+        character: 1
+      end_position:
+        bytes: 381
+        line: 14
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\t\t"
+  token:
+    start_position:
+      bytes: 381
+      line: 14
+      character: 3
+    end_position:
+      bytes: 386
+      line: 14
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: print
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 386
+      line: 14
+      character: 8
+    end_position:
+      bytes: 387
+      line: 14
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 387
+      line: 14
+      character: 9
+    end_position:
+      bytes: 402
+      line: 14
+      character: 24
+    token_type:
+      type: StringLiteral
+      literal: "[LineOfSight]"
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 402
+      line: 14
+      character: 24
+    end_position:
+      bytes: 403
+      line: 14
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 403
+        line: 14
+        character: 25
+      end_position:
+        bytes: 404
+        line: 14
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 404
+      line: 14
+      character: 26
+    end_position:
+      bytes: 407
+      line: 14
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 407
+      line: 14
+      character: 29
+    end_position:
+      bytes: 408
+      line: 14
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 408
+        line: 14
+        character: 30
+      end_position:
+        bytes: 409
+        line: 14
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 409
+        line: 15
+        character: 1
+      end_position:
+        bytes: 410
+        line: 15
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 410
+      line: 15
+      character: 2
+    end_position:
+      bytes: 413
+      line: 15
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 413
+        line: 15
+        character: 5
+      end_position:
+        bytes: 414
+        line: 15
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 414
+      line: 16
+      character: 1
+    end_position:
+      bytes: 418
+      line: 16
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: else
+  trailing_trivia:
+    - start_position:
+        bytes: 418
+        line: 16
+        character: 5
+      end_position:
+        bytes: 419
+        line: 16
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 419
+        line: 17
+        character: 1
+      end_position:
+        bytes: 420
+        line: 17
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 420
+      line: 17
+      character: 2
+    end_position:
+      bytes: 428
+      line: 17
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 428
+        line: 17
+        character: 10
+      end_position:
+        bytes: 429
+        line: 17
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 429
+      line: 17
+      character: 11
+    end_position:
+      bytes: 434
+      line: 17
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: debug
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 434
+      line: 17
+      character: 16
+    end_position:
+      bytes: 435
+      line: 17
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 435
+      line: 17
+      character: 17
+    end_position:
+      bytes: 436
+      line: 17
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 436
+        line: 17
+        character: 18
+      end_position:
+        bytes: 437
+        line: 17
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 437
+        line: 18
+        character: 1
+      end_position:
+        bytes: 438
+        line: 18
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 438
+      line: 18
+      character: 2
+    end_position:
+      bytes: 441
+      line: 18
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 441
+        line: 18
+        character: 5
+      end_position:
+        bytes: 442
+        line: 18
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 442
+      line: 19
+      character: 1
+    end_position:
+      bytes: 445
+      line: 19
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 445
+        line: 19
+        character: 4
+      end_position:
+        bytes: 446
+        line: 19
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 446
+        line: 20
+        character: 1
+      end_position:
+        bytes: 447
+        line: 20
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 447
+      line: 21
+      character: 1
+    end_position:
+      bytes: 453
+      line: 21
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 453
+        line: 21
+        character: 7
+      end_position:
+        bytes: 454
+        line: 21
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 454
+      line: 21
+      character: 8
+    end_position:
+      bytes: 462
+      line: 21
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 462
+      line: 21
+      character: 16
+    end_position:
+      bytes: 463
+      line: 21
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 463
+      line: 21
+      character: 17
+    end_position:
+      bytes: 469
+      line: 21
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 469
+      line: 21
+      character: 23
+    end_position:
+      bytes: 470
+      line: 21
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 470
+        line: 21
+        character: 24
+      end_position:
+        bytes: 471
+        line: 21
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 471
+      line: 21
+      character: 25
+    end_position:
+      bytes: 480
+      line: 21
+      character: 34
+    token_type:
+      type: Identifier
+      identifier: character
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 480
+      line: 21
+      character: 34
+    end_position:
+      bytes: 481
+      line: 21
+      character: 35
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 481
+        line: 21
+        character: 35
+      end_position:
+        bytes: 482
+        line: 21
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 482
+      line: 21
+      character: 36
+    end_position:
+      bytes: 487
+      line: 21
+      character: 41
+    token_type:
+      type: Identifier
+      identifier: range
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 487
+      line: 21
+      character: 41
+    end_position:
+      bytes: 488
+      line: 21
+      character: 42
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 488
+        line: 21
+        character: 42
+      end_position:
+        bytes: 489
+        line: 21
+        character: 43
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 489
+      line: 21
+      character: 43
+    end_position:
+      bytes: 497
+      line: 21
+      character: 51
+    token_type:
+      type: Identifier
+      identifier: ignoreIf
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 497
+      line: 21
+      character: 51
+    end_position:
+      bytes: 498
+      line: 21
+      character: 52
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 498
+        line: 21
+        character: 52
+      end_position:
+        bytes: 499
+        line: 21
+        character: 53
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 499
+      line: 21
+      character: 53
+    end_position:
+      bytes: 508
+      line: 21
+      character: 62
+    token_type:
+      type: Identifier
+      identifier: blacklist
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 508
+      line: 21
+      character: 62
+    end_position:
+      bytes: 509
+      line: 21
+      character: 63
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 509
+        line: 21
+        character: 63
+      end_position:
+        bytes: 510
+        line: 21
+        character: 63
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 510
+        line: 22
+        character: 1
+      end_position:
+        bytes: 511
+        line: 22
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 511
+      line: 22
+      character: 2
+    end_position:
+      bytes: 513
+      line: 22
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 513
+        line: 22
+        character: 4
+      end_position:
+        bytes: 514
+        line: 22
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 514
+      line: 22
+      character: 5
+    end_position:
+      bytes: 520
+      line: 22
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: typeof
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 520
+      line: 22
+      character: 11
+    end_position:
+      bytes: 521
+      line: 22
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 521
+      line: 22
+      character: 12
+    end_position:
+      bytes: 527
+      line: 22
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 527
+      line: 22
+      character: 18
+    end_position:
+      bytes: 528
+      line: 22
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 528
+        line: 22
+        character: 19
+      end_position:
+        bytes: 529
+        line: 22
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 529
+      line: 22
+      character: 20
+    end_position:
+      bytes: 531
+      line: 22
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: "=="
+  trailing_trivia:
+    - start_position:
+        bytes: 531
+        line: 22
+        character: 22
+      end_position:
+        bytes: 532
+        line: 22
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 532
+      line: 22
+      character: 23
+    end_position:
+      bytes: 542
+      line: 22
+      character: 33
+    token_type:
+      type: StringLiteral
+      literal: Instance
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 542
+        line: 22
+        character: 33
+      end_position:
+        bytes: 543
+        line: 22
+        character: 34
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 543
+      line: 22
+      character: 34
+    end_position:
+      bytes: 547
+      line: 22
+      character: 38
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 547
+        line: 22
+        character: 38
+      end_position:
+        bytes: 548
+        line: 22
+        character: 38
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 548
+        line: 23
+        character: 1
+      end_position:
+        bytes: 550
+        line: 23
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\t\t"
+  token:
+    start_position:
+      bytes: 550
+      line: 23
+      character: 3
+    end_position:
+      bytes: 552
+      line: 23
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 552
+        line: 23
+        character: 5
+      end_position:
+        bytes: 553
+        line: 23
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 553
+      line: 23
+      character: 6
+    end_position:
+      bytes: 559
+      line: 23
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 559
+      line: 23
+      character: 12
+    end_position:
+      bytes: 560
+      line: 23
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 560
+      line: 23
+      character: 13
+    end_position:
+      bytes: 568
+      line: 23
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: Position
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 568
+      line: 23
+      character: 21
+    end_position:
+      bytes: 569
+      line: 23
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 569
+      line: 23
+      character: 22
+    end_position:
+      bytes: 576
+      line: 23
+      character: 29
+    token_type:
+      type: Identifier
+      identifier: FuzzyEq
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 576
+      line: 23
+      character: 29
+    end_position:
+      bytes: 577
+      line: 23
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 577
+      line: 23
+      character: 30
+    end_position:
+      bytes: 586
+      line: 23
+      character: 39
+    token_type:
+      type: Identifier
+      identifier: character
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 586
+      line: 23
+      character: 39
+    end_position:
+      bytes: 587
+      line: 23
+      character: 40
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 587
+      line: 23
+      character: 40
+    end_position:
+      bytes: 598
+      line: 23
+      character: 51
+    token_type:
+      type: Identifier
+      identifier: PrimaryPart
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 598
+      line: 23
+      character: 51
+    end_position:
+      bytes: 599
+      line: 23
+      character: 52
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 599
+      line: 23
+      character: 52
+    end_position:
+      bytes: 607
+      line: 23
+      character: 60
+    token_type:
+      type: Identifier
+      identifier: Position
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 607
+      line: 23
+      character: 60
+    end_position:
+      bytes: 608
+      line: 23
+      character: 61
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 608
+        line: 23
+        character: 61
+      end_position:
+        bytes: 609
+        line: 23
+        character: 62
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 609
+      line: 23
+      character: 62
+    end_position:
+      bytes: 613
+      line: 23
+      character: 66
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 613
+        line: 23
+        character: 66
+      end_position:
+        bytes: 614
+        line: 23
+        character: 66
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 614
+        line: 24
+        character: 1
+      end_position:
+        bytes: 617
+        line: 24
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t"
+  token:
+    start_position:
+      bytes: 617
+      line: 24
+      character: 4
+    end_position:
+      bytes: 622
+      line: 24
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: debug
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 622
+      line: 24
+      character: 9
+    end_position:
+      bytes: 623
+      line: 24
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 623
+      line: 24
+      character: 10
+    end_position:
+      bytes: 645
+      line: 24
+      character: 32
+    token_type:
+      type: StringLiteral
+      literal: ORIGIN WAS CHARACTER
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 645
+      line: 24
+      character: 32
+    end_position:
+      bytes: 646
+      line: 24
+      character: 33
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 646
+        line: 24
+        character: 33
+      end_position:
+        bytes: 647
+        line: 24
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 647
+        line: 25
+        character: 1
+      end_position:
+        bytes: 650
+        line: 25
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t"
+  token:
+    start_position:
+      bytes: 650
+      line: 25
+      character: 4
+    end_position:
+      bytes: 656
+      line: 25
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 656
+        line: 25
+        character: 10
+      end_position:
+        bytes: 657
+        line: 25
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 657
+      line: 25
+      character: 11
+    end_position:
+      bytes: 663
+      line: 25
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 663
+      line: 25
+      character: 17
+    end_position:
+      bytes: 664
+      line: 25
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 664
+        line: 25
+        character: 18
+      end_position:
+        bytes: 665
+        line: 25
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 665
+      line: 25
+      character: 19
+    end_position:
+      bytes: 671
+      line: 25
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 671
+      line: 25
+      character: 25
+    end_position:
+      bytes: 672
+      line: 25
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 672
+      line: 25
+      character: 26
+    end_position:
+      bytes: 680
+      line: 25
+      character: 34
+    token_type:
+      type: Identifier
+      identifier: Position
+  trailing_trivia:
+    - start_position:
+        bytes: 680
+        line: 25
+        character: 34
+      end_position:
+        bytes: 681
+        line: 25
+        character: 34
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 681
+        line: 26
+        character: 1
+      end_position:
+        bytes: 683
+        line: 26
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\t\t"
+  token:
+    start_position:
+      bytes: 683
+      line: 26
+      character: 3
+    end_position:
+      bytes: 686
+      line: 26
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 686
+        line: 26
+        character: 6
+      end_position:
+        bytes: 687
+        line: 26
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 687
+        line: 27
+        character: 1
+      end_position:
+        bytes: 688
+        line: 27
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 688
+        line: 28
+        character: 1
+      end_position:
+        bytes: 690
+        line: 28
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\t\t"
+  token:
+    start_position:
+      bytes: 690
+      line: 28
+      character: 3
+    end_position:
+      bytes: 696
+      line: 28
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia:
+    - start_position:
+        bytes: 696
+        line: 28
+        character: 9
+      end_position:
+        bytes: 697
+        line: 28
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 697
+      line: 28
+      character: 10
+    end_position:
+      bytes: 698
+      line: 28
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 698
+        line: 28
+        character: 11
+      end_position:
+        bytes: 699
+        line: 28
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 699
+      line: 28
+      character: 12
+    end_position:
+      bytes: 705
+      line: 28
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 705
+      line: 28
+      character: 18
+    end_position:
+      bytes: 706
+      line: 28
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 706
+      line: 28
+      character: 19
+    end_position:
+      bytes: 714
+      line: 28
+      character: 27
+    token_type:
+      type: Identifier
+      identifier: Position
+  trailing_trivia:
+    - start_position:
+        bytes: 714
+        line: 28
+        character: 27
+      end_position:
+        bytes: 715
+        line: 28
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 715
+        line: 29
+        character: 1
+      end_position:
+        bytes: 716
+        line: 29
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 716
+      line: 29
+      character: 2
+    end_position:
+      bytes: 719
+      line: 29
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 719
+        line: 29
+        character: 5
+      end_position:
+        bytes: 720
+        line: 29
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 720
+        line: 30
+        character: 1
+      end_position:
+        bytes: 721
+        line: 30
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 721
+        line: 31
+        character: 1
+      end_position:
+        bytes: 722
+        line: 31
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 722
+      line: 31
+      character: 2
+    end_position:
+      bytes: 731
+      line: 31
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: blacklist
+  trailing_trivia:
+    - start_position:
+        bytes: 731
+        line: 31
+        character: 11
+      end_position:
+        bytes: 732
+        line: 31
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 732
+      line: 31
+      character: 12
+    end_position:
+      bytes: 733
+      line: 31
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 733
+        line: 31
+        character: 13
+      end_position:
+        bytes: 734
+        line: 31
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 734
+      line: 31
+      character: 14
+    end_position:
+      bytes: 743
+      line: 31
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: blacklist
+  trailing_trivia:
+    - start_position:
+        bytes: 743
+        line: 31
+        character: 23
+      end_position:
+        bytes: 744
+        line: 31
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 744
+      line: 31
+      character: 24
+    end_position:
+      bytes: 746
+      line: 31
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: or
+  trailing_trivia:
+    - start_position:
+        bytes: 746
+        line: 31
+        character: 26
+      end_position:
+        bytes: 747
+        line: 31
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 747
+      line: 31
+      character: 27
+    end_position:
+      bytes: 748
+      line: 31
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 748
+      line: 31
+      character: 28
+    end_position:
+      bytes: 749
+      line: 31
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 749
+        line: 31
+        character: 29
+      end_position:
+        bytes: 750
+        line: 31
+        character: 29
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 750
+        line: 32
+        character: 1
+      end_position:
+        bytes: 751
+        line: 32
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 751
+        line: 33
+        character: 1
+      end_position:
+        bytes: 752
+        line: 33
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 752
+      line: 33
+      character: 2
+    end_position:
+      bytes: 757
+      line: 33
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 757
+        line: 33
+        character: 7
+      end_position:
+        bytes: 758
+        line: 33
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 758
+      line: 33
+      character: 8
+    end_position:
+      bytes: 761
+      line: 33
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 761
+      line: 33
+      character: 11
+    end_position:
+      bytes: 762
+      line: 33
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 762
+        line: 33
+        character: 12
+      end_position:
+        bytes: 763
+        line: 33
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 763
+      line: 33
+      character: 13
+    end_position:
+      bytes: 768
+      line: 33
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: point
+  trailing_trivia:
+    - start_position:
+        bytes: 768
+        line: 33
+        character: 18
+      end_position:
+        bytes: 769
+        line: 33
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 769
+      line: 33
+      character: 19
+    end_position:
+      bytes: 771
+      line: 33
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 771
+        line: 33
+        character: 21
+      end_position:
+        bytes: 772
+        line: 33
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 772
+        line: 34
+        character: 1
+      end_position:
+        bytes: 774
+        line: 34
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\t\t"
+  token:
+    start_position:
+      bytes: 774
+      line: 34
+      character: 3
+    end_position:
+      bytes: 779
+      line: 34
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: while
+  trailing_trivia:
+    - start_position:
+        bytes: 779
+        line: 34
+        character: 8
+      end_position:
+        bytes: 780
+        line: 34
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 780
+      line: 34
+      character: 9
+    end_position:
+      bytes: 784
+      line: 34
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "true"
+  trailing_trivia:
+    - start_position:
+        bytes: 784
+        line: 34
+        character: 13
+      end_position:
+        bytes: 785
+        line: 34
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 785
+      line: 34
+      character: 14
+    end_position:
+      bytes: 787
+      line: 34
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 787
+        line: 34
+        character: 16
+      end_position:
+        bytes: 788
+        line: 34
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 788
+        line: 35
+        character: 1
+      end_position:
+        bytes: 791
+        line: 35
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t"
+  token:
+    start_position:
+      bytes: 791
+      line: 35
+      character: 4
+    end_position:
+      bytes: 794
+      line: 35
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 794
+      line: 35
+      character: 7
+    end_position:
+      bytes: 795
+      line: 35
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 795
+        line: 35
+        character: 8
+      end_position:
+        bytes: 796
+        line: 35
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 796
+      line: 35
+      character: 9
+    end_position:
+      bytes: 801
+      line: 35
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: point
+  trailing_trivia:
+    - start_position:
+        bytes: 801
+        line: 35
+        character: 14
+      end_position:
+        bytes: 802
+        line: 35
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 802
+      line: 35
+      character: 15
+    end_position:
+      bytes: 803
+      line: 35
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 803
+        line: 35
+        character: 16
+      end_position:
+        bytes: 804
+        line: 35
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 804
+      line: 35
+      character: 17
+    end_position:
+      bytes: 811
+      line: 35
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: Raycast
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 811
+      line: 35
+      character: 24
+    end_position:
+      bytes: 812
+      line: 35
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 812
+      line: 35
+      character: 25
+    end_position:
+      bytes: 815
+      line: 35
+      character: 28
+    token_type:
+      type: Identifier
+      identifier: Ray
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 815
+      line: 35
+      character: 28
+    end_position:
+      bytes: 816
+      line: 35
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 816
+      line: 35
+      character: 29
+    end_position:
+      bytes: 819
+      line: 35
+      character: 32
+    token_type:
+      type: Identifier
+      identifier: new
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 819
+      line: 35
+      character: 32
+    end_position:
+      bytes: 820
+      line: 35
+      character: 33
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 820
+      line: 35
+      character: 33
+    end_position:
+      bytes: 826
+      line: 35
+      character: 39
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 826
+      line: 35
+      character: 39
+    end_position:
+      bytes: 827
+      line: 35
+      character: 40
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 827
+        line: 35
+        character: 40
+      end_position:
+        bytes: 828
+        line: 35
+        character: 41
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 828
+      line: 35
+      character: 41
+    end_position:
+      bytes: 829
+      line: 35
+      character: 42
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 829
+      line: 35
+      character: 42
+    end_position:
+      bytes: 835
+      line: 35
+      character: 48
+    token_type:
+      type: Identifier
+      identifier: origin
+  trailing_trivia:
+    - start_position:
+        bytes: 835
+        line: 35
+        character: 48
+      end_position:
+        bytes: 836
+        line: 35
+        character: 49
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 836
+      line: 35
+      character: 49
+    end_position:
+      bytes: 837
+      line: 35
+      character: 50
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia:
+    - start_position:
+        bytes: 837
+        line: 35
+        character: 50
+      end_position:
+        bytes: 838
+        line: 35
+        character: 51
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 838
+      line: 35
+      character: 51
+    end_position:
+      bytes: 847
+      line: 35
+      character: 60
+    token_type:
+      type: Identifier
+      identifier: character
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 847
+      line: 35
+      character: 60
+    end_position:
+      bytes: 848
+      line: 35
+      character: 61
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 848
+      line: 35
+      character: 61
+    end_position:
+      bytes: 859
+      line: 35
+      character: 72
+    token_type:
+      type: Identifier
+      identifier: PrimaryPart
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 859
+      line: 35
+      character: 72
+    end_position:
+      bytes: 860
+      line: 35
+      character: 73
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 860
+      line: 35
+      character: 73
+    end_position:
+      bytes: 868
+      line: 35
+      character: 81
+    token_type:
+      type: Identifier
+      identifier: Position
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 868
+      line: 35
+      character: 81
+    end_position:
+      bytes: 869
+      line: 35
+      character: 82
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 869
+      line: 35
+      character: 82
+    end_position:
+      bytes: 870
+      line: 35
+      character: 83
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 870
+      line: 35
+      character: 83
+    end_position:
+      bytes: 874
+      line: 35
+      character: 87
+    token_type:
+      type: Identifier
+      identifier: Unit
+  trailing_trivia:
+    - start_position:
+        bytes: 874
+        line: 35
+        character: 87
+      end_position:
+        bytes: 875
+        line: 35
+        character: 88
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 875
+      line: 35
+      character: 88
+    end_position:
+      bytes: 876
+      line: 35
+      character: 89
+    token_type:
+      type: Symbol
+      symbol: "*"
+  trailing_trivia:
+    - start_position:
+        bytes: 876
+        line: 35
+        character: 89
+      end_position:
+        bytes: 877
+        line: 35
+        character: 90
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 877
+      line: 35
+      character: 90
+    end_position:
+      bytes: 878
+      line: 35
+      character: 91
+    token_type:
+      type: Symbol
+      symbol: "-"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 878
+      line: 35
+      character: 91
+    end_position:
+      bytes: 883
+      line: 35
+      character: 96
+    token_type:
+      type: Identifier
+      identifier: range
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 883
+      line: 35
+      character: 96
+    end_position:
+      bytes: 884
+      line: 35
+      character: 97
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 884
+      line: 35
+      character: 97
+    end_position:
+      bytes: 885
+      line: 35
+      character: 98
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 885
+        line: 35
+        character: 98
+      end_position:
+        bytes: 886
+        line: 35
+        character: 99
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 886
+      line: 35
+      character: 99
+    end_position:
+      bytes: 895
+      line: 35
+      character: 108
+    token_type:
+      type: Identifier
+      identifier: blacklist
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 895
+      line: 35
+      character: 108
+    end_position:
+      bytes: 896
+      line: 35
+      character: 109
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 896
+        line: 35
+        character: 109
+      end_position:
+        bytes: 897
+        line: 35
+        character: 109
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 897
+        line: 36
+        character: 1
+      end_position:
+        bytes: 898
+        line: 36
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 898
+        line: 37
+        character: 1
+      end_position:
+        bytes: 901
+        line: 37
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t"
+  token:
+    start_position:
+      bytes: 901
+      line: 37
+      character: 4
+    end_position:
+      bytes: 903
+      line: 37
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: if
+  trailing_trivia:
+    - start_position:
+        bytes: 903
+        line: 37
+        character: 6
+      end_position:
+        bytes: 904
+        line: 37
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 904
+      line: 37
+      character: 7
+    end_position:
+      bytes: 907
+      line: 37
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia:
+    - start_position:
+        bytes: 907
+        line: 37
+        character: 10
+      end_position:
+        bytes: 908
+        line: 37
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 908
+      line: 37
+      character: 11
+    end_position:
+      bytes: 911
+      line: 37
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 911
+        line: 37
+        character: 14
+      end_position:
+        bytes: 912
+        line: 37
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 912
+      line: 37
+      character: 15
+    end_position:
+      bytes: 915
+      line: 37
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 915
+      line: 37
+      character: 18
+    end_position:
+      bytes: 916
+      line: 37
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 916
+      line: 37
+      character: 19
+    end_position:
+      bytes: 930
+      line: 37
+      character: 33
+    token_type:
+      type: Identifier
+      identifier: IsDescendantOf
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 930
+      line: 37
+      character: 33
+    end_position:
+      bytes: 931
+      line: 37
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 931
+      line: 37
+      character: 34
+    end_position:
+      bytes: 940
+      line: 37
+      character: 43
+    token_type:
+      type: Identifier
+      identifier: character
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 940
+      line: 37
+      character: 43
+    end_position:
+      bytes: 941
+      line: 37
+      character: 44
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 941
+        line: 37
+        character: 44
+      end_position:
+        bytes: 942
+        line: 37
+        character: 45
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 942
+      line: 37
+      character: 45
+    end_position:
+      bytes: 946
+      line: 37
+      character: 49
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 946
+        line: 37
+        character: 49
+      end_position:
+        bytes: 947
+        line: 37
+        character: 49
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 947
+        line: 38
+        character: 1
+      end_position:
+        bytes: 951
+        line: 38
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t\t"
+  token:
+    start_position:
+      bytes: 951
+      line: 38
+      character: 5
+    end_position:
+      bytes: 956
+      line: 38
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: break
+  trailing_trivia:
+    - start_position:
+        bytes: 956
+        line: 38
+        character: 10
+      end_position:
+        bytes: 957
+        line: 38
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 957
+        line: 39
+        character: 1
+      end_position:
+        bytes: 960
+        line: 39
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t"
+  token:
+    start_position:
+      bytes: 960
+      line: 39
+      character: 4
+    end_position:
+      bytes: 966
+      line: 39
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: elseif
+  trailing_trivia:
+    - start_position:
+        bytes: 966
+        line: 39
+        character: 10
+      end_position:
+        bytes: 967
+        line: 39
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 967
+      line: 39
+      character: 11
+    end_position:
+      bytes: 970
+      line: 39
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia:
+    - start_position:
+        bytes: 970
+        line: 39
+        character: 14
+      end_position:
+        bytes: 971
+        line: 39
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 971
+      line: 39
+      character: 15
+    end_position:
+      bytes: 974
+      line: 39
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 974
+        line: 39
+        character: 18
+      end_position:
+        bytes: 975
+        line: 39
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 975
+      line: 39
+      character: 19
+    end_position:
+      bytes: 983
+      line: 39
+      character: 27
+    token_type:
+      type: Identifier
+      identifier: ignoreIf
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 983
+      line: 39
+      character: 27
+    end_position:
+      bytes: 984
+      line: 39
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 984
+      line: 39
+      character: 28
+    end_position:
+      bytes: 987
+      line: 39
+      character: 31
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 987
+      line: 39
+      character: 31
+    end_position:
+      bytes: 988
+      line: 39
+      character: 32
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 988
+        line: 39
+        character: 32
+      end_position:
+        bytes: 989
+        line: 39
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 989
+      line: 39
+      character: 33
+    end_position:
+      bytes: 993
+      line: 39
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: then
+  trailing_trivia:
+    - start_position:
+        bytes: 993
+        line: 39
+        character: 37
+      end_position:
+        bytes: 994
+        line: 39
+        character: 37
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 994
+        line: 40
+        character: 1
+      end_position:
+        bytes: 998
+        line: 40
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t\t"
+  token:
+    start_position:
+      bytes: 998
+      line: 40
+      character: 5
+    end_position:
+      bytes: 1003
+      line: 40
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: debug
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1003
+      line: 40
+      character: 10
+    end_position:
+      bytes: 1004
+      line: 40
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1004
+      line: 40
+      character: 11
+    end_position:
+      bytes: 1021
+      line: 40
+      character: 28
+    token_type:
+      type: StringLiteral
+      literal: IGNORING OFF IF
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1021
+      line: 40
+      character: 28
+    end_position:
+      bytes: 1022
+      line: 40
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 1022
+        line: 40
+        character: 29
+      end_position:
+        bytes: 1023
+        line: 40
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1023
+      line: 40
+      character: 30
+    end_position:
+      bytes: 1026
+      line: 40
+      character: 33
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1026
+      line: 40
+      character: 33
+    end_position:
+      bytes: 1027
+      line: 40
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1027
+      line: 40
+      character: 34
+    end_position:
+      bytes: 1038
+      line: 40
+      character: 45
+    token_type:
+      type: Identifier
+      identifier: GetFullName
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1038
+      line: 40
+      character: 45
+    end_position:
+      bytes: 1039
+      line: 40
+      character: 46
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1039
+      line: 40
+      character: 46
+    end_position:
+      bytes: 1040
+      line: 40
+      character: 47
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1040
+      line: 40
+      character: 47
+    end_position:
+      bytes: 1041
+      line: 40
+      character: 48
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 1041
+        line: 40
+        character: 48
+      end_position:
+        bytes: 1042
+        line: 40
+        character: 48
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1042
+        line: 41
+        character: 1
+      end_position:
+        bytes: 1046
+        line: 41
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t\t"
+  token:
+    start_position:
+      bytes: 1046
+      line: 41
+      character: 5
+    end_position:
+      bytes: 1055
+      line: 41
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: blacklist
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1055
+      line: 41
+      character: 14
+    end_position:
+      bytes: 1056
+      line: 41
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1056
+      line: 41
+      character: 15
+    end_position:
+      bytes: 1057
+      line: 41
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "#"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1057
+      line: 41
+      character: 16
+    end_position:
+      bytes: 1066
+      line: 41
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: blacklist
+  trailing_trivia:
+    - start_position:
+        bytes: 1066
+        line: 41
+        character: 25
+      end_position:
+        bytes: 1067
+        line: 41
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1067
+      line: 41
+      character: 26
+    end_position:
+      bytes: 1068
+      line: 41
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 1068
+        line: 41
+        character: 27
+      end_position:
+        bytes: 1069
+        line: 41
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1069
+      line: 41
+      character: 28
+    end_position:
+      bytes: 1070
+      line: 41
+      character: 29
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1070
+      line: 41
+      character: 29
+    end_position:
+      bytes: 1071
+      line: 41
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia:
+    - start_position:
+        bytes: 1071
+        line: 41
+        character: 30
+      end_position:
+        bytes: 1072
+        line: 41
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1072
+      line: 41
+      character: 31
+    end_position:
+      bytes: 1073
+      line: 41
+      character: 32
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 1073
+        line: 41
+        character: 32
+      end_position:
+        bytes: 1074
+        line: 41
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1074
+      line: 41
+      character: 33
+    end_position:
+      bytes: 1077
+      line: 41
+      character: 36
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia:
+    - start_position:
+        bytes: 1077
+        line: 41
+        character: 36
+      end_position:
+        bytes: 1078
+        line: 41
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1078
+        line: 42
+        character: 1
+      end_position:
+        bytes: 1081
+        line: 42
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t"
+  token:
+    start_position:
+      bytes: 1081
+      line: 42
+      character: 4
+    end_position:
+      bytes: 1085
+      line: 42
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: else
+  trailing_trivia:
+    - start_position:
+        bytes: 1085
+        line: 42
+        character: 8
+      end_position:
+        bytes: 1086
+        line: 42
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1086
+        line: 43
+        character: 1
+      end_position:
+        bytes: 1090
+        line: 43
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t\t"
+  token:
+    start_position:
+      bytes: 1090
+      line: 43
+      character: 5
+    end_position:
+      bytes: 1095
+      line: 43
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: break
+  trailing_trivia:
+    - start_position:
+        bytes: 1095
+        line: 43
+        character: 10
+      end_position:
+        bytes: 1096
+        line: 43
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1096
+        line: 44
+        character: 1
+      end_position:
+        bytes: 1099
+        line: 44
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\t\t\t"
+  token:
+    start_position:
+      bytes: 1099
+      line: 44
+      character: 4
+    end_position:
+      bytes: 1102
+      line: 44
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 1102
+        line: 44
+        character: 7
+      end_position:
+        bytes: 1103
+        line: 44
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1103
+        line: 45
+        character: 1
+      end_position:
+        bytes: 1105
+        line: 45
+        character: 3
+      token_type:
+        type: Whitespace
+        characters: "\t\t"
+  token:
+    start_position:
+      bytes: 1105
+      line: 45
+      character: 3
+    end_position:
+      bytes: 1108
+      line: 45
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 1108
+        line: 45
+        character: 6
+      end_position:
+        bytes: 1109
+        line: 45
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1109
+        line: 46
+        character: 1
+      end_position:
+        bytes: 1110
+        line: 46
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 1110
+      line: 46
+      character: 2
+    end_position:
+      bytes: 1113
+      line: 46
+      character: 5
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 1113
+        line: 46
+        character: 5
+      end_position:
+        bytes: 1114
+        line: 46
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1114
+        line: 47
+        character: 1
+      end_position:
+        bytes: 1115
+        line: 47
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 1115
+        line: 48
+        character: 1
+      end_position:
+        bytes: 1116
+        line: 48
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 1116
+      line: 48
+      character: 2
+    end_position:
+      bytes: 1121
+      line: 48
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: debug
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1121
+      line: 48
+      character: 7
+    end_position:
+      bytes: 1122
+      line: 48
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1122
+      line: 48
+      character: 8
+    end_position:
+      bytes: 1134
+      line: 48
+      character: 20
+    token_type:
+      type: StringLiteral
+      literal: LOS RESULT
+      quote_type: Double
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1134
+      line: 48
+      character: 20
+    end_position:
+      bytes: 1135
+      line: 48
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 1135
+        line: 48
+        character: 21
+      end_position:
+        bytes: 1136
+        line: 48
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1136
+      line: 48
+      character: 22
+    end_position:
+      bytes: 1139
+      line: 48
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia:
+    - start_position:
+        bytes: 1139
+        line: 48
+        character: 25
+      end_position:
+        bytes: 1140
+        line: 48
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1140
+      line: 48
+      character: 26
+    end_position:
+      bytes: 1143
+      line: 48
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 1143
+        line: 48
+        character: 29
+      end_position:
+        bytes: 1144
+        line: 48
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1144
+      line: 48
+      character: 30
+    end_position:
+      bytes: 1147
+      line: 48
+      character: 33
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1147
+      line: 48
+      character: 33
+    end_position:
+      bytes: 1148
+      line: 48
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1148
+      line: 48
+      character: 34
+    end_position:
+      bytes: 1159
+      line: 48
+      character: 45
+    token_type:
+      type: Identifier
+      identifier: GetFullName
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1159
+      line: 48
+      character: 45
+    end_position:
+      bytes: 1160
+      line: 48
+      character: 46
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1160
+      line: 48
+      character: 46
+    end_position:
+      bytes: 1161
+      line: 48
+      character: 47
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1161
+      line: 48
+      character: 47
+    end_position:
+      bytes: 1162
+      line: 48
+      character: 48
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 1162
+        line: 48
+        character: 48
+      end_position:
+        bytes: 1163
+        line: 48
+        character: 48
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 1163
+        line: 49
+        character: 1
+      end_position:
+        bytes: 1164
+        line: 49
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+    - start_position:
+        bytes: 1164
+        line: 50
+        character: 1
+      end_position:
+        bytes: 1165
+        line: 50
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 1165
+      line: 50
+      character: 2
+    end_position:
+      bytes: 1171
+      line: 50
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 1171
+        line: 50
+        character: 8
+      end_position:
+        bytes: 1172
+        line: 50
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1172
+      line: 50
+      character: 9
+    end_position:
+      bytes: 1175
+      line: 50
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia:
+    - start_position:
+        bytes: 1175
+        line: 50
+        character: 12
+      end_position:
+        bytes: 1176
+        line: 50
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1176
+      line: 50
+      character: 13
+    end_position:
+      bytes: 1179
+      line: 50
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: and
+  trailing_trivia:
+    - start_position:
+        bytes: 1179
+        line: 50
+        character: 16
+      end_position:
+        bytes: 1180
+        line: 50
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1180
+      line: 50
+      character: 17
+    end_position:
+      bytes: 1183
+      line: 50
+      character: 20
+    token_type:
+      type: Identifier
+      identifier: hit
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1183
+      line: 50
+      character: 20
+    end_position:
+      bytes: 1184
+      line: 50
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1184
+      line: 50
+      character: 21
+    end_position:
+      bytes: 1198
+      line: 50
+      character: 35
+    token_type:
+      type: Identifier
+      identifier: IsDescendantOf
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1198
+      line: 50
+      character: 35
+    end_position:
+      bytes: 1199
+      line: 50
+      character: 36
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1199
+      line: 50
+      character: 36
+    end_position:
+      bytes: 1208
+      line: 50
+      character: 45
+    token_type:
+      type: Identifier
+      identifier: character
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1208
+      line: 50
+      character: 45
+    end_position:
+      bytes: 1209
+      line: 50
+      character: 46
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1209
+      line: 50
+      character: 46
+    end_position:
+      bytes: 1210
+      line: 50
+      character: 47
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 1210
+        line: 50
+        character: 47
+      end_position:
+        bytes: 1211
+        line: 50
+        character: 48
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1211
+      line: 50
+      character: 48
+    end_position:
+      bytes: 1216
+      line: 50
+      character: 53
+    token_type:
+      type: Identifier
+      identifier: point
+  trailing_trivia:
+    - start_position:
+        bytes: 1216
+        line: 50
+        character: 53
+      end_position:
+        bytes: 1217
+        line: 50
+        character: 53
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1217
+      line: 51
+      character: 1
+    end_position:
+      bytes: 1220
+      line: 51
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 1220
+        line: 51
+        character: 4
+      end_position:
+        bytes: 1221
+        line: 51
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 1221
+      line: 52
+      character: 1
+    end_position:
+      bytes: 1221
+      line: 52
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/shorthand_array_type/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/shorthand_array_type/tokens.snap
@@ -4,388 +4,457 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/shorthand_array_type
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: Array
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 22
-    line: 2
-    character: 1
-  end_position:
-    bytes: 26
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 26
-    line: 2
-    character: 5
-  end_position:
-    bytes: 27
-    line: 2
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 27
-    line: 2
-    character: 6
-  end_position:
-    bytes: 32
-    line: 2
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: Array
-- start_position:
-    bytes: 32
-    line: 2
-    character: 11
-  end_position:
-    bytes: 33
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 33
-    line: 2
-    character: 12
-  end_position:
-    bytes: 34
-    line: 2
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 34
-    line: 2
-    character: 13
-  end_position:
-    bytes: 35
-    line: 2
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 35
-    line: 2
-    character: 14
-  end_position:
-    bytes: 36
-    line: 2
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 36
-    line: 2
-    character: 15
-  end_position:
-    bytes: 37
-    line: 2
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 37
-    line: 2
-    character: 16
-  end_position:
-    bytes: 38
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 38
-    line: 2
-    character: 17
-  end_position:
-    bytes: 39
-    line: 2
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 39
-    line: 2
-    character: 18
-  end_position:
-    bytes: 40
-    line: 2
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 2
-    character: 19
-  end_position:
-    bytes: 41
-    line: 2
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 41
-    line: 2
-    character: 20
-  end_position:
-    bytes: 47
-    line: 2
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 47
-    line: 2
-    character: 26
-  end_position:
-    bytes: 48
-    line: 2
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 48
-    line: 2
-    character: 27
-  end_position:
-    bytes: 49
-    line: 2
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 49
-    line: 2
-    character: 28
-  end_position:
-    bytes: 50
-    line: 2
-    character: 29
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 50
-    line: 2
-    character: 29
-  end_position:
-    bytes: 51
-    line: 2
-    character: 30
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 51
-    line: 2
-    character: 30
-  end_position:
-    bytes: 52
-    line: 2
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 52
-    line: 2
-    character: 31
-  end_position:
-    bytes: 53
-    line: 2
-    character: 32
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 53
-    line: 2
-    character: 32
-  end_position:
-    bytes: 53
-    line: 2
-    character: 32
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: Array
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 11
+      line: 1
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 12
+      line: 1
+      character: 13
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 13
+        line: 1
+        character: 14
+      end_position:
+        bytes: 14
+        line: 1
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 15
+        line: 1
+        character: 16
+      end_position:
+        bytes: 16
+        line: 1
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 22
+      end_position:
+        bytes: 22
+        line: 1
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 2
+      character: 1
+    end_position:
+      bytes: 26
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 26
+        line: 2
+        character: 5
+      end_position:
+        bytes: 27
+        line: 2
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 27
+      line: 2
+      character: 6
+    end_position:
+      bytes: 32
+      line: 2
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: Array
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 2
+      character: 11
+    end_position:
+      bytes: 33
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 2
+      character: 12
+    end_position:
+      bytes: 34
+      line: 2
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 34
+      line: 2
+      character: 13
+    end_position:
+      bytes: 35
+      line: 2
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 35
+        line: 2
+        character: 14
+      end_position:
+        bytes: 36
+        line: 2
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 2
+      character: 15
+    end_position:
+      bytes: 37
+      line: 2
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 37
+        line: 2
+        character: 16
+      end_position:
+        bytes: 38
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 38
+      line: 2
+      character: 17
+    end_position:
+      bytes: 39
+      line: 2
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 2
+        character: 18
+      end_position:
+        bytes: 40
+        line: 2
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 19
+    end_position:
+      bytes: 41
+      line: 2
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 2
+      character: 20
+    end_position:
+      bytes: 47
+      line: 2
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 2
+      character: 26
+    end_position:
+      bytes: 48
+      line: 2
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 2
+      character: 27
+    end_position:
+      bytes: 49
+      line: 2
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 49
+        line: 2
+        character: 28
+      end_position:
+        bytes: 50
+        line: 2
+        character: 29
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 50
+      line: 2
+      character: 29
+    end_position:
+      bytes: 51
+      line: 2
+      character: 30
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia:
+    - start_position:
+        bytes: 51
+        line: 2
+        character: 30
+      end_position:
+        bytes: 52
+        line: 2
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 52
+      line: 2
+      character: 31
+    end_position:
+      bytes: 53
+      line: 2
+      character: 32
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 2
+      character: 32
+    end_position:
+      bytes: 53
+      line: 2
+      character: 32
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/types/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types/tokens.snap
@@ -4,4304 +4,4979 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/types
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: Identity
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 21
-    line: 2
-    character: 1
-  end_position:
-    bytes: 25
-    line: 2
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 25
-    line: 2
-    character: 5
-  end_position:
-    bytes: 26
-    line: 2
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 26
-    line: 2
-    character: 6
-  end_position:
-    bytes: 31
-    line: 2
-    character: 11
-  token_type:
-    type: Identifier
-    identifier: Array
-- start_position:
-    bytes: 31
-    line: 2
-    character: 11
-  end_position:
-    bytes: 32
-    line: 2
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 32
-    line: 2
-    character: 12
-  end_position:
-    bytes: 33
-    line: 2
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 33
-    line: 2
-    character: 13
-  end_position:
-    bytes: 34
-    line: 2
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 34
-    line: 2
-    character: 14
-  end_position:
-    bytes: 35
-    line: 2
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 35
-    line: 2
-    character: 15
-  end_position:
-    bytes: 36
-    line: 2
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 36
-    line: 2
-    character: 16
-  end_position:
-    bytes: 37
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 37
-    line: 2
-    character: 17
-  end_position:
-    bytes: 38
-    line: 2
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 38
-    line: 2
-    character: 18
-  end_position:
-    bytes: 39
-    line: 2
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 39
-    line: 2
-    character: 19
-  end_position:
-    bytes: 40
-    line: 2
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "["
-- start_position:
-    bytes: 40
-    line: 2
-    character: 20
-  end_position:
-    bytes: 46
-    line: 2
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 46
-    line: 2
-    character: 26
-  end_position:
-    bytes: 47
-    line: 2
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: "]"
-- start_position:
-    bytes: 47
-    line: 2
-    character: 27
-  end_position:
-    bytes: 48
-    line: 2
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 48
-    line: 2
-    character: 28
-  end_position:
-    bytes: 49
-    line: 2
-    character: 29
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 49
-    line: 2
-    character: 29
-  end_position:
-    bytes: 55
-    line: 2
-    character: 35
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 55
-    line: 2
-    character: 35
-  end_position:
-    bytes: 56
-    line: 2
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 56
-    line: 2
-    character: 36
-  end_position:
-    bytes: 57
-    line: 2
-    character: 37
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 57
-    line: 2
-    character: 37
-  end_position:
-    bytes: 58
-    line: 2
-    character: 37
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 58
-    line: 3
-    character: 1
-  end_position:
-    bytes: 62
-    line: 3
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 62
-    line: 3
-    character: 5
-  end_position:
-    bytes: 63
-    line: 3
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 63
-    line: 3
-    character: 6
-  end_position:
-    bytes: 69
-    line: 3
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: Object
-- start_position:
-    bytes: 69
-    line: 3
-    character: 12
-  end_position:
-    bytes: 70
-    line: 3
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 70
-    line: 3
-    character: 13
-  end_position:
-    bytes: 71
-    line: 3
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 71
-    line: 3
-    character: 14
-  end_position:
-    bytes: 72
-    line: 3
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 72
-    line: 3
-    character: 15
-  end_position:
-    bytes: 73
-    line: 3
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 73
-    line: 3
-    character: 16
-  end_position:
-    bytes: 74
-    line: 3
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 74
-    line: 3
-    character: 17
-  end_position:
-    bytes: 75
-    line: 3
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 75
-    line: 3
-    character: 18
-  end_position:
-    bytes: 76
-    line: 3
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 76
-    line: 3
-    character: 19
-  end_position:
-    bytes: 77
-    line: 3
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 77
-    line: 3
-    character: 20
-  end_position:
-    bytes: 83
-    line: 3
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 83
-    line: 3
-    character: 26
-  end_position:
-    bytes: 84
-    line: 3
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 84
-    line: 3
-    character: 27
-  end_position:
-    bytes: 85
-    line: 3
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 85
-    line: 3
-    character: 28
-  end_position:
-    bytes: 86
-    line: 3
-    character: 29
-  token_type:
-    type: Identifier
-    identifier: y
-- start_position:
-    bytes: 86
-    line: 3
-    character: 29
-  end_position:
-    bytes: 87
-    line: 3
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 87
-    line: 3
-    character: 30
-  end_position:
-    bytes: 88
-    line: 3
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 88
-    line: 3
-    character: 31
-  end_position:
-    bytes: 94
-    line: 3
-    character: 37
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 94
-    line: 3
-    character: 37
-  end_position:
-    bytes: 95
-    line: 3
-    character: 38
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 95
-    line: 3
-    character: 38
-  end_position:
-    bytes: 96
-    line: 3
-    character: 39
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 96
-    line: 3
-    character: 39
-  end_position:
-    bytes: 97
-    line: 3
-    character: 39
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 97
-    line: 4
-    character: 1
-  end_position:
-    bytes: 101
-    line: 4
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 101
-    line: 4
-    character: 5
-  end_position:
-    bytes: 102
-    line: 4
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 102
-    line: 4
-    character: 6
-  end_position:
-    bytes: 108
-    line: 4
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: Typeof
-- start_position:
-    bytes: 108
-    line: 4
-    character: 12
-  end_position:
-    bytes: 109
-    line: 4
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 109
-    line: 4
-    character: 13
-  end_position:
-    bytes: 110
-    line: 4
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 110
-    line: 4
-    character: 14
-  end_position:
-    bytes: 111
-    line: 4
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 111
-    line: 4
-    character: 15
-  end_position:
-    bytes: 117
-    line: 4
-    character: 21
-  token_type:
-    type: Identifier
-    identifier: typeof
-- start_position:
-    bytes: 117
-    line: 4
-    character: 21
-  end_position:
-    bytes: 118
-    line: 4
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 118
-    line: 4
-    character: 22
-  end_position:
-    bytes: 119
-    line: 4
-    character: 23
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 119
-    line: 4
-    character: 23
-  end_position:
-    bytes: 120
-    line: 4
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 120
-    line: 4
-    character: 24
-  end_position:
-    bytes: 121
-    line: 4
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 121
-    line: 4
-    character: 25
-  end_position:
-    bytes: 122
-    line: 4
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 122
-    line: 4
-    character: 26
-  end_position:
-    bytes: 123
-    line: 4
-    character: 27
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 123
-    line: 4
-    character: 27
-  end_position:
-    bytes: 124
-    line: 4
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 124
-    line: 4
-    character: 28
-  end_position:
-    bytes: 125
-    line: 4
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: +
-- start_position:
-    bytes: 125
-    line: 4
-    character: 29
-  end_position:
-    bytes: 126
-    line: 4
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 126
-    line: 4
-    character: 30
-  end_position:
-    bytes: 129
-    line: 4
-    character: 33
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 129
-    line: 4
-    character: 33
-  end_position:
-    bytes: 130
-    line: 4
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 130
-    line: 4
-    character: 34
-  end_position:
-    bytes: 131
-    line: 4
-    character: 35
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 131
-    line: 4
-    character: 35
-  end_position:
-    bytes: 132
-    line: 4
-    character: 36
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 132
-    line: 4
-    character: 36
-  end_position:
-    bytes: 133
-    line: 4
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 133
-    line: 5
-    character: 1
-  end_position:
-    bytes: 134
-    line: 5
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 134
-    line: 6
-    character: 1
-  end_position:
-    bytes: 138
-    line: 6
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 138
-    line: 6
-    character: 5
-  end_position:
-    bytes: 139
-    line: 6
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 139
-    line: 6
-    character: 6
-  end_position:
-    bytes: 148
-    line: 6
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: Callback1
-- start_position:
-    bytes: 148
-    line: 6
-    character: 15
-  end_position:
-    bytes: 149
-    line: 6
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 149
-    line: 6
-    character: 16
-  end_position:
-    bytes: 150
-    line: 6
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 150
-    line: 6
-    character: 17
-  end_position:
-    bytes: 151
-    line: 6
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 151
-    line: 6
-    character: 18
-  end_position:
-    bytes: 152
-    line: 6
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 152
-    line: 6
-    character: 19
-  end_position:
-    bytes: 158
-    line: 6
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 158
-    line: 6
-    character: 25
-  end_position:
-    bytes: 159
-    line: 6
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 159
-    line: 6
-    character: 26
-  end_position:
-    bytes: 160
-    line: 6
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 160
-    line: 6
-    character: 27
-  end_position:
-    bytes: 162
-    line: 6
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "->"
-- start_position:
-    bytes: 162
-    line: 6
-    character: 29
-  end_position:
-    bytes: 163
-    line: 6
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 163
-    line: 6
-    character: 30
-  end_position:
-    bytes: 169
-    line: 6
-    character: 36
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 169
-    line: 6
-    character: 36
-  end_position:
-    bytes: 170
-    line: 6
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 170
-    line: 7
-    character: 1
-  end_position:
-    bytes: 174
-    line: 7
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 174
-    line: 7
-    character: 5
-  end_position:
-    bytes: 175
-    line: 7
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 175
-    line: 7
-    character: 6
-  end_position:
-    bytes: 184
-    line: 7
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: Callback2
-- start_position:
-    bytes: 184
-    line: 7
-    character: 15
-  end_position:
-    bytes: 185
-    line: 7
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 185
-    line: 7
-    character: 16
-  end_position:
-    bytes: 186
-    line: 7
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 186
-    line: 7
-    character: 17
-  end_position:
-    bytes: 187
-    line: 7
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 187
-    line: 7
-    character: 18
-  end_position:
-    bytes: 188
-    line: 7
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 188
-    line: 7
-    character: 19
-  end_position:
-    bytes: 194
-    line: 7
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 194
-    line: 7
-    character: 25
-  end_position:
-    bytes: 195
-    line: 7
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 195
-    line: 7
-    character: 26
-  end_position:
-    bytes: 196
-    line: 7
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 196
-    line: 7
-    character: 27
-  end_position:
-    bytes: 202
-    line: 7
-    character: 33
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 202
-    line: 7
-    character: 33
-  end_position:
-    bytes: 203
-    line: 7
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 203
-    line: 7
-    character: 34
-  end_position:
-    bytes: 204
-    line: 7
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 204
-    line: 7
-    character: 35
-  end_position:
-    bytes: 206
-    line: 7
-    character: 37
-  token_type:
-    type: Symbol
-    symbol: "->"
-- start_position:
-    bytes: 206
-    line: 7
-    character: 37
-  end_position:
-    bytes: 207
-    line: 7
-    character: 38
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 207
-    line: 7
-    character: 38
-  end_position:
-    bytes: 213
-    line: 7
-    character: 44
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 213
-    line: 7
-    character: 44
-  end_position:
-    bytes: 214
-    line: 7
-    character: 44
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 214
-    line: 8
-    character: 1
-  end_position:
-    bytes: 218
-    line: 8
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 218
-    line: 8
-    character: 5
-  end_position:
-    bytes: 219
-    line: 8
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 219
-    line: 8
-    character: 6
-  end_position:
-    bytes: 228
-    line: 8
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: Callback3
-- start_position:
-    bytes: 228
-    line: 8
-    character: 15
-  end_position:
-    bytes: 229
-    line: 8
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 229
-    line: 8
-    character: 16
-  end_position:
-    bytes: 230
-    line: 8
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 230
-    line: 8
-    character: 17
-  end_position:
-    bytes: 231
-    line: 8
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 231
-    line: 8
-    character: 18
-  end_position:
-    bytes: 232
-    line: 8
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 232
-    line: 8
-    character: 19
-  end_position:
-    bytes: 238
-    line: 8
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 238
-    line: 8
-    character: 25
-  end_position:
-    bytes: 239
-    line: 8
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 239
-    line: 8
-    character: 26
-  end_position:
-    bytes: 240
-    line: 8
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 240
-    line: 8
-    character: 27
-  end_position:
-    bytes: 246
-    line: 8
-    character: 33
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 246
-    line: 8
-    character: 33
-  end_position:
-    bytes: 247
-    line: 8
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 247
-    line: 8
-    character: 34
-  end_position:
-    bytes: 248
-    line: 8
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 248
-    line: 8
-    character: 35
-  end_position:
-    bytes: 250
-    line: 8
-    character: 37
-  token_type:
-    type: Symbol
-    symbol: "->"
-- start_position:
-    bytes: 250
-    line: 8
-    character: 37
-  end_position:
-    bytes: 251
-    line: 8
-    character: 38
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 251
-    line: 8
-    character: 38
-  end_position:
-    bytes: 252
-    line: 8
-    character: 39
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 252
-    line: 8
-    character: 39
-  end_position:
-    bytes: 258
-    line: 8
-    character: 45
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 258
-    line: 8
-    character: 45
-  end_position:
-    bytes: 259
-    line: 8
-    character: 46
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 259
-    line: 8
-    character: 46
-  end_position:
-    bytes: 260
-    line: 8
-    character: 47
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 260
-    line: 8
-    character: 47
-  end_position:
-    bytes: 266
-    line: 8
-    character: 53
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 266
-    line: 8
-    character: 53
-  end_position:
-    bytes: 267
-    line: 8
-    character: 54
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 267
-    line: 8
-    character: 54
-  end_position:
-    bytes: 268
-    line: 8
-    character: 54
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 268
-    line: 9
-    character: 1
-  end_position:
-    bytes: 272
-    line: 9
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 272
-    line: 9
-    character: 5
-  end_position:
-    bytes: 273
-    line: 9
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 273
-    line: 9
-    character: 6
-  end_position:
-    bytes: 282
-    line: 9
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: Callback4
-- start_position:
-    bytes: 282
-    line: 9
-    character: 15
-  end_position:
-    bytes: 283
-    line: 9
-    character: 16
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 283
-    line: 9
-    character: 16
-  end_position:
-    bytes: 284
-    line: 9
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 284
-    line: 9
-    character: 17
-  end_position:
-    bytes: 285
-    line: 9
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 285
-    line: 9
-    character: 18
-  end_position:
-    bytes: 286
-    line: 9
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 286
-    line: 9
-    character: 19
-  end_position:
-    bytes: 292
-    line: 9
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 292
-    line: 9
-    character: 25
-  end_position:
-    bytes: 293
-    line: 9
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 293
-    line: 9
-    character: 26
-  end_position:
-    bytes: 294
-    line: 9
-    character: 27
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 294
-    line: 9
-    character: 27
-  end_position:
-    bytes: 296
-    line: 9
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "->"
-- start_position:
-    bytes: 296
-    line: 9
-    character: 29
-  end_position:
-    bytes: 297
-    line: 9
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 297
-    line: 9
-    character: 30
-  end_position:
-    bytes: 298
-    line: 9
-    character: 31
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 298
-    line: 9
-    character: 31
-  end_position:
-    bytes: 304
-    line: 9
-    character: 37
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 304
-    line: 9
-    character: 37
-  end_position:
-    bytes: 305
-    line: 9
-    character: 38
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 305
-    line: 9
-    character: 38
-  end_position:
-    bytes: 306
-    line: 9
-    character: 39
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 306
-    line: 9
-    character: 39
-  end_position:
-    bytes: 308
-    line: 9
-    character: 41
-  token_type:
-    type: Symbol
-    symbol: "->"
-- start_position:
-    bytes: 308
-    line: 9
-    character: 41
-  end_position:
-    bytes: 309
-    line: 9
-    character: 42
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 309
-    line: 9
-    character: 42
-  end_position:
-    bytes: 310
-    line: 9
-    character: 43
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 310
-    line: 9
-    character: 43
-  end_position:
-    bytes: 311
-    line: 9
-    character: 44
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 311
-    line: 9
-    character: 44
-  end_position:
-    bytes: 312
-    line: 9
-    character: 44
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 312
-    line: 10
-    character: 1
-  end_position:
-    bytes: 313
-    line: 10
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 313
-    line: 11
-    character: 1
-  end_position:
-    bytes: 317
-    line: 11
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 317
-    line: 11
-    character: 5
-  end_position:
-    bytes: 318
-    line: 11
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 318
-    line: 11
-    character: 6
-  end_position:
-    bytes: 321
-    line: 11
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: Foo
-- start_position:
-    bytes: 321
-    line: 11
-    character: 9
-  end_position:
-    bytes: 322
-    line: 11
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 322
-    line: 11
-    character: 10
-  end_position:
-    bytes: 323
-    line: 11
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 323
-    line: 11
-    character: 11
-  end_position:
-    bytes: 324
-    line: 11
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 324
-    line: 11
-    character: 12
-  end_position:
-    bytes: 325
-    line: 11
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 325
-    line: 11
-    character: 13
-  end_position:
-    bytes: 326
-    line: 11
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 326
-    line: 12
-    character: 1
-  end_position:
-    bytes: 327
-    line: 12
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 327
-    line: 12
-    character: 2
-  end_position:
-    bytes: 330
-    line: 12
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 330
-    line: 12
-    character: 5
-  end_position:
-    bytes: 331
-    line: 12
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 331
-    line: 12
-    character: 6
-  end_position:
-    bytes: 332
-    line: 12
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 332
-    line: 12
-    character: 7
-  end_position:
-    bytes: 338
-    line: 12
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 338
-    line: 12
-    character: 13
-  end_position:
-    bytes: 339
-    line: 12
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 339
-    line: 12
-    character: 14
-  end_position:
-    bytes: 340
-    line: 12
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 340
-    line: 13
-    character: 1
-  end_position:
-    bytes: 341
-    line: 13
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 341
-    line: 13
-    character: 2
-  end_position:
-    bytes: 344
-    line: 13
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: baz
-- start_position:
-    bytes: 344
-    line: 13
-    character: 5
-  end_position:
-    bytes: 345
-    line: 13
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 345
-    line: 13
-    character: 6
-  end_position:
-    bytes: 346
-    line: 13
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 346
-    line: 13
-    character: 7
-  end_position:
-    bytes: 352
-    line: 13
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 352
-    line: 13
-    character: 13
-  end_position:
-    bytes: 353
-    line: 13
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 353
-    line: 13
-    character: 14
-  end_position:
-    bytes: 354
-    line: 13
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 354
-    line: 14
-    character: 1
-  end_position:
-    bytes: 355
-    line: 14
-    character: 2
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 355
-    line: 14
-    character: 2
-  end_position:
-    bytes: 356
-    line: 14
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 356
-    line: 15
-    character: 1
-  end_position:
-    bytes: 357
-    line: 15
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 357
-    line: 16
-    character: 1
-  end_position:
-    bytes: 362
-    line: 16
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 362
-    line: 16
-    character: 6
-  end_position:
-    bytes: 363
-    line: 16
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 363
-    line: 16
-    character: 7
-  end_position:
-    bytes: 366
-    line: 16
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 366
-    line: 16
-    character: 10
-  end_position:
-    bytes: 367
-    line: 16
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 367
-    line: 16
-    character: 11
-  end_position:
-    bytes: 368
-    line: 16
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 368
-    line: 16
-    character: 12
-  end_position:
-    bytes: 374
-    line: 16
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 374
-    line: 16
-    character: 18
-  end_position:
-    bytes: 375
-    line: 16
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 375
-    line: 16
-    character: 19
-  end_position:
-    bytes: 376
-    line: 16
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 376
-    line: 16
-    character: 20
-  end_position:
-    bytes: 377
-    line: 16
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 377
-    line: 16
-    character: 21
-  end_position:
-    bytes: 378
-    line: 16
-    character: 22
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 378
-    line: 16
-    character: 22
-  end_position:
-    bytes: 379
-    line: 16
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 379
-    line: 17
-    character: 1
-  end_position:
-    bytes: 384
-    line: 17
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 384
-    line: 17
-    character: 6
-  end_position:
-    bytes: 385
-    line: 17
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 385
-    line: 17
-    character: 7
-  end_position:
-    bytes: 388
-    line: 17
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 388
-    line: 17
-    character: 10
-  end_position:
-    bytes: 389
-    line: 17
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 389
-    line: 17
-    character: 11
-  end_position:
-    bytes: 390
-    line: 17
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 390
-    line: 17
-    character: 12
-  end_position:
-    bytes: 396
-    line: 17
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 396
-    line: 17
-    character: 18
-  end_position:
-    bytes: 397
-    line: 17
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "?"
-- start_position:
-    bytes: 397
-    line: 17
-    character: 19
-  end_position:
-    bytes: 398
-    line: 17
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 398
-    line: 18
-    character: 1
-  end_position:
-    bytes: 403
-    line: 18
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 403
-    line: 18
-    character: 6
-  end_position:
-    bytes: 404
-    line: 18
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 404
-    line: 18
-    character: 7
-  end_position:
-    bytes: 407
-    line: 18
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 407
-    line: 18
-    character: 10
-  end_position:
-    bytes: 408
-    line: 18
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 408
-    line: 18
-    character: 11
-  end_position:
-    bytes: 409
-    line: 18
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 409
-    line: 18
-    character: 12
-  end_position:
-    bytes: 414
-    line: 18
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: Array
-- start_position:
-    bytes: 414
-    line: 18
-    character: 17
-  end_position:
-    bytes: 415
-    line: 18
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 415
-    line: 18
-    character: 18
-  end_position:
-    bytes: 416
-    line: 18
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 416
-    line: 18
-    character: 19
-  end_position:
-    bytes: 417
-    line: 18
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 417
-    line: 18
-    character: 20
-  end_position:
-    bytes: 418
-    line: 18
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 418
-    line: 19
-    character: 1
-  end_position:
-    bytes: 423
-    line: 19
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 423
-    line: 19
-    character: 6
-  end_position:
-    bytes: 424
-    line: 19
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 424
-    line: 19
-    character: 7
-  end_position:
-    bytes: 427
-    line: 19
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 427
-    line: 19
-    character: 10
-  end_position:
-    bytes: 428
-    line: 19
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 428
-    line: 19
-    character: 11
-  end_position:
-    bytes: 429
-    line: 19
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 429
-    line: 19
-    character: 12
-  end_position:
-    bytes: 434
-    line: 19
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: Array
-- start_position:
-    bytes: 434
-    line: 19
-    character: 17
-  end_position:
-    bytes: 435
-    line: 19
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 435
-    line: 19
-    character: 18
-  end_position:
-    bytes: 436
-    line: 19
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: T
-- start_position:
-    bytes: 436
-    line: 19
-    character: 19
-  end_position:
-    bytes: 437
-    line: 19
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 437
-    line: 19
-    character: 20
-  end_position:
-    bytes: 438
-    line: 19
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 438
-    line: 19
-    character: 21
-  end_position:
-    bytes: 439
-    line: 19
-    character: 22
-  token_type:
-    type: Identifier
-    identifier: U
-- start_position:
-    bytes: 439
-    line: 19
-    character: 22
-  end_position:
-    bytes: 440
-    line: 19
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 440
-    line: 19
-    character: 23
-  end_position:
-    bytes: 441
-    line: 19
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 441
-    line: 20
-    character: 1
-  end_position:
-    bytes: 446
-    line: 20
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 446
-    line: 20
-    character: 6
-  end_position:
-    bytes: 447
-    line: 20
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 447
-    line: 20
-    character: 7
-  end_position:
-    bytes: 450
-    line: 20
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 450
-    line: 20
-    character: 10
-  end_position:
-    bytes: 451
-    line: 20
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 451
-    line: 20
-    character: 11
-  end_position:
-    bytes: 452
-    line: 20
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 452
-    line: 20
-    character: 12
-  end_position:
-    bytes: 453
-    line: 20
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 453
-    line: 20
-    character: 13
-  end_position:
-    bytes: 456
-    line: 20
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 456
-    line: 20
-    character: 16
-  end_position:
-    bytes: 457
-    line: 20
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 457
-    line: 20
-    character: 17
-  end_position:
-    bytes: 459
-    line: 20
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: "::"
-- start_position:
-    bytes: 459
-    line: 20
-    character: 19
-  end_position:
-    bytes: 460
-    line: 20
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 460
-    line: 20
-    character: 20
-  end_position:
-    bytes: 466
-    line: 20
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 466
-    line: 20
-    character: 26
-  end_position:
-    bytes: 467
-    line: 20
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 467
-    line: 21
-    character: 1
-  end_position:
-    bytes: 472
-    line: 21
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 472
-    line: 21
-    character: 6
-  end_position:
-    bytes: 473
-    line: 21
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 473
-    line: 21
-    character: 7
-  end_position:
-    bytes: 476
-    line: 21
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 476
-    line: 21
-    character: 10
-  end_position:
-    bytes: 477
-    line: 21
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 477
-    line: 21
-    character: 11
-  end_position:
-    bytes: 478
-    line: 21
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 478
-    line: 21
-    character: 12
-  end_position:
-    bytes: 484
-    line: 21
-    character: 18
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 484
-    line: 21
-    character: 18
-  end_position:
-    bytes: 485
-    line: 21
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 485
-    line: 21
-    character: 19
-  end_position:
-    bytes: 486
-    line: 21
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 486
-    line: 21
-    character: 20
-  end_position:
-    bytes: 489
-    line: 21
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 489
-    line: 21
-    character: 23
-  end_position:
-    bytes: 490
-    line: 21
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 490
-    line: 21
-    character: 24
-  end_position:
-    bytes: 491
-    line: 21
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 491
-    line: 21
-    character: 25
-  end_position:
-    bytes: 497
-    line: 21
-    character: 31
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 497
-    line: 21
-    character: 31
-  end_position:
-    bytes: 498
-    line: 21
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 498
-    line: 22
-    character: 1
-  end_position:
-    bytes: 499
-    line: 22
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 499
-    line: 23
-    character: 1
-  end_position:
-    bytes: 504
-    line: 23
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 504
-    line: 23
-    character: 6
-  end_position:
-    bytes: 505
-    line: 23
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 505
-    line: 23
-    character: 7
-  end_position:
-    bytes: 510
-    line: 23
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: union
-- start_position:
-    bytes: 510
-    line: 23
-    character: 12
-  end_position:
-    bytes: 511
-    line: 23
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 511
-    line: 23
-    character: 13
-  end_position:
-    bytes: 512
-    line: 23
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 512
-    line: 23
-    character: 14
-  end_position:
-    bytes: 518
-    line: 23
-    character: 20
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 518
-    line: 23
-    character: 20
-  end_position:
-    bytes: 519
-    line: 23
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 519
-    line: 23
-    character: 21
-  end_position:
-    bytes: 520
-    line: 23
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: "|"
-- start_position:
-    bytes: 520
-    line: 23
-    character: 22
-  end_position:
-    bytes: 521
-    line: 23
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 521
-    line: 23
-    character: 23
-  end_position:
-    bytes: 527
-    line: 23
-    character: 29
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 527
-    line: 23
-    character: 29
-  end_position:
-    bytes: 528
-    line: 23
-    character: 29
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 528
-    line: 24
-    character: 1
-  end_position:
-    bytes: 533
-    line: 24
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 533
-    line: 24
-    character: 6
-  end_position:
-    bytes: 534
-    line: 24
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 534
-    line: 24
-    character: 7
-  end_position:
-    bytes: 544
-    line: 24
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: multiUnion
-- start_position:
-    bytes: 544
-    line: 24
-    character: 17
-  end_position:
-    bytes: 545
-    line: 24
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 545
-    line: 24
-    character: 18
-  end_position:
-    bytes: 546
-    line: 24
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 546
-    line: 24
-    character: 19
-  end_position:
-    bytes: 552
-    line: 24
-    character: 25
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 552
-    line: 24
-    character: 25
-  end_position:
-    bytes: 553
-    line: 24
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 553
-    line: 24
-    character: 26
-  end_position:
-    bytes: 554
-    line: 24
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: "|"
-- start_position:
-    bytes: 554
-    line: 24
-    character: 27
-  end_position:
-    bytes: 555
-    line: 24
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 555
-    line: 24
-    character: 28
-  end_position:
-    bytes: 561
-    line: 24
-    character: 34
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 561
-    line: 24
-    character: 34
-  end_position:
-    bytes: 562
-    line: 24
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 562
-    line: 24
-    character: 35
-  end_position:
-    bytes: 563
-    line: 24
-    character: 36
-  token_type:
-    type: Symbol
-    symbol: "|"
-- start_position:
-    bytes: 563
-    line: 24
-    character: 36
-  end_position:
-    bytes: 564
-    line: 24
-    character: 37
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 564
-    line: 24
-    character: 37
-  end_position:
-    bytes: 567
-    line: 24
-    character: 40
-  token_type:
-    type: Symbol
-    symbol: nil
-- start_position:
-    bytes: 567
-    line: 24
-    character: 40
-  end_position:
-    bytes: 568
-    line: 24
-    character: 40
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 568
-    line: 25
-    character: 1
-  end_position:
-    bytes: 569
-    line: 25
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 569
-    line: 26
-    character: 1
-  end_position:
-    bytes: 574
-    line: 26
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 574
-    line: 26
-    character: 6
-  end_position:
-    bytes: 575
-    line: 26
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 575
-    line: 26
-    character: 7
-  end_position:
-    bytes: 587
-    line: 26
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: intersection
-- start_position:
-    bytes: 587
-    line: 26
-    character: 19
-  end_position:
-    bytes: 588
-    line: 26
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 588
-    line: 26
-    character: 20
-  end_position:
-    bytes: 589
-    line: 26
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 589
-    line: 26
-    character: 21
-  end_position:
-    bytes: 595
-    line: 26
-    character: 27
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 595
-    line: 26
-    character: 27
-  end_position:
-    bytes: 596
-    line: 26
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 596
-    line: 26
-    character: 28
-  end_position:
-    bytes: 597
-    line: 26
-    character: 29
-  token_type:
-    type: Symbol
-    symbol: "&"
-- start_position:
-    bytes: 597
-    line: 26
-    character: 29
-  end_position:
-    bytes: 598
-    line: 26
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 598
-    line: 26
-    character: 30
-  end_position:
-    bytes: 604
-    line: 26
-    character: 36
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 604
-    line: 26
-    character: 36
-  end_position:
-    bytes: 605
-    line: 26
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 605
-    line: 27
-    character: 1
-  end_position:
-    bytes: 610
-    line: 27
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 610
-    line: 27
-    character: 6
-  end_position:
-    bytes: 611
-    line: 27
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 611
-    line: 27
-    character: 7
-  end_position:
-    bytes: 628
-    line: 27
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: multiIntersection
-- start_position:
-    bytes: 628
-    line: 27
-    character: 24
-  end_position:
-    bytes: 629
-    line: 27
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 629
-    line: 27
-    character: 25
-  end_position:
-    bytes: 630
-    line: 27
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 630
-    line: 27
-    character: 26
-  end_position:
-    bytes: 636
-    line: 27
-    character: 32
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 636
-    line: 27
-    character: 32
-  end_position:
-    bytes: 637
-    line: 27
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 637
-    line: 27
-    character: 33
-  end_position:
-    bytes: 638
-    line: 27
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: "&"
-- start_position:
-    bytes: 638
-    line: 27
-    character: 34
-  end_position:
-    bytes: 639
-    line: 27
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 639
-    line: 27
-    character: 35
-  end_position:
-    bytes: 645
-    line: 27
-    character: 41
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 645
-    line: 27
-    character: 41
-  end_position:
-    bytes: 646
-    line: 27
-    character: 42
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 646
-    line: 27
-    character: 42
-  end_position:
-    bytes: 647
-    line: 27
-    character: 43
-  token_type:
-    type: Symbol
-    symbol: "&"
-- start_position:
-    bytes: 647
-    line: 27
-    character: 43
-  end_position:
-    bytes: 648
-    line: 27
-    character: 44
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 648
-    line: 27
-    character: 44
-  end_position:
-    bytes: 651
-    line: 27
-    character: 47
-  token_type:
-    type: Symbol
-    symbol: nil
-- start_position:
-    bytes: 651
-    line: 27
-    character: 47
-  end_position:
-    bytes: 652
-    line: 27
-    character: 47
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 652
-    line: 28
-    character: 1
-  end_position:
-    bytes: 653
-    line: 28
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 653
-    line: 29
-    character: 1
-  end_position:
-    bytes: 661
-    line: 29
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 661
-    line: 29
-    character: 9
-  end_position:
-    bytes: 662
-    line: 29
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 662
-    line: 29
-    character: 10
-  end_position:
-    bytes: 665
-    line: 29
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 665
-    line: 29
-    character: 13
-  end_position:
-    bytes: 666
-    line: 29
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 666
-    line: 29
-    character: 14
-  end_position:
-    bytes: 671
-    line: 29
-    character: 19
-  token_type:
-    type: Identifier
-    identifier: param
-- start_position:
-    bytes: 671
-    line: 29
-    character: 19
-  end_position:
-    bytes: 672
-    line: 29
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 672
-    line: 29
-    character: 20
-  end_position:
-    bytes: 673
-    line: 29
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 673
-    line: 29
-    character: 21
-  end_position:
-    bytes: 679
-    line: 29
-    character: 27
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 679
-    line: 29
-    character: 27
-  end_position:
-    bytes: 680
-    line: 29
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 680
-    line: 29
-    character: 28
-  end_position:
-    bytes: 681
-    line: 29
-    character: 29
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 681
-    line: 29
-    character: 29
-  end_position:
-    bytes: 682
-    line: 29
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 682
-    line: 29
-    character: 30
-  end_position:
-    bytes: 683
-    line: 29
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 683
-    line: 29
-    character: 31
-  end_position:
-    bytes: 689
-    line: 29
-    character: 37
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 689
-    line: 29
-    character: 37
-  end_position:
-    bytes: 690
-    line: 29
-    character: 37
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 690
-    line: 30
-    character: 1
-  end_position:
-    bytes: 691
-    line: 30
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 691
-    line: 30
-    character: 2
-  end_position:
-    bytes: 697
-    line: 30
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 697
-    line: 30
-    character: 8
-  end_position:
-    bytes: 698
-    line: 30
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 698
-    line: 30
-    character: 9
-  end_position:
-    bytes: 703
-    line: 30
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: param
-- start_position:
-    bytes: 703
-    line: 30
-    character: 14
-  end_position:
-    bytes: 704
-    line: 30
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 704
-    line: 31
-    character: 1
-  end_position:
-    bytes: 707
-    line: 31
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 707
-    line: 31
-    character: 4
-  end_position:
-    bytes: 708
-    line: 31
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 708
-    line: 32
-    character: 1
-  end_position:
-    bytes: 709
-    line: 32
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 709
-    line: 33
-    character: 1
-  end_position:
-    bytes: 717
-    line: 33
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 717
-    line: 33
-    character: 9
-  end_position:
-    bytes: 718
-    line: 33
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 718
-    line: 33
-    character: 10
-  end_position:
-    bytes: 721
-    line: 33
-    character: 13
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 721
-    line: 33
-    character: 13
-  end_position:
-    bytes: 722
-    line: 33
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 722
-    line: 33
-    character: 14
-  end_position:
-    bytes: 723
-    line: 33
-    character: 15
-  token_type:
-    type: Identifier
-    identifier: a
-- start_position:
-    bytes: 723
-    line: 33
-    character: 15
-  end_position:
-    bytes: 724
-    line: 33
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 724
-    line: 33
-    character: 16
-  end_position:
-    bytes: 725
-    line: 33
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 725
-    line: 33
-    character: 17
-  end_position:
-    bytes: 731
-    line: 33
-    character: 23
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 731
-    line: 33
-    character: 23
-  end_position:
-    bytes: 732
-    line: 33
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 732
-    line: 33
-    character: 24
-  end_position:
-    bytes: 733
-    line: 33
-    character: 25
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 733
-    line: 33
-    character: 25
-  end_position:
-    bytes: 734
-    line: 33
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: b
-- start_position:
-    bytes: 734
-    line: 33
-    character: 26
-  end_position:
-    bytes: 735
-    line: 33
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 735
-    line: 33
-    character: 27
-  end_position:
-    bytes: 736
-    line: 33
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 736
-    line: 33
-    character: 28
-  end_position:
-    bytes: 742
-    line: 33
-    character: 34
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 742
-    line: 33
-    character: 34
-  end_position:
-    bytes: 743
-    line: 33
-    character: 35
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 743
-    line: 33
-    character: 35
-  end_position:
-    bytes: 744
-    line: 33
-    character: 36
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 744
-    line: 33
-    character: 36
-  end_position:
-    bytes: 747
-    line: 33
-    character: 39
-  token_type:
-    type: Symbol
-    symbol: "..."
-- start_position:
-    bytes: 747
-    line: 33
-    character: 39
-  end_position:
-    bytes: 748
-    line: 33
-    character: 40
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 748
-    line: 33
-    character: 40
-  end_position:
-    bytes: 749
-    line: 33
-    character: 40
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 749
-    line: 34
-    character: 1
-  end_position:
-    bytes: 752
-    line: 34
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 752
-    line: 34
-    character: 4
-  end_position:
-    bytes: 753
-    line: 34
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 753
-    line: 35
-    character: 1
-  end_position:
-    bytes: 754
-    line: 35
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 754
-    line: 36
-    character: 1
-  end_position:
-    bytes: 759
-    line: 36
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 759
-    line: 36
-    character: 6
-  end_position:
-    bytes: 760
-    line: 36
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 760
-    line: 36
-    character: 7
-  end_position:
-    bytes: 763
-    line: 36
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 763
-    line: 36
-    character: 10
-  end_position:
-    bytes: 764
-    line: 36
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 764
-    line: 36
-    character: 11
-  end_position:
-    bytes: 765
-    line: 36
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 765
-    line: 36
-    character: 12
-  end_position:
-    bytes: 766
-    line: 36
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 766
-    line: 36
-    character: 13
-  end_position:
-    bytes: 774
-    line: 36
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 774
-    line: 36
-    character: 21
-  end_position:
-    bytes: 775
-    line: 36
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 775
-    line: 36
-    character: 22
-  end_position:
-    bytes: 776
-    line: 36
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 776
-    line: 36
-    character: 23
-  end_position:
-    bytes: 777
-    line: 36
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 777
-    line: 36
-    character: 24
-  end_position:
-    bytes: 778
-    line: 36
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 778
-    line: 36
-    character: 25
-  end_position:
-    bytes: 779
-    line: 36
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 779
-    line: 36
-    character: 26
-  end_position:
-    bytes: 785
-    line: 36
-    character: 32
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 785
-    line: 36
-    character: 32
-  end_position:
-    bytes: 786
-    line: 36
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 786
-    line: 36
-    character: 33
-  end_position:
-    bytes: 787
-    line: 36
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: "|"
-- start_position:
-    bytes: 787
-    line: 36
-    character: 34
-  end_position:
-    bytes: 788
-    line: 36
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 788
-    line: 36
-    character: 35
-  end_position:
-    bytes: 791
-    line: 36
-    character: 38
-  token_type:
-    type: Symbol
-    symbol: nil
-- start_position:
-    bytes: 791
-    line: 36
-    character: 38
-  end_position:
-    bytes: 792
-    line: 36
-    character: 38
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 792
-    line: 37
-    character: 1
-  end_position:
-    bytes: 793
-    line: 37
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 793
-    line: 37
-    character: 2
-  end_position:
-    bytes: 799
-    line: 37
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 799
-    line: 37
-    character: 8
-  end_position:
-    bytes: 800
-    line: 37
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 800
-    line: 37
-    character: 9
-  end_position:
-    bytes: 801
-    line: 37
-    character: 10
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 801
-    line: 37
-    character: 10
-  end_position:
-    bytes: 802
-    line: 37
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 802
-    line: 38
-    character: 1
-  end_position:
-    bytes: 805
-    line: 38
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 805
-    line: 38
-    character: 4
-  end_position:
-    bytes: 806
-    line: 38
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 806
-    line: 39
-    character: 1
-  end_position:
-    bytes: 807
-    line: 39
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 807
-    line: 40
-    character: 1
-  end_position:
-    bytes: 812
-    line: 40
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 812
-    line: 40
-    character: 6
-  end_position:
-    bytes: 813
-    line: 40
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 813
-    line: 40
-    character: 7
-  end_position:
-    bytes: 816
-    line: 40
-    character: 10
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 816
-    line: 40
-    character: 10
-  end_position:
-    bytes: 817
-    line: 40
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 817
-    line: 40
-    character: 11
-  end_position:
-    bytes: 818
-    line: 40
-    character: 12
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 818
-    line: 40
-    character: 12
-  end_position:
-    bytes: 819
-    line: 40
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 819
-    line: 40
-    character: 13
-  end_position:
-    bytes: 827
-    line: 40
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: function
-- start_position:
-    bytes: 827
-    line: 40
-    character: 21
-  end_position:
-    bytes: 828
-    line: 40
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 828
-    line: 40
-    character: 22
-  end_position:
-    bytes: 829
-    line: 40
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 829
-    line: 40
-    character: 23
-  end_position:
-    bytes: 830
-    line: 40
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 830
-    line: 40
-    character: 24
-  end_position:
-    bytes: 831
-    line: 40
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 831
-    line: 40
-    character: 25
-  end_position:
-    bytes: 832
-    line: 40
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 832
-    line: 40
-    character: 26
-  end_position:
-    bytes: 838
-    line: 40
-    character: 32
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 838
-    line: 40
-    character: 32
-  end_position:
-    bytes: 839
-    line: 40
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 839
-    line: 40
-    character: 33
-  end_position:
-    bytes: 840
-    line: 40
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: "&"
-- start_position:
-    bytes: 840
-    line: 40
-    character: 34
-  end_position:
-    bytes: 841
-    line: 40
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 841
-    line: 40
-    character: 35
-  end_position:
-    bytes: 844
-    line: 40
-    character: 38
-  token_type:
-    type: Symbol
-    symbol: nil
-- start_position:
-    bytes: 844
-    line: 40
-    character: 38
-  end_position:
-    bytes: 845
-    line: 40
-    character: 38
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 845
-    line: 41
-    character: 1
-  end_position:
-    bytes: 846
-    line: 41
-    character: 2
-  token_type:
-    type: Whitespace
-    characters: "\t"
-- start_position:
-    bytes: 846
-    line: 41
-    character: 2
-  end_position:
-    bytes: 852
-    line: 41
-    character: 8
-  token_type:
-    type: Symbol
-    symbol: return
-- start_position:
-    bytes: 852
-    line: 41
-    character: 8
-  end_position:
-    bytes: 853
-    line: 41
-    character: 9
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 853
-    line: 41
-    character: 9
-  end_position:
-    bytes: 854
-    line: 41
-    character: 10
-  token_type:
-    type: Number
-    text: "3"
-- start_position:
-    bytes: 854
-    line: 41
-    character: 10
-  end_position:
-    bytes: 855
-    line: 41
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 855
-    line: 42
-    character: 1
-  end_position:
-    bytes: 858
-    line: 42
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 858
-    line: 42
-    character: 4
-  end_position:
-    bytes: 858
-    line: 42
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 13
+      line: 1
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: Identity
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 14
+      line: 1
+      character: 15
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 14
+      line: 1
+      character: 15
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 18
+      line: 1
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 18
+        line: 1
+        character: 19
+      end_position:
+        bytes: 19
+        line: 1
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 20
+      line: 1
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia:
+    - start_position:
+        bytes: 20
+        line: 1
+        character: 21
+      end_position:
+        bytes: 21
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 21
+      line: 2
+      character: 1
+    end_position:
+      bytes: 25
+      line: 2
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 2
+        character: 5
+      end_position:
+        bytes: 26
+        line: 2
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 6
+    end_position:
+      bytes: 31
+      line: 2
+      character: 11
+    token_type:
+      type: Identifier
+      identifier: Array
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 2
+      character: 11
+    end_position:
+      bytes: 32
+      line: 2
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 2
+      character: 12
+    end_position:
+      bytes: 33
+      line: 2
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 2
+      character: 13
+    end_position:
+      bytes: 34
+      line: 2
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 2
+        character: 14
+      end_position:
+        bytes: 35
+        line: 2
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 2
+      character: 15
+    end_position:
+      bytes: 36
+      line: 2
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 36
+        line: 2
+        character: 16
+      end_position:
+        bytes: 37
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 37
+      line: 2
+      character: 17
+    end_position:
+      bytes: 38
+      line: 2
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 38
+        line: 2
+        character: 18
+      end_position:
+        bytes: 39
+        line: 2
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 39
+      line: 2
+      character: 19
+    end_position:
+      bytes: 40
+      line: 2
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "["
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 20
+    end_position:
+      bytes: 46
+      line: 2
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 46
+      line: 2
+      character: 26
+    end_position:
+      bytes: 47
+      line: 2
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: "]"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 2
+      character: 27
+    end_position:
+      bytes: 48
+      line: 2
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 48
+        line: 2
+        character: 28
+      end_position:
+        bytes: 49
+        line: 2
+        character: 29
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 49
+      line: 2
+      character: 29
+    end_position:
+      bytes: 55
+      line: 2
+      character: 35
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 55
+        line: 2
+        character: 35
+      end_position:
+        bytes: 56
+        line: 2
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 56
+      line: 2
+      character: 36
+    end_position:
+      bytes: 57
+      line: 2
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 57
+        line: 2
+        character: 37
+      end_position:
+        bytes: 58
+        line: 2
+        character: 37
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 3
+      character: 1
+    end_position:
+      bytes: 62
+      line: 3
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 62
+        line: 3
+        character: 5
+      end_position:
+        bytes: 63
+        line: 3
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 63
+      line: 3
+      character: 6
+    end_position:
+      bytes: 69
+      line: 3
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: Object
+  trailing_trivia:
+    - start_position:
+        bytes: 69
+        line: 3
+        character: 12
+      end_position:
+        bytes: 70
+        line: 3
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 70
+      line: 3
+      character: 13
+    end_position:
+      bytes: 71
+      line: 3
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 71
+        line: 3
+        character: 14
+      end_position:
+        bytes: 72
+        line: 3
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 72
+      line: 3
+      character: 15
+    end_position:
+      bytes: 73
+      line: 3
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 73
+        line: 3
+        character: 16
+      end_position:
+        bytes: 74
+        line: 3
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 3
+      character: 17
+    end_position:
+      bytes: 75
+      line: 3
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 3
+      character: 18
+    end_position:
+      bytes: 76
+      line: 3
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 76
+        line: 3
+        character: 19
+      end_position:
+        bytes: 77
+        line: 3
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 77
+      line: 3
+      character: 20
+    end_position:
+      bytes: 83
+      line: 3
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 83
+      line: 3
+      character: 26
+    end_position:
+      bytes: 84
+      line: 3
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 84
+        line: 3
+        character: 27
+      end_position:
+        bytes: 85
+        line: 3
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 85
+      line: 3
+      character: 28
+    end_position:
+      bytes: 86
+      line: 3
+      character: 29
+    token_type:
+      type: Identifier
+      identifier: y
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 86
+      line: 3
+      character: 29
+    end_position:
+      bytes: 87
+      line: 3
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 87
+        line: 3
+        character: 30
+      end_position:
+        bytes: 88
+        line: 3
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 88
+      line: 3
+      character: 31
+    end_position:
+      bytes: 94
+      line: 3
+      character: 37
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 94
+        line: 3
+        character: 37
+      end_position:
+        bytes: 95
+        line: 3
+        character: 38
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 95
+      line: 3
+      character: 38
+    end_position:
+      bytes: 96
+      line: 3
+      character: 39
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 96
+        line: 3
+        character: 39
+      end_position:
+        bytes: 97
+        line: 3
+        character: 39
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 97
+      line: 4
+      character: 1
+    end_position:
+      bytes: 101
+      line: 4
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 101
+        line: 4
+        character: 5
+      end_position:
+        bytes: 102
+        line: 4
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 102
+      line: 4
+      character: 6
+    end_position:
+      bytes: 108
+      line: 4
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: Typeof
+  trailing_trivia:
+    - start_position:
+        bytes: 108
+        line: 4
+        character: 12
+      end_position:
+        bytes: 109
+        line: 4
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 109
+      line: 4
+      character: 13
+    end_position:
+      bytes: 110
+      line: 4
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 110
+        line: 4
+        character: 14
+      end_position:
+        bytes: 111
+        line: 4
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 111
+      line: 4
+      character: 15
+    end_position:
+      bytes: 117
+      line: 4
+      character: 21
+    token_type:
+      type: Identifier
+      identifier: typeof
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 117
+      line: 4
+      character: 21
+    end_position:
+      bytes: 118
+      line: 4
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 118
+      line: 4
+      character: 22
+    end_position:
+      bytes: 119
+      line: 4
+      character: 23
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 119
+        line: 4
+        character: 23
+      end_position:
+        bytes: 120
+        line: 4
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 120
+      line: 4
+      character: 24
+    end_position:
+      bytes: 121
+      line: 4
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 121
+        line: 4
+        character: 25
+      end_position:
+        bytes: 122
+        line: 4
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 122
+      line: 4
+      character: 26
+    end_position:
+      bytes: 123
+      line: 4
+      character: 27
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 123
+        line: 4
+        character: 27
+      end_position:
+        bytes: 124
+        line: 4
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 124
+      line: 4
+      character: 28
+    end_position:
+      bytes: 125
+      line: 4
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: +
+  trailing_trivia:
+    - start_position:
+        bytes: 125
+        line: 4
+        character: 29
+      end_position:
+        bytes: 126
+        line: 4
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 126
+      line: 4
+      character: 30
+    end_position:
+      bytes: 129
+      line: 4
+      character: 33
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 129
+      line: 4
+      character: 33
+    end_position:
+      bytes: 130
+      line: 4
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 130
+      line: 4
+      character: 34
+    end_position:
+      bytes: 131
+      line: 4
+      character: 35
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 131
+      line: 4
+      character: 35
+    end_position:
+      bytes: 132
+      line: 4
+      character: 36
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 132
+        line: 4
+        character: 36
+      end_position:
+        bytes: 133
+        line: 4
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 133
+        line: 5
+        character: 1
+      end_position:
+        bytes: 134
+        line: 5
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 134
+      line: 6
+      character: 1
+    end_position:
+      bytes: 138
+      line: 6
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 138
+        line: 6
+        character: 5
+      end_position:
+        bytes: 139
+        line: 6
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 139
+      line: 6
+      character: 6
+    end_position:
+      bytes: 148
+      line: 6
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: Callback1
+  trailing_trivia:
+    - start_position:
+        bytes: 148
+        line: 6
+        character: 15
+      end_position:
+        bytes: 149
+        line: 6
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 149
+      line: 6
+      character: 16
+    end_position:
+      bytes: 150
+      line: 6
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 150
+        line: 6
+        character: 17
+      end_position:
+        bytes: 151
+        line: 6
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 151
+      line: 6
+      character: 18
+    end_position:
+      bytes: 152
+      line: 6
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 152
+      line: 6
+      character: 19
+    end_position:
+      bytes: 158
+      line: 6
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 158
+      line: 6
+      character: 25
+    end_position:
+      bytes: 159
+      line: 6
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 159
+        line: 6
+        character: 26
+      end_position:
+        bytes: 160
+        line: 6
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 160
+      line: 6
+      character: 27
+    end_position:
+      bytes: 162
+      line: 6
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "->"
+  trailing_trivia:
+    - start_position:
+        bytes: 162
+        line: 6
+        character: 29
+      end_position:
+        bytes: 163
+        line: 6
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 163
+      line: 6
+      character: 30
+    end_position:
+      bytes: 169
+      line: 6
+      character: 36
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 169
+        line: 6
+        character: 36
+      end_position:
+        bytes: 170
+        line: 6
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 170
+      line: 7
+      character: 1
+    end_position:
+      bytes: 174
+      line: 7
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 174
+        line: 7
+        character: 5
+      end_position:
+        bytes: 175
+        line: 7
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 175
+      line: 7
+      character: 6
+    end_position:
+      bytes: 184
+      line: 7
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: Callback2
+  trailing_trivia:
+    - start_position:
+        bytes: 184
+        line: 7
+        character: 15
+      end_position:
+        bytes: 185
+        line: 7
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 185
+      line: 7
+      character: 16
+    end_position:
+      bytes: 186
+      line: 7
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 186
+        line: 7
+        character: 17
+      end_position:
+        bytes: 187
+        line: 7
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 187
+      line: 7
+      character: 18
+    end_position:
+      bytes: 188
+      line: 7
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 188
+      line: 7
+      character: 19
+    end_position:
+      bytes: 194
+      line: 7
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 194
+      line: 7
+      character: 25
+    end_position:
+      bytes: 195
+      line: 7
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 195
+        line: 7
+        character: 26
+      end_position:
+        bytes: 196
+        line: 7
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 196
+      line: 7
+      character: 27
+    end_position:
+      bytes: 202
+      line: 7
+      character: 33
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 202
+      line: 7
+      character: 33
+    end_position:
+      bytes: 203
+      line: 7
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 203
+        line: 7
+        character: 34
+      end_position:
+        bytes: 204
+        line: 7
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 204
+      line: 7
+      character: 35
+    end_position:
+      bytes: 206
+      line: 7
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: "->"
+  trailing_trivia:
+    - start_position:
+        bytes: 206
+        line: 7
+        character: 37
+      end_position:
+        bytes: 207
+        line: 7
+        character: 38
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 207
+      line: 7
+      character: 38
+    end_position:
+      bytes: 213
+      line: 7
+      character: 44
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 213
+        line: 7
+        character: 44
+      end_position:
+        bytes: 214
+        line: 7
+        character: 44
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 214
+      line: 8
+      character: 1
+    end_position:
+      bytes: 218
+      line: 8
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 218
+        line: 8
+        character: 5
+      end_position:
+        bytes: 219
+        line: 8
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 219
+      line: 8
+      character: 6
+    end_position:
+      bytes: 228
+      line: 8
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: Callback3
+  trailing_trivia:
+    - start_position:
+        bytes: 228
+        line: 8
+        character: 15
+      end_position:
+        bytes: 229
+        line: 8
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 229
+      line: 8
+      character: 16
+    end_position:
+      bytes: 230
+      line: 8
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 230
+        line: 8
+        character: 17
+      end_position:
+        bytes: 231
+        line: 8
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 231
+      line: 8
+      character: 18
+    end_position:
+      bytes: 232
+      line: 8
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 232
+      line: 8
+      character: 19
+    end_position:
+      bytes: 238
+      line: 8
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 238
+      line: 8
+      character: 25
+    end_position:
+      bytes: 239
+      line: 8
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 239
+        line: 8
+        character: 26
+      end_position:
+        bytes: 240
+        line: 8
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 240
+      line: 8
+      character: 27
+    end_position:
+      bytes: 246
+      line: 8
+      character: 33
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 246
+      line: 8
+      character: 33
+    end_position:
+      bytes: 247
+      line: 8
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 247
+        line: 8
+        character: 34
+      end_position:
+        bytes: 248
+        line: 8
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 248
+      line: 8
+      character: 35
+    end_position:
+      bytes: 250
+      line: 8
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: "->"
+  trailing_trivia:
+    - start_position:
+        bytes: 250
+        line: 8
+        character: 37
+      end_position:
+        bytes: 251
+        line: 8
+        character: 38
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 251
+      line: 8
+      character: 38
+    end_position:
+      bytes: 252
+      line: 8
+      character: 39
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 252
+      line: 8
+      character: 39
+    end_position:
+      bytes: 258
+      line: 8
+      character: 45
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 258
+      line: 8
+      character: 45
+    end_position:
+      bytes: 259
+      line: 8
+      character: 46
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 259
+        line: 8
+        character: 46
+      end_position:
+        bytes: 260
+        line: 8
+        character: 47
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 260
+      line: 8
+      character: 47
+    end_position:
+      bytes: 266
+      line: 8
+      character: 53
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 266
+      line: 8
+      character: 53
+    end_position:
+      bytes: 267
+      line: 8
+      character: 54
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 267
+        line: 8
+        character: 54
+      end_position:
+        bytes: 268
+        line: 8
+        character: 54
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 268
+      line: 9
+      character: 1
+    end_position:
+      bytes: 272
+      line: 9
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 272
+        line: 9
+        character: 5
+      end_position:
+        bytes: 273
+        line: 9
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 273
+      line: 9
+      character: 6
+    end_position:
+      bytes: 282
+      line: 9
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: Callback4
+  trailing_trivia:
+    - start_position:
+        bytes: 282
+        line: 9
+        character: 15
+      end_position:
+        bytes: 283
+        line: 9
+        character: 16
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 283
+      line: 9
+      character: 16
+    end_position:
+      bytes: 284
+      line: 9
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 284
+        line: 9
+        character: 17
+      end_position:
+        bytes: 285
+        line: 9
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 285
+      line: 9
+      character: 18
+    end_position:
+      bytes: 286
+      line: 9
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 286
+      line: 9
+      character: 19
+    end_position:
+      bytes: 292
+      line: 9
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 292
+      line: 9
+      character: 25
+    end_position:
+      bytes: 293
+      line: 9
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 293
+        line: 9
+        character: 26
+      end_position:
+        bytes: 294
+        line: 9
+        character: 27
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 294
+      line: 9
+      character: 27
+    end_position:
+      bytes: 296
+      line: 9
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "->"
+  trailing_trivia:
+    - start_position:
+        bytes: 296
+        line: 9
+        character: 29
+      end_position:
+        bytes: 297
+        line: 9
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 297
+      line: 9
+      character: 30
+    end_position:
+      bytes: 298
+      line: 9
+      character: 31
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 298
+      line: 9
+      character: 31
+    end_position:
+      bytes: 304
+      line: 9
+      character: 37
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 304
+      line: 9
+      character: 37
+    end_position:
+      bytes: 305
+      line: 9
+      character: 38
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 305
+        line: 9
+        character: 38
+      end_position:
+        bytes: 306
+        line: 9
+        character: 39
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 306
+      line: 9
+      character: 39
+    end_position:
+      bytes: 308
+      line: 9
+      character: 41
+    token_type:
+      type: Symbol
+      symbol: "->"
+  trailing_trivia:
+    - start_position:
+        bytes: 308
+        line: 9
+        character: 41
+      end_position:
+        bytes: 309
+        line: 9
+        character: 42
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 309
+      line: 9
+      character: 42
+    end_position:
+      bytes: 310
+      line: 9
+      character: 43
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 310
+      line: 9
+      character: 43
+    end_position:
+      bytes: 311
+      line: 9
+      character: 44
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 311
+        line: 9
+        character: 44
+      end_position:
+        bytes: 312
+        line: 9
+        character: 44
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 312
+        line: 10
+        character: 1
+      end_position:
+        bytes: 313
+        line: 10
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 313
+      line: 11
+      character: 1
+    end_position:
+      bytes: 317
+      line: 11
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 317
+        line: 11
+        character: 5
+      end_position:
+        bytes: 318
+        line: 11
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 318
+      line: 11
+      character: 6
+    end_position:
+      bytes: 321
+      line: 11
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: Foo
+  trailing_trivia:
+    - start_position:
+        bytes: 321
+        line: 11
+        character: 9
+      end_position:
+        bytes: 322
+        line: 11
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 322
+      line: 11
+      character: 10
+    end_position:
+      bytes: 323
+      line: 11
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 323
+        line: 11
+        character: 11
+      end_position:
+        bytes: 324
+        line: 11
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 324
+      line: 11
+      character: 12
+    end_position:
+      bytes: 325
+      line: 11
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 325
+        line: 11
+        character: 13
+      end_position:
+        bytes: 326
+        line: 11
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 326
+        line: 12
+        character: 1
+      end_position:
+        bytes: 327
+        line: 12
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 327
+      line: 12
+      character: 2
+    end_position:
+      bytes: 330
+      line: 12
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 330
+      line: 12
+      character: 5
+    end_position:
+      bytes: 331
+      line: 12
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 331
+        line: 12
+        character: 6
+      end_position:
+        bytes: 332
+        line: 12
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 332
+      line: 12
+      character: 7
+    end_position:
+      bytes: 338
+      line: 12
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 338
+      line: 12
+      character: 13
+    end_position:
+      bytes: 339
+      line: 12
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 339
+        line: 12
+        character: 14
+      end_position:
+        bytes: 340
+        line: 12
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 340
+        line: 13
+        character: 1
+      end_position:
+        bytes: 341
+        line: 13
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 341
+      line: 13
+      character: 2
+    end_position:
+      bytes: 344
+      line: 13
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: baz
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 344
+      line: 13
+      character: 5
+    end_position:
+      bytes: 345
+      line: 13
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 345
+        line: 13
+        character: 6
+      end_position:
+        bytes: 346
+        line: 13
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 346
+      line: 13
+      character: 7
+    end_position:
+      bytes: 352
+      line: 13
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 352
+      line: 13
+      character: 13
+    end_position:
+      bytes: 353
+      line: 13
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 353
+        line: 13
+        character: 14
+      end_position:
+        bytes: 354
+        line: 13
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 354
+      line: 14
+      character: 1
+    end_position:
+      bytes: 355
+      line: 14
+      character: 2
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 355
+        line: 14
+        character: 2
+      end_position:
+        bytes: 356
+        line: 14
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 356
+        line: 15
+        character: 1
+      end_position:
+        bytes: 357
+        line: 15
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 357
+      line: 16
+      character: 1
+    end_position:
+      bytes: 362
+      line: 16
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 362
+        line: 16
+        character: 6
+      end_position:
+        bytes: 363
+        line: 16
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 363
+      line: 16
+      character: 7
+    end_position:
+      bytes: 366
+      line: 16
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 366
+      line: 16
+      character: 10
+    end_position:
+      bytes: 367
+      line: 16
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 367
+        line: 16
+        character: 11
+      end_position:
+        bytes: 368
+        line: 16
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 368
+      line: 16
+      character: 12
+    end_position:
+      bytes: 374
+      line: 16
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 374
+        line: 16
+        character: 18
+      end_position:
+        bytes: 375
+        line: 16
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 375
+      line: 16
+      character: 19
+    end_position:
+      bytes: 376
+      line: 16
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 376
+        line: 16
+        character: 20
+      end_position:
+        bytes: 377
+        line: 16
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 377
+      line: 16
+      character: 21
+    end_position:
+      bytes: 378
+      line: 16
+      character: 22
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia:
+    - start_position:
+        bytes: 378
+        line: 16
+        character: 22
+      end_position:
+        bytes: 379
+        line: 16
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 379
+      line: 17
+      character: 1
+    end_position:
+      bytes: 384
+      line: 17
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 384
+        line: 17
+        character: 6
+      end_position:
+        bytes: 385
+        line: 17
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 385
+      line: 17
+      character: 7
+    end_position:
+      bytes: 388
+      line: 17
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 388
+      line: 17
+      character: 10
+    end_position:
+      bytes: 389
+      line: 17
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 389
+        line: 17
+        character: 11
+      end_position:
+        bytes: 390
+        line: 17
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 390
+      line: 17
+      character: 12
+    end_position:
+      bytes: 396
+      line: 17
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 396
+      line: 17
+      character: 18
+    end_position:
+      bytes: 397
+      line: 17
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "?"
+  trailing_trivia:
+    - start_position:
+        bytes: 397
+        line: 17
+        character: 19
+      end_position:
+        bytes: 398
+        line: 17
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 398
+      line: 18
+      character: 1
+    end_position:
+      bytes: 403
+      line: 18
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 403
+        line: 18
+        character: 6
+      end_position:
+        bytes: 404
+        line: 18
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 404
+      line: 18
+      character: 7
+    end_position:
+      bytes: 407
+      line: 18
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 407
+      line: 18
+      character: 10
+    end_position:
+      bytes: 408
+      line: 18
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 408
+        line: 18
+        character: 11
+      end_position:
+        bytes: 409
+        line: 18
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 409
+      line: 18
+      character: 12
+    end_position:
+      bytes: 414
+      line: 18
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: Array
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 414
+      line: 18
+      character: 17
+    end_position:
+      bytes: 415
+      line: 18
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 415
+      line: 18
+      character: 18
+    end_position:
+      bytes: 416
+      line: 18
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 416
+      line: 18
+      character: 19
+    end_position:
+      bytes: 417
+      line: 18
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 417
+        line: 18
+        character: 20
+      end_position:
+        bytes: 418
+        line: 18
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 418
+      line: 19
+      character: 1
+    end_position:
+      bytes: 423
+      line: 19
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 423
+        line: 19
+        character: 6
+      end_position:
+        bytes: 424
+        line: 19
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 424
+      line: 19
+      character: 7
+    end_position:
+      bytes: 427
+      line: 19
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 427
+      line: 19
+      character: 10
+    end_position:
+      bytes: 428
+      line: 19
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 428
+        line: 19
+        character: 11
+      end_position:
+        bytes: 429
+        line: 19
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 429
+      line: 19
+      character: 12
+    end_position:
+      bytes: 434
+      line: 19
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: Array
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 434
+      line: 19
+      character: 17
+    end_position:
+      bytes: 435
+      line: 19
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 435
+      line: 19
+      character: 18
+    end_position:
+      bytes: 436
+      line: 19
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: T
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 436
+      line: 19
+      character: 19
+    end_position:
+      bytes: 437
+      line: 19
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 437
+        line: 19
+        character: 20
+      end_position:
+        bytes: 438
+        line: 19
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 438
+      line: 19
+      character: 21
+    end_position:
+      bytes: 439
+      line: 19
+      character: 22
+    token_type:
+      type: Identifier
+      identifier: U
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 439
+      line: 19
+      character: 22
+    end_position:
+      bytes: 440
+      line: 19
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 440
+        line: 19
+        character: 23
+      end_position:
+        bytes: 441
+        line: 19
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 441
+      line: 20
+      character: 1
+    end_position:
+      bytes: 446
+      line: 20
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 446
+        line: 20
+        character: 6
+      end_position:
+        bytes: 447
+        line: 20
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 447
+      line: 20
+      character: 7
+    end_position:
+      bytes: 450
+      line: 20
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia:
+    - start_position:
+        bytes: 450
+        line: 20
+        character: 10
+      end_position:
+        bytes: 451
+        line: 20
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 451
+      line: 20
+      character: 11
+    end_position:
+      bytes: 452
+      line: 20
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 452
+        line: 20
+        character: 12
+      end_position:
+        bytes: 453
+        line: 20
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 453
+      line: 20
+      character: 13
+    end_position:
+      bytes: 456
+      line: 20
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 456
+        line: 20
+        character: 16
+      end_position:
+        bytes: 457
+        line: 20
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 457
+      line: 20
+      character: 17
+    end_position:
+      bytes: 459
+      line: 20
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: "::"
+  trailing_trivia:
+    - start_position:
+        bytes: 459
+        line: 20
+        character: 19
+      end_position:
+        bytes: 460
+        line: 20
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 460
+      line: 20
+      character: 20
+    end_position:
+      bytes: 466
+      line: 20
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 466
+        line: 20
+        character: 26
+      end_position:
+        bytes: 467
+        line: 20
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 467
+      line: 21
+      character: 1
+    end_position:
+      bytes: 472
+      line: 21
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 472
+        line: 21
+        character: 6
+      end_position:
+        bytes: 473
+        line: 21
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 473
+      line: 21
+      character: 7
+    end_position:
+      bytes: 476
+      line: 21
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 476
+      line: 21
+      character: 10
+    end_position:
+      bytes: 477
+      line: 21
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 477
+        line: 21
+        character: 11
+      end_position:
+        bytes: 478
+        line: 21
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 478
+      line: 21
+      character: 12
+    end_position:
+      bytes: 484
+      line: 21
+      character: 18
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 484
+      line: 21
+      character: 18
+    end_position:
+      bytes: 485
+      line: 21
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 485
+        line: 21
+        character: 19
+      end_position:
+        bytes: 486
+        line: 21
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 486
+      line: 21
+      character: 20
+    end_position:
+      bytes: 489
+      line: 21
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 489
+      line: 21
+      character: 23
+    end_position:
+      bytes: 490
+      line: 21
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 490
+        line: 21
+        character: 24
+      end_position:
+        bytes: 491
+        line: 21
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 491
+      line: 21
+      character: 25
+    end_position:
+      bytes: 497
+      line: 21
+      character: 31
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 497
+        line: 21
+        character: 31
+      end_position:
+        bytes: 498
+        line: 21
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 498
+        line: 22
+        character: 1
+      end_position:
+        bytes: 499
+        line: 22
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 499
+      line: 23
+      character: 1
+    end_position:
+      bytes: 504
+      line: 23
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 504
+        line: 23
+        character: 6
+      end_position:
+        bytes: 505
+        line: 23
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 505
+      line: 23
+      character: 7
+    end_position:
+      bytes: 510
+      line: 23
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: union
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 510
+      line: 23
+      character: 12
+    end_position:
+      bytes: 511
+      line: 23
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 511
+        line: 23
+        character: 13
+      end_position:
+        bytes: 512
+        line: 23
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 512
+      line: 23
+      character: 14
+    end_position:
+      bytes: 518
+      line: 23
+      character: 20
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 518
+        line: 23
+        character: 20
+      end_position:
+        bytes: 519
+        line: 23
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 519
+      line: 23
+      character: 21
+    end_position:
+      bytes: 520
+      line: 23
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: "|"
+  trailing_trivia:
+    - start_position:
+        bytes: 520
+        line: 23
+        character: 22
+      end_position:
+        bytes: 521
+        line: 23
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 521
+      line: 23
+      character: 23
+    end_position:
+      bytes: 527
+      line: 23
+      character: 29
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 527
+        line: 23
+        character: 29
+      end_position:
+        bytes: 528
+        line: 23
+        character: 29
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 528
+      line: 24
+      character: 1
+    end_position:
+      bytes: 533
+      line: 24
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 533
+        line: 24
+        character: 6
+      end_position:
+        bytes: 534
+        line: 24
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 534
+      line: 24
+      character: 7
+    end_position:
+      bytes: 544
+      line: 24
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: multiUnion
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 544
+      line: 24
+      character: 17
+    end_position:
+      bytes: 545
+      line: 24
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 545
+        line: 24
+        character: 18
+      end_position:
+        bytes: 546
+        line: 24
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 546
+      line: 24
+      character: 19
+    end_position:
+      bytes: 552
+      line: 24
+      character: 25
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 552
+        line: 24
+        character: 25
+      end_position:
+        bytes: 553
+        line: 24
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 553
+      line: 24
+      character: 26
+    end_position:
+      bytes: 554
+      line: 24
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: "|"
+  trailing_trivia:
+    - start_position:
+        bytes: 554
+        line: 24
+        character: 27
+      end_position:
+        bytes: 555
+        line: 24
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 555
+      line: 24
+      character: 28
+    end_position:
+      bytes: 561
+      line: 24
+      character: 34
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 561
+        line: 24
+        character: 34
+      end_position:
+        bytes: 562
+        line: 24
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 562
+      line: 24
+      character: 35
+    end_position:
+      bytes: 563
+      line: 24
+      character: 36
+    token_type:
+      type: Symbol
+      symbol: "|"
+  trailing_trivia:
+    - start_position:
+        bytes: 563
+        line: 24
+        character: 36
+      end_position:
+        bytes: 564
+        line: 24
+        character: 37
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 564
+      line: 24
+      character: 37
+    end_position:
+      bytes: 567
+      line: 24
+      character: 40
+    token_type:
+      type: Symbol
+      symbol: nil
+  trailing_trivia:
+    - start_position:
+        bytes: 567
+        line: 24
+        character: 40
+      end_position:
+        bytes: 568
+        line: 24
+        character: 40
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 568
+        line: 25
+        character: 1
+      end_position:
+        bytes: 569
+        line: 25
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 569
+      line: 26
+      character: 1
+    end_position:
+      bytes: 574
+      line: 26
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 574
+        line: 26
+        character: 6
+      end_position:
+        bytes: 575
+        line: 26
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 575
+      line: 26
+      character: 7
+    end_position:
+      bytes: 587
+      line: 26
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: intersection
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 587
+      line: 26
+      character: 19
+    end_position:
+      bytes: 588
+      line: 26
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 588
+        line: 26
+        character: 20
+      end_position:
+        bytes: 589
+        line: 26
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 589
+      line: 26
+      character: 21
+    end_position:
+      bytes: 595
+      line: 26
+      character: 27
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 595
+        line: 26
+        character: 27
+      end_position:
+        bytes: 596
+        line: 26
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 596
+      line: 26
+      character: 28
+    end_position:
+      bytes: 597
+      line: 26
+      character: 29
+    token_type:
+      type: Symbol
+      symbol: "&"
+  trailing_trivia:
+    - start_position:
+        bytes: 597
+        line: 26
+        character: 29
+      end_position:
+        bytes: 598
+        line: 26
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 598
+      line: 26
+      character: 30
+    end_position:
+      bytes: 604
+      line: 26
+      character: 36
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 604
+        line: 26
+        character: 36
+      end_position:
+        bytes: 605
+        line: 26
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 605
+      line: 27
+      character: 1
+    end_position:
+      bytes: 610
+      line: 27
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 610
+        line: 27
+        character: 6
+      end_position:
+        bytes: 611
+        line: 27
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 611
+      line: 27
+      character: 7
+    end_position:
+      bytes: 628
+      line: 27
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: multiIntersection
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 628
+      line: 27
+      character: 24
+    end_position:
+      bytes: 629
+      line: 27
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 629
+        line: 27
+        character: 25
+      end_position:
+        bytes: 630
+        line: 27
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 630
+      line: 27
+      character: 26
+    end_position:
+      bytes: 636
+      line: 27
+      character: 32
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 636
+        line: 27
+        character: 32
+      end_position:
+        bytes: 637
+        line: 27
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 637
+      line: 27
+      character: 33
+    end_position:
+      bytes: 638
+      line: 27
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: "&"
+  trailing_trivia:
+    - start_position:
+        bytes: 638
+        line: 27
+        character: 34
+      end_position:
+        bytes: 639
+        line: 27
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 639
+      line: 27
+      character: 35
+    end_position:
+      bytes: 645
+      line: 27
+      character: 41
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 645
+        line: 27
+        character: 41
+      end_position:
+        bytes: 646
+        line: 27
+        character: 42
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 646
+      line: 27
+      character: 42
+    end_position:
+      bytes: 647
+      line: 27
+      character: 43
+    token_type:
+      type: Symbol
+      symbol: "&"
+  trailing_trivia:
+    - start_position:
+        bytes: 647
+        line: 27
+        character: 43
+      end_position:
+        bytes: 648
+        line: 27
+        character: 44
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 648
+      line: 27
+      character: 44
+    end_position:
+      bytes: 651
+      line: 27
+      character: 47
+    token_type:
+      type: Symbol
+      symbol: nil
+  trailing_trivia:
+    - start_position:
+        bytes: 651
+        line: 27
+        character: 47
+      end_position:
+        bytes: 652
+        line: 27
+        character: 47
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 652
+        line: 28
+        character: 1
+      end_position:
+        bytes: 653
+        line: 28
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 653
+      line: 29
+      character: 1
+    end_position:
+      bytes: 661
+      line: 29
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 661
+        line: 29
+        character: 9
+      end_position:
+        bytes: 662
+        line: 29
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 662
+      line: 29
+      character: 10
+    end_position:
+      bytes: 665
+      line: 29
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 665
+      line: 29
+      character: 13
+    end_position:
+      bytes: 666
+      line: 29
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 666
+      line: 29
+      character: 14
+    end_position:
+      bytes: 671
+      line: 29
+      character: 19
+    token_type:
+      type: Identifier
+      identifier: param
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 671
+      line: 29
+      character: 19
+    end_position:
+      bytes: 672
+      line: 29
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 672
+        line: 29
+        character: 20
+      end_position:
+        bytes: 673
+        line: 29
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 673
+      line: 29
+      character: 21
+    end_position:
+      bytes: 679
+      line: 29
+      character: 27
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 679
+      line: 29
+      character: 27
+    end_position:
+      bytes: 680
+      line: 29
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 680
+        line: 29
+        character: 28
+      end_position:
+        bytes: 681
+        line: 29
+        character: 29
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 681
+      line: 29
+      character: 29
+    end_position:
+      bytes: 682
+      line: 29
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 682
+        line: 29
+        character: 30
+      end_position:
+        bytes: 683
+        line: 29
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 683
+      line: 29
+      character: 31
+    end_position:
+      bytes: 689
+      line: 29
+      character: 37
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 689
+        line: 29
+        character: 37
+      end_position:
+        bytes: 690
+        line: 29
+        character: 37
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 690
+        line: 30
+        character: 1
+      end_position:
+        bytes: 691
+        line: 30
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 691
+      line: 30
+      character: 2
+    end_position:
+      bytes: 697
+      line: 30
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 697
+        line: 30
+        character: 8
+      end_position:
+        bytes: 698
+        line: 30
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 698
+      line: 30
+      character: 9
+    end_position:
+      bytes: 703
+      line: 30
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: param
+  trailing_trivia:
+    - start_position:
+        bytes: 703
+        line: 30
+        character: 14
+      end_position:
+        bytes: 704
+        line: 30
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 704
+      line: 31
+      character: 1
+    end_position:
+      bytes: 707
+      line: 31
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 707
+        line: 31
+        character: 4
+      end_position:
+        bytes: 708
+        line: 31
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 708
+        line: 32
+        character: 1
+      end_position:
+        bytes: 709
+        line: 32
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 709
+      line: 33
+      character: 1
+    end_position:
+      bytes: 717
+      line: 33
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia:
+    - start_position:
+        bytes: 717
+        line: 33
+        character: 9
+      end_position:
+        bytes: 718
+        line: 33
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 718
+      line: 33
+      character: 10
+    end_position:
+      bytes: 721
+      line: 33
+      character: 13
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 721
+      line: 33
+      character: 13
+    end_position:
+      bytes: 722
+      line: 33
+      character: 14
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 722
+      line: 33
+      character: 14
+    end_position:
+      bytes: 723
+      line: 33
+      character: 15
+    token_type:
+      type: Identifier
+      identifier: a
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 723
+      line: 33
+      character: 15
+    end_position:
+      bytes: 724
+      line: 33
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 724
+        line: 33
+        character: 16
+      end_position:
+        bytes: 725
+        line: 33
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 725
+      line: 33
+      character: 17
+    end_position:
+      bytes: 731
+      line: 33
+      character: 23
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 731
+      line: 33
+      character: 23
+    end_position:
+      bytes: 732
+      line: 33
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 732
+        line: 33
+        character: 24
+      end_position:
+        bytes: 733
+        line: 33
+        character: 25
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 733
+      line: 33
+      character: 25
+    end_position:
+      bytes: 734
+      line: 33
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: b
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 734
+      line: 33
+      character: 26
+    end_position:
+      bytes: 735
+      line: 33
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 735
+        line: 33
+        character: 27
+      end_position:
+        bytes: 736
+        line: 33
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 736
+      line: 33
+      character: 28
+    end_position:
+      bytes: 742
+      line: 33
+      character: 34
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 742
+      line: 33
+      character: 34
+    end_position:
+      bytes: 743
+      line: 33
+      character: 35
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 743
+        line: 33
+        character: 35
+      end_position:
+        bytes: 744
+        line: 33
+        character: 36
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 744
+      line: 33
+      character: 36
+    end_position:
+      bytes: 747
+      line: 33
+      character: 39
+    token_type:
+      type: Symbol
+      symbol: "..."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 747
+      line: 33
+      character: 39
+    end_position:
+      bytes: 748
+      line: 33
+      character: 40
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 748
+        line: 33
+        character: 40
+      end_position:
+        bytes: 749
+        line: 33
+        character: 40
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 749
+      line: 34
+      character: 1
+    end_position:
+      bytes: 752
+      line: 34
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 752
+        line: 34
+        character: 4
+      end_position:
+        bytes: 753
+        line: 34
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 753
+        line: 35
+        character: 1
+      end_position:
+        bytes: 754
+        line: 35
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 754
+      line: 36
+      character: 1
+    end_position:
+      bytes: 759
+      line: 36
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 759
+        line: 36
+        character: 6
+      end_position:
+        bytes: 760
+        line: 36
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 760
+      line: 36
+      character: 7
+    end_position:
+      bytes: 763
+      line: 36
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 763
+        line: 36
+        character: 10
+      end_position:
+        bytes: 764
+        line: 36
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 764
+      line: 36
+      character: 11
+    end_position:
+      bytes: 765
+      line: 36
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 765
+        line: 36
+        character: 12
+      end_position:
+        bytes: 766
+        line: 36
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 766
+      line: 36
+      character: 13
+    end_position:
+      bytes: 774
+      line: 36
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 774
+      line: 36
+      character: 21
+    end_position:
+      bytes: 775
+      line: 36
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 775
+      line: 36
+      character: 22
+    end_position:
+      bytes: 776
+      line: 36
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 776
+        line: 36
+        character: 23
+      end_position:
+        bytes: 777
+        line: 36
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 777
+      line: 36
+      character: 24
+    end_position:
+      bytes: 778
+      line: 36
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 778
+        line: 36
+        character: 25
+      end_position:
+        bytes: 779
+        line: 36
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 779
+      line: 36
+      character: 26
+    end_position:
+      bytes: 785
+      line: 36
+      character: 32
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 785
+        line: 36
+        character: 32
+      end_position:
+        bytes: 786
+        line: 36
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 786
+      line: 36
+      character: 33
+    end_position:
+      bytes: 787
+      line: 36
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: "|"
+  trailing_trivia:
+    - start_position:
+        bytes: 787
+        line: 36
+        character: 34
+      end_position:
+        bytes: 788
+        line: 36
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 788
+      line: 36
+      character: 35
+    end_position:
+      bytes: 791
+      line: 36
+      character: 38
+    token_type:
+      type: Symbol
+      symbol: nil
+  trailing_trivia:
+    - start_position:
+        bytes: 791
+        line: 36
+        character: 38
+      end_position:
+        bytes: 792
+        line: 36
+        character: 38
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 792
+        line: 37
+        character: 1
+      end_position:
+        bytes: 793
+        line: 37
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 793
+      line: 37
+      character: 2
+    end_position:
+      bytes: 799
+      line: 37
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 799
+        line: 37
+        character: 8
+      end_position:
+        bytes: 800
+        line: 37
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 800
+      line: 37
+      character: 9
+    end_position:
+      bytes: 801
+      line: 37
+      character: 10
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia:
+    - start_position:
+        bytes: 801
+        line: 37
+        character: 10
+      end_position:
+        bytes: 802
+        line: 37
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 802
+      line: 38
+      character: 1
+    end_position:
+      bytes: 805
+      line: 38
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 805
+        line: 38
+        character: 4
+      end_position:
+        bytes: 806
+        line: 38
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 806
+        line: 39
+        character: 1
+      end_position:
+        bytes: 807
+        line: 39
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 807
+      line: 40
+      character: 1
+    end_position:
+      bytes: 812
+      line: 40
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 812
+        line: 40
+        character: 6
+      end_position:
+        bytes: 813
+        line: 40
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 813
+      line: 40
+      character: 7
+    end_position:
+      bytes: 816
+      line: 40
+      character: 10
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia:
+    - start_position:
+        bytes: 816
+        line: 40
+        character: 10
+      end_position:
+        bytes: 817
+        line: 40
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 817
+      line: 40
+      character: 11
+    end_position:
+      bytes: 818
+      line: 40
+      character: 12
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 818
+        line: 40
+        character: 12
+      end_position:
+        bytes: 819
+        line: 40
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 819
+      line: 40
+      character: 13
+    end_position:
+      bytes: 827
+      line: 40
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: function
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 827
+      line: 40
+      character: 21
+    end_position:
+      bytes: 828
+      line: 40
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 828
+      line: 40
+      character: 22
+    end_position:
+      bytes: 829
+      line: 40
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 829
+        line: 40
+        character: 23
+      end_position:
+        bytes: 830
+        line: 40
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 830
+      line: 40
+      character: 24
+    end_position:
+      bytes: 831
+      line: 40
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 831
+        line: 40
+        character: 25
+      end_position:
+        bytes: 832
+        line: 40
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 832
+      line: 40
+      character: 26
+    end_position:
+      bytes: 838
+      line: 40
+      character: 32
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 838
+        line: 40
+        character: 32
+      end_position:
+        bytes: 839
+        line: 40
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 839
+      line: 40
+      character: 33
+    end_position:
+      bytes: 840
+      line: 40
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: "&"
+  trailing_trivia:
+    - start_position:
+        bytes: 840
+        line: 40
+        character: 34
+      end_position:
+        bytes: 841
+        line: 40
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 841
+      line: 40
+      character: 35
+    end_position:
+      bytes: 844
+      line: 40
+      character: 38
+    token_type:
+      type: Symbol
+      symbol: nil
+  trailing_trivia:
+    - start_position:
+        bytes: 844
+        line: 40
+        character: 38
+      end_position:
+        bytes: 845
+        line: 40
+        character: 38
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 845
+        line: 41
+        character: 1
+      end_position:
+        bytes: 846
+        line: 41
+        character: 2
+      token_type:
+        type: Whitespace
+        characters: "\t"
+  token:
+    start_position:
+      bytes: 846
+      line: 41
+      character: 2
+    end_position:
+      bytes: 852
+      line: 41
+      character: 8
+    token_type:
+      type: Symbol
+      symbol: return
+  trailing_trivia:
+    - start_position:
+        bytes: 852
+        line: 41
+        character: 8
+      end_position:
+        bytes: 853
+        line: 41
+        character: 9
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 853
+      line: 41
+      character: 9
+    end_position:
+      bytes: 854
+      line: 41
+      character: 10
+    token_type:
+      type: Number
+      text: "3"
+  trailing_trivia:
+    - start_position:
+        bytes: 854
+        line: 41
+        character: 10
+      end_position:
+        bytes: 855
+        line: 41
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 855
+      line: 42
+      character: 1
+    end_position:
+      bytes: 858
+      line: 42
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 858
+      line: 42
+      character: 4
+    end_position:
+      bytes: 858
+      line: 42
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/types_exported/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_exported/tokens.snap
@@ -4,366 +4,420 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/types_exported
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: Foo
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: bar
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 18
-    line: 1
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 18
-    line: 1
-    character: 19
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Identifier
-    identifier: any
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 23
-    line: 1
-    character: 24
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 23
-    line: 1
-    character: 24
-  end_position:
-    bytes: 24
-    line: 1
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 24
-    line: 2
-    character: 1
-  end_position:
-    bytes: 30
-    line: 2
-    character: 7
-  token_type:
-    type: Identifier
-    identifier: export
-- start_position:
-    bytes: 30
-    line: 2
-    character: 7
-  end_position:
-    bytes: 31
-    line: 2
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 31
-    line: 2
-    character: 8
-  end_position:
-    bytes: 35
-    line: 2
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: type
-- start_position:
-    bytes: 35
-    line: 2
-    character: 12
-  end_position:
-    bytes: 36
-    line: 2
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 36
-    line: 2
-    character: 13
-  end_position:
-    bytes: 39
-    line: 2
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: Baz
-- start_position:
-    bytes: 39
-    line: 2
-    character: 16
-  end_position:
-    bytes: 40
-    line: 2
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 40
-    line: 2
-    character: 17
-  end_position:
-    bytes: 41
-    line: 2
-    character: 18
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 41
-    line: 2
-    character: 18
-  end_position:
-    bytes: 42
-    line: 2
-    character: 19
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 42
-    line: 2
-    character: 19
-  end_position:
-    bytes: 43
-    line: 2
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 43
-    line: 2
-    character: 20
-  end_position:
-    bytes: 44
-    line: 2
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 44
-    line: 2
-    character: 21
-  end_position:
-    bytes: 47
-    line: 2
-    character: 24
-  token_type:
-    type: Identifier
-    identifier: foo
-- start_position:
-    bytes: 47
-    line: 2
-    character: 24
-  end_position:
-    bytes: 48
-    line: 2
-    character: 25
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 48
-    line: 2
-    character: 25
-  end_position:
-    bytes: 49
-    line: 2
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 49
-    line: 2
-    character: 26
-  end_position:
-    bytes: 52
-    line: 2
-    character: 29
-  token_type:
-    type: Identifier
-    identifier: any
-- start_position:
-    bytes: 52
-    line: 2
-    character: 29
-  end_position:
-    bytes: 53
-    line: 2
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 53
-    line: 2
-    character: 30
-  end_position:
-    bytes: 54
-    line: 2
-    character: 31
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 54
-    line: 2
-    character: 31
-  end_position:
-    bytes: 55
-    line: 2
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 55
-    line: 3
-    character: 1
-  end_position:
-    bytes: 55
-    line: 3
-    character: 1
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 4
+      line: 1
+      character: 5
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 4
+        line: 1
+        character: 5
+      end_position:
+        bytes: 5
+        line: 1
+        character: 6
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: Foo
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 10
+      line: 1
+      character: 11
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 10
+        line: 1
+        character: 11
+      end_position:
+        bytes: 11
+        line: 1
+        character: 12
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 11
+      line: 1
+      character: 12
+    end_position:
+      bytes: 12
+      line: 1
+      character: 13
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 12
+        line: 1
+        character: 13
+      end_position:
+        bytes: 13
+        line: 1
+        character: 14
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 13
+      line: 1
+      character: 14
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: bar
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 17
+      line: 1
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 17
+        line: 1
+        character: 18
+      end_position:
+        bytes: 18
+        line: 1
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 18
+      line: 1
+      character: 19
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Identifier
+      identifier: any
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 22
+      end_position:
+        bytes: 22
+        line: 1
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 1
+      character: 23
+    end_position:
+      bytes: 23
+      line: 1
+      character: 24
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 23
+        line: 1
+        character: 24
+      end_position:
+        bytes: 24
+        line: 1
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 24
+      line: 2
+      character: 1
+    end_position:
+      bytes: 30
+      line: 2
+      character: 7
+    token_type:
+      type: Identifier
+      identifier: export
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 2
+        character: 7
+      end_position:
+        bytes: 31
+        line: 2
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 31
+      line: 2
+      character: 8
+    end_position:
+      bytes: 35
+      line: 2
+      character: 12
+    token_type:
+      type: Identifier
+      identifier: type
+  trailing_trivia:
+    - start_position:
+        bytes: 35
+        line: 2
+        character: 12
+      end_position:
+        bytes: 36
+        line: 2
+        character: 13
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 36
+      line: 2
+      character: 13
+    end_position:
+      bytes: 39
+      line: 2
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: Baz
+  trailing_trivia:
+    - start_position:
+        bytes: 39
+        line: 2
+        character: 16
+      end_position:
+        bytes: 40
+        line: 2
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 40
+      line: 2
+      character: 17
+    end_position:
+      bytes: 41
+      line: 2
+      character: 18
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 41
+        line: 2
+        character: 18
+      end_position:
+        bytes: 42
+        line: 2
+        character: 19
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 2
+      character: 19
+    end_position:
+      bytes: 43
+      line: 2
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 43
+        line: 2
+        character: 20
+      end_position:
+        bytes: 44
+        line: 2
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 44
+      line: 2
+      character: 21
+    end_position:
+      bytes: 47
+      line: 2
+      character: 24
+    token_type:
+      type: Identifier
+      identifier: foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 2
+      character: 24
+    end_position:
+      bytes: 48
+      line: 2
+      character: 25
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 48
+        line: 2
+        character: 25
+      end_position:
+        bytes: 49
+        line: 2
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 49
+      line: 2
+      character: 26
+    end_position:
+      bytes: 52
+      line: 2
+      character: 29
+    token_type:
+      type: Identifier
+      identifier: any
+  trailing_trivia:
+    - start_position:
+        bytes: 52
+        line: 2
+        character: 29
+      end_position:
+        bytes: 53
+        line: 2
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 2
+      character: 30
+    end_position:
+      bytes: 54
+      line: 2
+      character: 31
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 54
+        line: 2
+        character: 31
+      end_position:
+        bytes: 55
+        line: 2
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 55
+      line: 3
+      character: 1
+    end_position:
+      bytes: 55
+      line: 3
+      character: 1
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/types_indexable/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_indexable/tokens.snap
@@ -4,709 +4,832 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/types_indexable
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 15
-    line: 1
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: module
-- start_position:
-    bytes: 15
-    line: 1
-    character: 16
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Identifier
-    identifier: Foo
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 21
-    line: 1
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 21
-    line: 1
-    character: 22
-  end_position:
-    bytes: 22
-    line: 1
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 22
-    line: 1
-    character: 23
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Symbol
-    symbol: nil
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 26
-    line: 1
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 26
-    line: 2
-    character: 1
-  end_position:
-    bytes: 31
-    line: 2
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 31
-    line: 2
-    character: 6
-  end_position:
-    bytes: 32
-    line: 2
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 32
-    line: 2
-    character: 7
-  end_position:
-    bytes: 33
-    line: 2
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 33
-    line: 2
-    character: 8
-  end_position:
-    bytes: 34
-    line: 2
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 34
-    line: 2
-    character: 9
-  end_position:
-    bytes: 35
-    line: 2
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 35
-    line: 2
-    character: 10
-  end_position:
-    bytes: 41
-    line: 2
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: module
-- start_position:
-    bytes: 41
-    line: 2
-    character: 16
-  end_position:
-    bytes: 42
-    line: 2
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 42
-    line: 2
-    character: 17
-  end_position:
-    bytes: 47
-    line: 2
-    character: 22
-  token_type:
-    type: Identifier
-    identifier: Array
-- start_position:
-    bytes: 47
-    line: 2
-    character: 22
-  end_position:
-    bytes: 48
-    line: 2
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: "<"
-- start_position:
-    bytes: 48
-    line: 2
-    character: 23
-  end_position:
-    bytes: 54
-    line: 2
-    character: 29
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 54
-    line: 2
-    character: 29
-  end_position:
-    bytes: 55
-    line: 2
-    character: 30
-  token_type:
-    type: Symbol
-    symbol: ">"
-- start_position:
-    bytes: 55
-    line: 2
-    character: 30
-  end_position:
-    bytes: 56
-    line: 2
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 56
-    line: 2
-    character: 31
-  end_position:
-    bytes: 57
-    line: 2
-    character: 32
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 57
-    line: 2
-    character: 32
-  end_position:
-    bytes: 58
-    line: 2
-    character: 33
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 58
-    line: 2
-    character: 33
-  end_position:
-    bytes: 59
-    line: 2
-    character: 34
-  token_type:
-    type: Symbol
-    symbol: "{"
-- start_position:
-    bytes: 59
-    line: 2
-    character: 34
-  end_position:
-    bytes: 60
-    line: 2
-    character: 35
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 60
-    line: 2
-    character: 35
-  end_position:
-    bytes: 65
-    line: 2
-    character: 40
-  token_type:
-    type: StringLiteral
-    literal: bar
-    quote_type: Double
-- start_position:
-    bytes: 65
-    line: 2
-    character: 40
-  end_position:
-    bytes: 66
-    line: 2
-    character: 41
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 66
-    line: 2
-    character: 41
-  end_position:
-    bytes: 67
-    line: 2
-    character: 42
-  token_type:
-    type: Symbol
-    symbol: "}"
-- start_position:
-    bytes: 67
-    line: 2
-    character: 42
-  end_position:
-    bytes: 68
-    line: 2
-    character: 42
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 68
-    line: 3
-    character: 1
-  end_position:
-    bytes: 73
-    line: 3
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 73
-    line: 3
-    character: 6
-  end_position:
-    bytes: 74
-    line: 3
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 74
-    line: 3
-    character: 7
-  end_position:
-    bytes: 75
-    line: 3
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 75
-    line: 3
-    character: 8
-  end_position:
-    bytes: 76
-    line: 3
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 76
-    line: 3
-    character: 9
-  end_position:
-    bytes: 77
-    line: 3
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 77
-    line: 3
-    character: 10
-  end_position:
-    bytes: 83
-    line: 3
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: module
-- start_position:
-    bytes: 83
-    line: 3
-    character: 16
-  end_position:
-    bytes: 84
-    line: 3
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 84
-    line: 3
-    character: 17
-  end_position:
-    bytes: 87
-    line: 3
-    character: 20
-  token_type:
-    type: Identifier
-    identifier: Foo
-- start_position:
-    bytes: 87
-    line: 3
-    character: 20
-  end_position:
-    bytes: 88
-    line: 3
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 88
-    line: 3
-    character: 21
-  end_position:
-    bytes: 89
-    line: 3
-    character: 22
-  token_type:
-    type: Symbol
-    symbol: "|"
-- start_position:
-    bytes: 89
-    line: 3
-    character: 22
-  end_position:
-    bytes: 90
-    line: 3
-    character: 23
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 90
-    line: 3
-    character: 23
-  end_position:
-    bytes: 96
-    line: 3
-    character: 29
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 96
-    line: 3
-    character: 29
-  end_position:
-    bytes: 97
-    line: 3
-    character: 30
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 97
-    line: 3
-    character: 30
-  end_position:
-    bytes: 98
-    line: 3
-    character: 31
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 98
-    line: 3
-    character: 31
-  end_position:
-    bytes: 99
-    line: 3
-    character: 32
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 99
-    line: 3
-    character: 32
-  end_position:
-    bytes: 104
-    line: 3
-    character: 37
-  token_type:
-    type: StringLiteral
-    literal: bar
-    quote_type: Double
-- start_position:
-    bytes: 104
-    line: 3
-    character: 37
-  end_position:
-    bytes: 105
-    line: 3
-    character: 37
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 105
-    line: 4
-    character: 1
-  end_position:
-    bytes: 110
-    line: 4
-    character: 6
-  token_type:
-    type: Symbol
-    symbol: local
-- start_position:
-    bytes: 110
-    line: 4
-    character: 6
-  end_position:
-    bytes: 111
-    line: 4
-    character: 7
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 111
-    line: 4
-    character: 7
-  end_position:
-    bytes: 112
-    line: 4
-    character: 8
-  token_type:
-    type: Identifier
-    identifier: x
-- start_position:
-    bytes: 112
-    line: 4
-    character: 8
-  end_position:
-    bytes: 113
-    line: 4
-    character: 9
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 113
-    line: 4
-    character: 9
-  end_position:
-    bytes: 114
-    line: 4
-    character: 10
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 114
-    line: 4
-    character: 10
-  end_position:
-    bytes: 120
-    line: 4
-    character: 16
-  token_type:
-    type: Identifier
-    identifier: module
-- start_position:
-    bytes: 120
-    line: 4
-    character: 16
-  end_position:
-    bytes: 121
-    line: 4
-    character: 17
-  token_type:
-    type: Symbol
-    symbol: "."
-- start_position:
-    bytes: 121
-    line: 4
-    character: 17
-  end_position:
-    bytes: 124
-    line: 4
-    character: 20
-  token_type:
-    type: Identifier
-    identifier: Foo
-- start_position:
-    bytes: 124
-    line: 4
-    character: 20
-  end_position:
-    bytes: 125
-    line: 4
-    character: 21
-  token_type:
-    type: Symbol
-    symbol: "?"
-- start_position:
-    bytes: 125
-    line: 4
-    character: 21
-  end_position:
-    bytes: 126
-    line: 4
-    character: 22
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 126
-    line: 4
-    character: 22
-  end_position:
-    bytes: 127
-    line: 4
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 127
-    line: 4
-    character: 23
-  end_position:
-    bytes: 128
-    line: 4
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 128
-    line: 4
-    character: 24
-  end_position:
-    bytes: 131
-    line: 4
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: nil
-- start_position:
-    bytes: 131
-    line: 4
-    character: 27
-  end_position:
-    bytes: 131
-    line: 4
-    character: 27
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 5
+        line: 1
+        character: 6
+      end_position:
+        bytes: 6
+        line: 1
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 6
+      line: 1
+      character: 7
+    end_position:
+      bytes: 7
+      line: 1
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 8
+        line: 1
+        character: 9
+      end_position:
+        bytes: 9
+        line: 1
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 9
+      line: 1
+      character: 10
+    end_position:
+      bytes: 15
+      line: 1
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: module
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 15
+      line: 1
+      character: 16
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 16
+      line: 1
+      character: 17
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Identifier
+      identifier: Foo
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 21
+      line: 1
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 21
+        line: 1
+        character: 22
+      end_position:
+        bytes: 22
+        line: 1
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 22
+      line: 1
+      character: 23
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Symbol
+      symbol: nil
+  trailing_trivia:
+    - start_position:
+        bytes: 25
+        line: 1
+        character: 26
+      end_position:
+        bytes: 26
+        line: 1
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 2
+      character: 1
+    end_position:
+      bytes: 31
+      line: 2
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 31
+        line: 2
+        character: 6
+      end_position:
+        bytes: 32
+        line: 2
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 32
+      line: 2
+      character: 7
+    end_position:
+      bytes: 33
+      line: 2
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 33
+      line: 2
+      character: 8
+    end_position:
+      bytes: 34
+      line: 2
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 34
+        line: 2
+        character: 9
+      end_position:
+        bytes: 35
+        line: 2
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 35
+      line: 2
+      character: 10
+    end_position:
+      bytes: 41
+      line: 2
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: module
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 2
+      character: 16
+    end_position:
+      bytes: 42
+      line: 2
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 2
+      character: 17
+    end_position:
+      bytes: 47
+      line: 2
+      character: 22
+    token_type:
+      type: Identifier
+      identifier: Array
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 47
+      line: 2
+      character: 22
+    end_position:
+      bytes: 48
+      line: 2
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: "<"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 48
+      line: 2
+      character: 23
+    end_position:
+      bytes: 54
+      line: 2
+      character: 29
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 2
+      character: 29
+    end_position:
+      bytes: 55
+      line: 2
+      character: 30
+    token_type:
+      type: Symbol
+      symbol: ">"
+  trailing_trivia:
+    - start_position:
+        bytes: 55
+        line: 2
+        character: 30
+      end_position:
+        bytes: 56
+        line: 2
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 56
+      line: 2
+      character: 31
+    end_position:
+      bytes: 57
+      line: 2
+      character: 32
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 57
+        line: 2
+        character: 32
+      end_position:
+        bytes: 58
+        line: 2
+        character: 33
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 2
+      character: 33
+    end_position:
+      bytes: 59
+      line: 2
+      character: 34
+    token_type:
+      type: Symbol
+      symbol: "{"
+  trailing_trivia:
+    - start_position:
+        bytes: 59
+        line: 2
+        character: 34
+      end_position:
+        bytes: 60
+        line: 2
+        character: 35
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 60
+      line: 2
+      character: 35
+    end_position:
+      bytes: 65
+      line: 2
+      character: 40
+    token_type:
+      type: StringLiteral
+      literal: bar
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 65
+        line: 2
+        character: 40
+      end_position:
+        bytes: 66
+        line: 2
+        character: 41
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 66
+      line: 2
+      character: 41
+    end_position:
+      bytes: 67
+      line: 2
+      character: 42
+    token_type:
+      type: Symbol
+      symbol: "}"
+  trailing_trivia:
+    - start_position:
+        bytes: 67
+        line: 2
+        character: 42
+      end_position:
+        bytes: 68
+        line: 2
+        character: 42
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 68
+      line: 3
+      character: 1
+    end_position:
+      bytes: 73
+      line: 3
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 73
+        line: 3
+        character: 6
+      end_position:
+        bytes: 74
+        line: 3
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 74
+      line: 3
+      character: 7
+    end_position:
+      bytes: 75
+      line: 3
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 75
+      line: 3
+      character: 8
+    end_position:
+      bytes: 76
+      line: 3
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 76
+        line: 3
+        character: 9
+      end_position:
+        bytes: 77
+        line: 3
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 77
+      line: 3
+      character: 10
+    end_position:
+      bytes: 83
+      line: 3
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: module
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 83
+      line: 3
+      character: 16
+    end_position:
+      bytes: 84
+      line: 3
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 84
+      line: 3
+      character: 17
+    end_position:
+      bytes: 87
+      line: 3
+      character: 20
+    token_type:
+      type: Identifier
+      identifier: Foo
+  trailing_trivia:
+    - start_position:
+        bytes: 87
+        line: 3
+        character: 20
+      end_position:
+        bytes: 88
+        line: 3
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 88
+      line: 3
+      character: 21
+    end_position:
+      bytes: 89
+      line: 3
+      character: 22
+    token_type:
+      type: Symbol
+      symbol: "|"
+  trailing_trivia:
+    - start_position:
+        bytes: 89
+        line: 3
+        character: 22
+      end_position:
+        bytes: 90
+        line: 3
+        character: 23
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 90
+      line: 3
+      character: 23
+    end_position:
+      bytes: 96
+      line: 3
+      character: 29
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 96
+        line: 3
+        character: 29
+      end_position:
+        bytes: 97
+        line: 3
+        character: 30
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 97
+      line: 3
+      character: 30
+    end_position:
+      bytes: 98
+      line: 3
+      character: 31
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 98
+        line: 3
+        character: 31
+      end_position:
+        bytes: 99
+        line: 3
+        character: 32
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 99
+      line: 3
+      character: 32
+    end_position:
+      bytes: 104
+      line: 3
+      character: 37
+    token_type:
+      type: StringLiteral
+      literal: bar
+      quote_type: Double
+  trailing_trivia:
+    - start_position:
+        bytes: 104
+        line: 3
+        character: 37
+      end_position:
+        bytes: 105
+        line: 3
+        character: 37
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 105
+      line: 4
+      character: 1
+    end_position:
+      bytes: 110
+      line: 4
+      character: 6
+    token_type:
+      type: Symbol
+      symbol: local
+  trailing_trivia:
+    - start_position:
+        bytes: 110
+        line: 4
+        character: 6
+      end_position:
+        bytes: 111
+        line: 4
+        character: 7
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 111
+      line: 4
+      character: 7
+    end_position:
+      bytes: 112
+      line: 4
+      character: 8
+    token_type:
+      type: Identifier
+      identifier: x
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 112
+      line: 4
+      character: 8
+    end_position:
+      bytes: 113
+      line: 4
+      character: 9
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 113
+        line: 4
+        character: 9
+      end_position:
+        bytes: 114
+        line: 4
+        character: 10
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 114
+      line: 4
+      character: 10
+    end_position:
+      bytes: 120
+      line: 4
+      character: 16
+    token_type:
+      type: Identifier
+      identifier: module
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 120
+      line: 4
+      character: 16
+    end_position:
+      bytes: 121
+      line: 4
+      character: 17
+    token_type:
+      type: Symbol
+      symbol: "."
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 121
+      line: 4
+      character: 17
+    end_position:
+      bytes: 124
+      line: 4
+      character: 20
+    token_type:
+      type: Identifier
+      identifier: Foo
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 124
+      line: 4
+      character: 20
+    end_position:
+      bytes: 125
+      line: 4
+      character: 21
+    token_type:
+      type: Symbol
+      symbol: "?"
+  trailing_trivia:
+    - start_position:
+        bytes: 125
+        line: 4
+        character: 21
+      end_position:
+        bytes: 126
+        line: 4
+        character: 22
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 126
+      line: 4
+      character: 22
+    end_position:
+      bytes: 127
+      line: 4
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 127
+        line: 4
+        character: 23
+      end_position:
+        bytes: 128
+        line: 4
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 128
+      line: 4
+      character: 24
+    end_position:
+      bytes: 131
+      line: 4
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: nil
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 131
+      line: 4
+      character: 27
+    end_position:
+      bytes: 131
+      line: 4
+      character: 27
+    token_type:
+      type: Eof
+  trailing_trivia: []
 

--- a/full-moon/tests/roblox_cases/pass/types_loops/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_loops/tokens.snap
@@ -4,487 +4,562 @@ expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/types_loops
 
 ---
-- start_position:
-    bytes: 0
-    line: 1
-    character: 1
-  end_position:
-    bytes: 3
-    line: 1
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 3
-    line: 1
-    character: 4
-  end_position:
-    bytes: 4
-    line: 1
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 4
-    line: 1
-    character: 5
-  end_position:
-    bytes: 5
-    line: 1
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: i
-- start_position:
-    bytes: 5
-    line: 1
-    character: 6
-  end_position:
-    bytes: 6
-    line: 1
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 6
-    line: 1
-    character: 7
-  end_position:
-    bytes: 7
-    line: 1
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 7
-    line: 1
-    character: 8
-  end_position:
-    bytes: 8
-    line: 1
-    character: 9
-  token_type:
-    type: Identifier
-    identifier: v
-- start_position:
-    bytes: 8
-    line: 1
-    character: 9
-  end_position:
-    bytes: 9
-    line: 1
-    character: 10
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 9
-    line: 1
-    character: 10
-  end_position:
-    bytes: 10
-    line: 1
-    character: 11
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 10
-    line: 1
-    character: 11
-  end_position:
-    bytes: 16
-    line: 1
-    character: 17
-  token_type:
-    type: Identifier
-    identifier: string
-- start_position:
-    bytes: 16
-    line: 1
-    character: 17
-  end_position:
-    bytes: 17
-    line: 1
-    character: 18
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 17
-    line: 1
-    character: 18
-  end_position:
-    bytes: 19
-    line: 1
-    character: 20
-  token_type:
-    type: Symbol
-    symbol: in
-- start_position:
-    bytes: 19
-    line: 1
-    character: 20
-  end_position:
-    bytes: 20
-    line: 1
-    character: 21
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 20
-    line: 1
-    character: 21
-  end_position:
-    bytes: 25
-    line: 1
-    character: 26
-  token_type:
-    type: Identifier
-    identifier: pairs
-- start_position:
-    bytes: 25
-    line: 1
-    character: 26
-  end_position:
-    bytes: 26
-    line: 1
-    character: 27
-  token_type:
-    type: Symbol
-    symbol: (
-- start_position:
-    bytes: 26
-    line: 1
-    character: 27
-  end_position:
-    bytes: 27
-    line: 1
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: )
-- start_position:
-    bytes: 27
-    line: 1
-    character: 28
-  end_position:
-    bytes: 28
-    line: 1
-    character: 29
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 28
-    line: 1
-    character: 29
-  end_position:
-    bytes: 30
-    line: 1
-    character: 31
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 30
-    line: 1
-    character: 31
-  end_position:
-    bytes: 31
-    line: 1
-    character: 31
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 31
-    line: 2
-    character: 1
-  end_position:
-    bytes: 32
-    line: 2
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 32
-    line: 3
-    character: 1
-  end_position:
-    bytes: 35
-    line: 3
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 35
-    line: 3
-    character: 4
-  end_position:
-    bytes: 36
-    line: 3
-    character: 4
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 36
-    line: 4
-    character: 1
-  end_position:
-    bytes: 37
-    line: 4
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 37
-    line: 5
-    character: 1
-  end_position:
-    bytes: 40
-    line: 5
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: for
-- start_position:
-    bytes: 40
-    line: 5
-    character: 4
-  end_position:
-    bytes: 41
-    line: 5
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 41
-    line: 5
-    character: 5
-  end_position:
-    bytes: 42
-    line: 5
-    character: 6
-  token_type:
-    type: Identifier
-    identifier: i
-- start_position:
-    bytes: 42
-    line: 5
-    character: 6
-  end_position:
-    bytes: 43
-    line: 5
-    character: 7
-  token_type:
-    type: Symbol
-    symbol: ":"
-- start_position:
-    bytes: 43
-    line: 5
-    character: 7
-  end_position:
-    bytes: 44
-    line: 5
-    character: 8
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 44
-    line: 5
-    character: 8
-  end_position:
-    bytes: 50
-    line: 5
-    character: 14
-  token_type:
-    type: Identifier
-    identifier: number
-- start_position:
-    bytes: 50
-    line: 5
-    character: 14
-  end_position:
-    bytes: 51
-    line: 5
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 51
-    line: 5
-    character: 15
-  end_position:
-    bytes: 52
-    line: 5
-    character: 16
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 52
-    line: 5
-    character: 16
-  end_position:
-    bytes: 53
-    line: 5
-    character: 17
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 53
-    line: 5
-    character: 17
-  end_position:
-    bytes: 54
-    line: 5
-    character: 18
-  token_type:
-    type: Number
-    text: "1"
-- start_position:
-    bytes: 54
-    line: 5
-    character: 18
-  end_position:
-    bytes: 55
-    line: 5
-    character: 19
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 55
-    line: 5
-    character: 19
-  end_position:
-    bytes: 56
-    line: 5
-    character: 20
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 56
-    line: 5
-    character: 20
-  end_position:
-    bytes: 58
-    line: 5
-    character: 22
-  token_type:
-    type: Number
-    text: "10"
-- start_position:
-    bytes: 58
-    line: 5
-    character: 22
-  end_position:
-    bytes: 59
-    line: 5
-    character: 23
-  token_type:
-    type: Symbol
-    symbol: ","
-- start_position:
-    bytes: 59
-    line: 5
-    character: 23
-  end_position:
-    bytes: 60
-    line: 5
-    character: 24
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 60
-    line: 5
-    character: 24
-  end_position:
-    bytes: 61
-    line: 5
-    character: 25
-  token_type:
-    type: Number
-    text: "2"
-- start_position:
-    bytes: 61
-    line: 5
-    character: 25
-  end_position:
-    bytes: 62
-    line: 5
-    character: 26
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 62
-    line: 5
-    character: 26
-  end_position:
-    bytes: 64
-    line: 5
-    character: 28
-  token_type:
-    type: Symbol
-    symbol: do
-- start_position:
-    bytes: 64
-    line: 5
-    character: 28
-  end_position:
-    bytes: 65
-    line: 5
-    character: 28
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 65
-    line: 6
-    character: 1
-  end_position:
-    bytes: 70
-    line: 6
-    character: 5
-  token_type:
-    type: Whitespace
-    characters: "    \n"
-- start_position:
-    bytes: 70
-    line: 7
-    character: 1
-  end_position:
-    bytes: 73
-    line: 7
-    character: 4
-  token_type:
-    type: Symbol
-    symbol: end
-- start_position:
-    bytes: 73
-    line: 7
-    character: 4
-  end_position:
-    bytes: 73
-    line: 7
-    character: 4
-  token_type:
-    type: Eof
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 0
+      line: 1
+      character: 1
+    end_position:
+      bytes: 3
+      line: 1
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 3
+        line: 1
+        character: 4
+      end_position:
+        bytes: 4
+        line: 1
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 4
+      line: 1
+      character: 5
+    end_position:
+      bytes: 5
+      line: 1
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: i
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 5
+      line: 1
+      character: 6
+    end_position:
+      bytes: 6
+      line: 1
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 6
+        line: 1
+        character: 7
+      end_position:
+        bytes: 7
+        line: 1
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 7
+      line: 1
+      character: 8
+    end_position:
+      bytes: 8
+      line: 1
+      character: 9
+    token_type:
+      type: Identifier
+      identifier: v
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 8
+      line: 1
+      character: 9
+    end_position:
+      bytes: 9
+      line: 1
+      character: 10
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 9
+        line: 1
+        character: 10
+      end_position:
+        bytes: 10
+        line: 1
+        character: 11
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 10
+      line: 1
+      character: 11
+    end_position:
+      bytes: 16
+      line: 1
+      character: 17
+    token_type:
+      type: Identifier
+      identifier: string
+  trailing_trivia:
+    - start_position:
+        bytes: 16
+        line: 1
+        character: 17
+      end_position:
+        bytes: 17
+        line: 1
+        character: 18
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 17
+      line: 1
+      character: 18
+    end_position:
+      bytes: 19
+      line: 1
+      character: 20
+    token_type:
+      type: Symbol
+      symbol: in
+  trailing_trivia:
+    - start_position:
+        bytes: 19
+        line: 1
+        character: 20
+      end_position:
+        bytes: 20
+        line: 1
+        character: 21
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 20
+      line: 1
+      character: 21
+    end_position:
+      bytes: 25
+      line: 1
+      character: 26
+    token_type:
+      type: Identifier
+      identifier: pairs
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 25
+      line: 1
+      character: 26
+    end_position:
+      bytes: 26
+      line: 1
+      character: 27
+    token_type:
+      type: Symbol
+      symbol: (
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 26
+      line: 1
+      character: 27
+    end_position:
+      bytes: 27
+      line: 1
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: )
+  trailing_trivia:
+    - start_position:
+        bytes: 27
+        line: 1
+        character: 28
+      end_position:
+        bytes: 28
+        line: 1
+        character: 29
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 28
+      line: 1
+      character: 29
+    end_position:
+      bytes: 30
+      line: 1
+      character: 31
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 30
+        line: 1
+        character: 31
+      end_position:
+        bytes: 31
+        line: 1
+        character: 31
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 31
+        line: 2
+        character: 1
+      end_position:
+        bytes: 32
+        line: 2
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 32
+      line: 3
+      character: 1
+    end_position:
+      bytes: 35
+      line: 3
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia:
+    - start_position:
+        bytes: 35
+        line: 3
+        character: 4
+      end_position:
+        bytes: 36
+        line: 3
+        character: 4
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 36
+        line: 4
+        character: 1
+      end_position:
+        bytes: 37
+        line: 4
+        character: 1
+      token_type:
+        type: Whitespace
+        characters: "\n"
+  token:
+    start_position:
+      bytes: 37
+      line: 5
+      character: 1
+    end_position:
+      bytes: 40
+      line: 5
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: for
+  trailing_trivia:
+    - start_position:
+        bytes: 40
+        line: 5
+        character: 4
+      end_position:
+        bytes: 41
+        line: 5
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 41
+      line: 5
+      character: 5
+    end_position:
+      bytes: 42
+      line: 5
+      character: 6
+    token_type:
+      type: Identifier
+      identifier: i
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 42
+      line: 5
+      character: 6
+    end_position:
+      bytes: 43
+      line: 5
+      character: 7
+    token_type:
+      type: Symbol
+      symbol: ":"
+  trailing_trivia:
+    - start_position:
+        bytes: 43
+        line: 5
+        character: 7
+      end_position:
+        bytes: 44
+        line: 5
+        character: 8
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 44
+      line: 5
+      character: 8
+    end_position:
+      bytes: 50
+      line: 5
+      character: 14
+    token_type:
+      type: Identifier
+      identifier: number
+  trailing_trivia:
+    - start_position:
+        bytes: 50
+        line: 5
+        character: 14
+      end_position:
+        bytes: 51
+        line: 5
+        character: 15
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 51
+      line: 5
+      character: 15
+    end_position:
+      bytes: 52
+      line: 5
+      character: 16
+    token_type:
+      type: Symbol
+      symbol: "="
+  trailing_trivia:
+    - start_position:
+        bytes: 52
+        line: 5
+        character: 16
+      end_position:
+        bytes: 53
+        line: 5
+        character: 17
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 53
+      line: 5
+      character: 17
+    end_position:
+      bytes: 54
+      line: 5
+      character: 18
+    token_type:
+      type: Number
+      text: "1"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 54
+      line: 5
+      character: 18
+    end_position:
+      bytes: 55
+      line: 5
+      character: 19
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 55
+        line: 5
+        character: 19
+      end_position:
+        bytes: 56
+        line: 5
+        character: 20
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 56
+      line: 5
+      character: 20
+    end_position:
+      bytes: 58
+      line: 5
+      character: 22
+    token_type:
+      type: Number
+      text: "10"
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 58
+      line: 5
+      character: 22
+    end_position:
+      bytes: 59
+      line: 5
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: ","
+  trailing_trivia:
+    - start_position:
+        bytes: 59
+        line: 5
+        character: 23
+      end_position:
+        bytes: 60
+        line: 5
+        character: 24
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 60
+      line: 5
+      character: 24
+    end_position:
+      bytes: 61
+      line: 5
+      character: 25
+    token_type:
+      type: Number
+      text: "2"
+  trailing_trivia:
+    - start_position:
+        bytes: 61
+        line: 5
+        character: 25
+      end_position:
+        bytes: 62
+        line: 5
+        character: 26
+      token_type:
+        type: Whitespace
+        characters: " "
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 62
+      line: 5
+      character: 26
+    end_position:
+      bytes: 64
+      line: 5
+      character: 28
+    token_type:
+      type: Symbol
+      symbol: do
+  trailing_trivia:
+    - start_position:
+        bytes: 64
+        line: 5
+        character: 28
+      end_position:
+        bytes: 65
+        line: 5
+        character: 28
+      token_type:
+        type: Whitespace
+        characters: "\n"
+- leading_trivia:
+    - start_position:
+        bytes: 65
+        line: 6
+        character: 1
+      end_position:
+        bytes: 70
+        line: 6
+        character: 5
+      token_type:
+        type: Whitespace
+        characters: "    \n"
+  token:
+    start_position:
+      bytes: 70
+      line: 7
+      character: 1
+    end_position:
+      bytes: 73
+      line: 7
+      character: 4
+    token_type:
+      type: Symbol
+      symbol: end
+  trailing_trivia: []
+- leading_trivia: []
+  token:
+    start_position:
+      bytes: 73
+      line: 7
+      character: 4
+    end_position:
+      bytes: 73
+      line: 7
+      character: 4
+    token_type:
+      type: Eof
+  trailing_trivia: []
 


### PR DESCRIPTION
This is based on #154 and is in preparation for splitting `Token` into `Token` and `Trivia`.  https://github.com/Kampfkarren/full-moon/commit/979afe701b5b1e68c94f682096801cec593a9daf adjusts the code in a way that the test data is unchanged (by flattening the `TokenReference`s before comparing with snapshots. The final commits removes that flattening; I've not checked the snapshot changes there in any detail.