### PR TITLE
Deny clippy warnings in CI and fix issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         cargo test --no-default-features --features serde
     - name: Clippy
       run: |
-        cargo clippy
+        cargo clippy -- -D warnings
     - name: Rustfmt
       run: |
         cargo fmt -- --check

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -1,7 +1,6 @@
 use crate::visitors::{Visit, VisitMut, Visitor, VisitorMut};
 
 use full_moon_derive::{symbols, Owned};
-use peg;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, cmp::Ordering, fmt, str::FromStr};
@@ -878,9 +877,9 @@ impl<'input> TokenCollector<'input> {
     }
 }
 
-fn from_parser_error<'input>(
-    code: &'input str,
-) -> impl Fn(peg::error::ParseError<peg::str::LineCol>) -> TokenizerError + 'input {
+fn from_parser_error(
+    code: &'_ str,
+) -> impl Fn(peg::error::ParseError<peg::str::LineCol>) -> TokenizerError + '_ {
     move |err| TokenizerError {
         error: TokenizerErrorType::UnexpectedToken(
             code[err.location.offset..].chars().next().expect(
@@ -905,7 +904,7 @@ fn from_parser_error<'input>(
 /// assert!(tokens("local 4 = end").is_ok()); // tokens does *not* check validity of code, only tokenizing
 /// assert!(tokens("--[[ Unclosed comment!").is_err());
 /// ```
-pub fn tokens<'a>(code: &'a str) -> Result<Vec<Token<'a>>, TokenizerError> {
+pub fn tokens(code: &str) -> Result<Vec<Token>, TokenizerError> {
     let mut tokens = TokenCollector::new();
 
     let mut raw_tokens = tokens::tokens(code).map_err(from_parser_error(code))?;

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::unnecessary_wraps)] // Clippy currently triggers false positives wrt. Advancement: https://github.com/rust-lang/rust-clippy/issues/6613
 use crate::visitors::{Visit, VisitMut, Visitor, VisitorMut};
 
 use full_moon_derive::{symbols, Owned};
@@ -182,13 +183,13 @@ impl<'a> TokenType<'a> {
     /// Returns whether a token can be practically ignored in most cases
     /// Comments and whitespace will return `true`, everything else will return `false`
     pub fn is_trivia(&self) -> bool {
-        match self {
+        matches!(
+            self,
             TokenType::Shebang { .. }
-            | TokenType::SingleLineComment { .. }
-            | TokenType::MultiLineComment { .. }
-            | TokenType::Whitespace { .. } => true,
-            _ => false,
-        }
+                | TokenType::SingleLineComment { .. }
+                | TokenType::MultiLineComment { .. }
+                | TokenType::Whitespace { .. }
+        )
     }
 
     /// Returns the kind of the token type.
@@ -954,7 +955,7 @@ impl std::error::Error for TokenizerError {}
 /// assert!(tokens("local 4 = end").is_ok()); // tokens does *not* check validity of code, only tokenizing
 /// assert!(tokens("--[[ Unclosed comment!").is_err());
 /// ```
-pub fn tokens<'a>(code: &'a str) -> Result<Vec<Token<'a>>, TokenizerError> {
+pub fn tokens(code: &str) -> Result<Vec<Token>, TokenizerError> {
     let mut tokens = Vec::new();
     let mut position = Position {
         bytes: 0,


### PR DESCRIPTION
Denies warnings in CI for clippy, so that the workflow fails.
Fixes currently outstanding warnings

Note, I had to allow `unnecessary_wraps` in the `tokenizer.rs` file due to all the `advance_XXXX()` methods, as clippy currently triggers a false positive for these cases (https://github.com/rust-lang/rust-clippy/issues/6613, and maybe https://github.com/rust-lang/rust-clippy/issues/6517?)