### PR TITLE
Finish renaming of `func_body` to `body` in `LocalFunction`

### DIFF
--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1603,13 +1603,13 @@ impl<'a> Assignment<'a> {
 /// A declaration of a local function, such as `local function x() end`
 #[derive(Clone, Debug, Display, PartialEq, Owned, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[display(fmt = "{}{}{}{}", "local_token", "function_token", "name", "func_body")]
+#[display(fmt = "{}{}{}{}", "local_token", "function_token", "name", "body")]
 pub struct LocalFunction<'a> {
     #[cfg_attr(feature = "serde", serde(borrow))]
     local_token: TokenReference<'a>,
     function_token: TokenReference<'a>,
     name: TokenReference<'a>,
-    func_body: FunctionBody<'a>,
+    body: FunctionBody<'a>,
 }
 
 impl<'a> LocalFunction<'a> {
@@ -1619,7 +1619,7 @@ impl<'a> LocalFunction<'a> {
             local_token: TokenReference::symbol("local ").unwrap(),
             function_token: TokenReference::symbol("function ").unwrap(),
             name,
-            func_body: FunctionBody::new(),
+            body: FunctionBody::new(),
         }
     }
 
@@ -1635,7 +1635,7 @@ impl<'a> LocalFunction<'a> {
 
     /// The function body, everything except `local function x` in `local function x(a, b, c) call() end`
     pub fn body(&self) -> &FunctionBody<'a> {
-        &self.func_body
+        &self.body
     }
 
     /// The name of the function, the `x` part of `local function x() end`
@@ -1665,8 +1665,8 @@ impl<'a> LocalFunction<'a> {
     }
 
     /// Returns a new LocalFunction with the given function body
-    pub fn with_func_body(self, func_body: FunctionBody<'a>) -> Self {
-        Self { func_body, ..self }
+    pub fn with_body(self, body: FunctionBody<'a>) -> Self {
+        Self { body, ..self }
     }
 }
 

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -921,14 +921,14 @@ define_parser!(ParseLocalFunction, LocalFunction<'a>, |_, state| {
     let (state, local_token) = ParseSymbol(Symbol::Local).parse(state)?;
     let (state, function_token) = ParseSymbol(Symbol::Function).parse(state)?;
     let (state, name) = expect!(state, ParseIdentifier.parse(state), "expected name");
-    let (state, func_body) = ParseFunctionBody.parse(state)?;
+    let (state, body) = ParseFunctionBody.parse(state)?;
     Ok((
         state,
         LocalFunction {
             local_token,
             function_token,
             name,
-            func_body,
+            body,
         },
     ))
 });

--- a/full-moon/tests/cases/pass/local-function-1/ast.snap
+++ b/full-moon/tests/cases/pass/local-function-1/ast.snap
@@ -1,7 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/local-function-1
 
 ---
 stmts:
@@ -73,7 +72,7 @@ stmts:
               type: Identifier
               identifier: x
           trailing_trivia: []
-        func_body:
+        body:
           parameters_parentheses:
             tokens:
               - leading_trivia: []

--- a/full-moon/tests/cases/pass/local-function-2/ast.snap
+++ b/full-moon/tests/cases/pass/local-function-2/ast.snap
@@ -1,7 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/local-function-2
 
 ---
 stmts:
@@ -73,7 +72,7 @@ stmts:
               type: Identifier
               identifier: foo
           trailing_trivia: []
-        func_body:
+        body:
           parameters_parentheses:
             tokens:
               - leading_trivia: []
@@ -271,7 +270,7 @@ stmts:
               type: Identifier
               identifier: bar
           trailing_trivia: []
-        func_body:
+        body:
           parameters_parentheses:
             tokens:
               - leading_trivia: []
@@ -428,7 +427,7 @@ stmts:
               type: Identifier
               identifier: baz
           trailing_trivia: []
-        func_body:
+        body:
           parameters_parentheses:
             tokens:
               - leading_trivia: []

--- a/full-moon/tests/cases/pass/multi-line-comments-6/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-6/ast.snap
@@ -1,7 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-comments-6
 
 ---
 stmts:
@@ -73,7 +72,7 @@ stmts:
               type: Identifier
               identifier: x
           trailing_trivia: []
-        func_body:
+        body:
           parameters_parentheses:
             tokens:
               - leading_trivia: []


### PR DESCRIPTION
This was missed off in #146 - `func_body()` was changed to `body()`, but `with_func_body()` was left