### PR TITLE
Add variadic type support and restrict where some types are allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Added support for typing variadic symbols in function parameters under the `roblox` feature flag
+- Added support for the `...T` variadic type annotation under the `roblox` feature flag
+
 ## [0.10.0] - 2021-03-26
 ### Added
 - Added `block.iter_stmts_with_semicolon()` which returns an iterator over tuples containing the statement and an optional semicolon.

--- a/full-moon/src/ast/parser_util.rs
+++ b/full-moon/src/ast/parser_util.rs
@@ -179,6 +179,12 @@ macro_rules! keep_going {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! define_roblox_parser {
+    ($parser:ident, $node:ty, $mock_ty:ty, |_, $state:ident| $body:expr) => {
+        define_parser! {$parser, $node, |_, mut $state: ParserState<'a, 'b>| $body}
+    };
+    ($parser:ident, $node:ty, $mock_ty:ty, |$self:ident, $state:ident| $body:expr) => {
+        define_parser! {$parser, $node, |$self:&$parser, mut $state: ParserState<'a, 'b>| $body}
+    };
     ($parser:ident, $node:ty, $mock_ty:ty, $body:expr) => {
         cfg_if::cfg_if! {
             if #[cfg(feature = "roblox")] {

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -1260,6 +1260,22 @@ cfg_if::cfg_if! {
         #[derive(Clone, Debug, PartialEq)]
         struct ParseTypeInfo;
         define_parser!(ParseTypeInfo, TypeInfo<'a>, |_, state| {
+            if let Ok((state, ellipse)) = ParseSymbol(Symbol::Ellipse).parse(state) {
+                let (state, type_info) = expect!(
+                    state,
+                    ParseTypeInfo.parse(state),
+                    "expected type info after `...`"
+                );
+
+                return Ok((
+                    state,
+                    TypeInfo::Variadic {
+                        ellipse,
+                        type_info: Box::new(type_info),
+                    }
+                ));
+            }
+
             let (mut state, mut base_type) = if let Ok((state, identifier)) = {
                 ParseIdentifier
                     .parse(state)

--- a/full-moon/src/ast/type_visitors.rs
+++ b/full-moon/src/ast/type_visitors.rs
@@ -92,6 +92,10 @@ impl<'a> Visit<'a> for TypeInfo<'a> {
                 ampersand.visit(visitor);
                 right.visit(visitor);
             }
+            TypeInfo::Variadic { ellipse, type_info } => {
+                ellipse.visit(visitor);
+                type_info.visit(visitor);
+            }
         };
         visitor.visit_type_info_end(self);
     }
@@ -226,6 +230,11 @@ impl<'a> VisitMut<'a> for TypeInfo<'a> {
                 left: left.visit_mut(visitor),
                 ampersand: ampersand.visit_mut(visitor),
                 right: right.visit_mut(visitor),
+            },
+
+            TypeInfo::Variadic { ellipse, type_info } => TypeInfo::Variadic {
+                ellipse: ellipse.visit_mut(visitor),
+                type_info: type_info.visit_mut(visitor),
             },
         };
         self = visitor.visit_type_info_end(self);

--- a/full-moon/src/ast/types.rs
+++ b/full-moon/src/ast/types.rs
@@ -167,6 +167,17 @@ pub enum TypeInfo<'a> {
         #[cfg_attr(feature = "serde", serde(borrow))]
         right: Box<TypeInfo<'a>>,
     },
+
+    /// A variadic type: `...number`.
+    #[display(fmt = "{}{}", "ellipse", "type_info")]
+    Variadic {
+        /// The ellipse: `...`.
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        ellipse: TokenReference<'a>,
+        /// The type that is variadic: `number`.
+        #[cfg_attr(feature = "serde", serde(borrow))]
+        type_info: Box<TypeInfo<'a>>,
+    },
 }
 
 /// A subset of TypeInfo that consists of items which can only be used as an index, such as `Foo` and `Foo<Bar>`,

--- a/full-moon/src/ast/visitors.rs
+++ b/full-moon/src/ast/visitors.rs
@@ -321,22 +321,14 @@ impl<'a> VisitMut<'a> for FunctionBody<'a> {
 
         for parameter_pair in self.parameters.into_pairs() {
             let parameter_tuple = parameter_pair.into_tuple();
-            let was_ellipse = matches!(parameter_tuple.0, Parameter::Ellipse(..));
             let parameter = parameter_tuple.0.visit_mut(visitor);
-            let type_specifier = if !was_ellipse {
-                type_specifiers
-                    .next()
-                    .and_then(|type_specifier| type_specifier)
-                    .map(|type_specifier| type_specifier.visit_mut(visitor))
-            } else {
-                None
-            };
 
+            let type_specifier = type_specifiers
+                .next()
+                .and_then(|type_specifier| type_specifier)
+                .map(|type_specifier| type_specifier.visit_mut(visitor));
+            new_type_specifiers.push(type_specifier);
             let punctuation = parameter_tuple.1.visit_mut(visitor);
-
-            if !was_ellipse {
-                new_type_specifiers.push(type_specifier);
-            }
 
             new_parameters.push(Pair::new(parameter, punctuation));
         }

--- a/full-moon/tests/fail_cases.rs
+++ b/full-moon/tests/fail_cases.rs
@@ -41,6 +41,27 @@ fn test_tokenizer_fail_cases() {
 }
 
 #[test]
+#[cfg(feature = "roblox")]
+#[cfg_attr(feature = "no-source-tests", ignore)]
+fn test_roblox_parser_fail_cases() {
+    run_test_folder("./tests/roblox_cases/fail/parser", |path| {
+        let source = fs::read_to_string(path.join("source.lua")).expect("couldn't read source.lua");
+
+        let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
+
+        assert_yaml_snapshot!("tokens", tokens);
+
+        match ast::Ast::from_tokens(tokens) {
+            Ok(_) => panic!("fail case passed for {:?}", path),
+            Err(error) => {
+                println!("error {:#?}", error);
+                assert_yaml_snapshot!("error", error);
+            }
+        }
+    })
+}
+
+#[test]
 #[cfg(feature = "lua52")]
 #[cfg_attr(feature = "no-source-tests", ignore)]
 fn test_lua52_parser_fail_cases() {

--- a/full-moon/tests/roblox_cases/fail/parser/param-types/source.lua
+++ b/full-moon/tests/roblox_cases/fail/parser/param-types/source.lua
@@ -1,0 +1,6 @@
+-- Not allowed tuples or `...type` in params
+function foo(test: (number, number))
+end
+
+function bar(test: ...number)
+end

--- a/full-moon/tests/roblox_cases/fail/parser/param-types/source.lua
+++ b/full-moon/tests/roblox_cases/fail/parser/param-types/source.lua
@@ -1,6 +1,0 @@
--- Not allowed tuples or `...type` in params
-function foo(test: (number, number))
-end
-
-function bar(test: ...number)
-end

--- a/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/error.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/error.snap
@@ -1,0 +1,20 @@
+---
+source: full-moon/tests/fail_cases.rs
+expression: error
+
+---
+UnexpectedToken:
+  token:
+    start_position:
+      bytes: 35
+      line: 1
+      character: 36
+    end_position:
+      bytes: 36
+      line: 1
+      character: 37
+    token_type:
+      type: Symbol
+      symbol: )
+  additional: "expected `->` when parsing function type"
+

--- a/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/source.lua
+++ b/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/source.lua
@@ -1,0 +1,2 @@
+function foo(test: (number, number))
+end

--- a/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/tokens.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/tokens.snap
@@ -1,0 +1,192 @@
+---
+source: full-moon/tests/fail_cases.rs
+expression: tokens
+
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 8
+    line: 1
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: function
+- start_position:
+    bytes: 8
+    line: 1
+    character: 9
+  end_position:
+    bytes: 9
+    line: 1
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 9
+    line: 1
+    character: 10
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: foo
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 13
+    line: 1
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 13
+    line: 1
+    character: 14
+  end_position:
+    bytes: 17
+    line: 1
+    character: 18
+  token_type:
+    type: Identifier
+    identifier: test
+- start_position:
+    bytes: 17
+    line: 1
+    character: 18
+  end_position:
+    bytes: 18
+    line: 1
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 18
+    line: 1
+    character: 19
+  end_position:
+    bytes: 19
+    line: 1
+    character: 20
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 19
+    line: 1
+    character: 20
+  end_position:
+    bytes: 20
+    line: 1
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 20
+    line: 1
+    character: 21
+  end_position:
+    bytes: 26
+    line: 1
+    character: 27
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 26
+    line: 1
+    character: 27
+  end_position:
+    bytes: 27
+    line: 1
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 27
+    line: 1
+    character: 28
+  end_position:
+    bytes: 28
+    line: 1
+    character: 29
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 28
+    line: 1
+    character: 29
+  end_position:
+    bytes: 34
+    line: 1
+    character: 35
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 34
+    line: 1
+    character: 35
+  end_position:
+    bytes: 35
+    line: 1
+    character: 36
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 35
+    line: 1
+    character: 36
+  end_position:
+    bytes: 36
+    line: 1
+    character: 37
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 36
+    line: 1
+    character: 37
+  end_position:
+    bytes: 37
+    line: 1
+    character: 37
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 37
+    line: 2
+    character: 1
+  end_position:
+    bytes: 40
+    line: 2
+    character: 4
+  token_type:
+    type: Symbol
+    symbol: end
+- start_position:
+    bytes: 40
+    line: 2
+    character: 4
+  end_position:
+    bytes: 40
+    line: 2
+    character: 4
+  token_type:
+    type: Eof
+

--- a/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/error.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/error.snap
@@ -1,0 +1,20 @@
+---
+source: full-moon/tests/fail_cases.rs
+expression: error
+
+---
+UnexpectedToken:
+  token:
+    start_position:
+      bytes: 19
+      line: 1
+      character: 20
+    end_position:
+      bytes: 22
+      line: 1
+      character: 23
+    token_type:
+      type: Symbol
+      symbol: "..."
+  additional: expected type after colon
+

--- a/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/source.lua
+++ b/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/source.lua
@@ -1,0 +1,2 @@
+function bar(test: ...number)
+end

--- a/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/tokens.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/tokens.snap
@@ -1,0 +1,159 @@
+---
+source: full-moon/tests/fail_cases.rs
+expression: tokens
+
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 8
+    line: 1
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: function
+- start_position:
+    bytes: 8
+    line: 1
+    character: 9
+  end_position:
+    bytes: 9
+    line: 1
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 9
+    line: 1
+    character: 10
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: bar
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 13
+    line: 1
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 13
+    line: 1
+    character: 14
+  end_position:
+    bytes: 17
+    line: 1
+    character: 18
+  token_type:
+    type: Identifier
+    identifier: test
+- start_position:
+    bytes: 17
+    line: 1
+    character: 18
+  end_position:
+    bytes: 18
+    line: 1
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 18
+    line: 1
+    character: 19
+  end_position:
+    bytes: 19
+    line: 1
+    character: 20
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 19
+    line: 1
+    character: 20
+  end_position:
+    bytes: 22
+    line: 1
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: "..."
+- start_position:
+    bytes: 22
+    line: 1
+    character: 23
+  end_position:
+    bytes: 28
+    line: 1
+    character: 29
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 28
+    line: 1
+    character: 29
+  end_position:
+    bytes: 29
+    line: 1
+    character: 30
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 29
+    line: 1
+    character: 30
+  end_position:
+    bytes: 30
+    line: 1
+    character: 30
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 30
+    line: 2
+    character: 1
+  end_position:
+    bytes: 33
+    line: 2
+    character: 4
+  token_type:
+    type: Symbol
+    symbol: end
+- start_position:
+    bytes: 33
+    line: 2
+    character: 4
+  end_position:
+    bytes: 34
+    line: 2
+    character: 4
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 34
+    line: 3
+    character: 1
+  end_position:
+    bytes: 34
+    line: 3
+    character: 1
+  token_type:
+    type: Eof
+

--- a/full-moon/tests/roblox_cases/pass/no_roblox_syntax/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/no_roblox_syntax/ast.snap
@@ -1,7 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
-input_file: full-moon/tests/roblox_cases/pass/no_roblox_syntax
 
 ---
 stmts:
@@ -1299,7 +1298,8 @@ stmts:
                                   type: Symbol
                                   symbol: "..."
                               trailing_trivia: []
-                    type_specifiers: []
+                    type_specifiers:
+                      - ~
                     block:
                       stmts:
                         - - FunctionCall:

--- a/full-moon/tests/roblox_cases/pass/types/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types/ast.snap
@@ -1,7 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
-input_file: full-moon/tests/roblox_cases/pass/types
 
 ---
 stmts:
@@ -4773,6 +4772,7 @@ stmts:
                       type: Identifier
                       identifier: string
                   trailing_trivia: []
+            - ~
           block:
             stmts: []
           end_token:

--- a/full-moon/tests/roblox_cases/pass/types_variadic/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_variadic/ast.snap
@@ -1,0 +1,415 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+
+---
+stmts:
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 0
+              line: 1
+              character: 1
+            end_position:
+              bytes: 4
+              line: 1
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 4
+                line: 1
+                character: 5
+              end_position:
+                bytes: 5
+                line: 1
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 5
+              line: 1
+              character: 6
+            end_position:
+              bytes: 8
+              line: 1
+              character: 9
+            token_type:
+              type: Identifier
+              identifier: Foo
+          trailing_trivia:
+            - start_position:
+                bytes: 8
+                line: 1
+                character: 9
+              end_position:
+                bytes: 9
+                line: 1
+                character: 10
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 9
+              line: 1
+              character: 10
+            end_position:
+              bytes: 10
+              line: 1
+              character: 11
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 10
+                line: 1
+                character: 11
+              end_position:
+                bytes: 11
+                line: 1
+                character: 12
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Callback:
+            parentheses:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 11
+                      line: 1
+                      character: 12
+                    end_position:
+                      bytes: 12
+                      line: 1
+                      character: 13
+                    token_type:
+                      type: Symbol
+                      symbol: (
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 21
+                      line: 1
+                      character: 22
+                    end_position:
+                      bytes: 22
+                      line: 1
+                      character: 23
+                    token_type:
+                      type: Symbol
+                      symbol: )
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 22
+                        line: 1
+                        character: 23
+                      end_position:
+                        bytes: 23
+                        line: 1
+                        character: 24
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+            arguments:
+              pairs:
+                - End:
+                    Variadic:
+                      ellipse:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 12
+                            line: 1
+                            character: 13
+                          end_position:
+                            bytes: 15
+                            line: 1
+                            character: 16
+                          token_type:
+                            type: Symbol
+                            symbol: "..."
+                        trailing_trivia: []
+                      type_info:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 15
+                              line: 1
+                              character: 16
+                            end_position:
+                              bytes: 21
+                              line: 1
+                              character: 22
+                            token_type:
+                              type: Identifier
+                              identifier: number
+                          trailing_trivia: []
+            arrow:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 23
+                  line: 1
+                  character: 24
+                end_position:
+                  bytes: 25
+                  line: 1
+                  character: 26
+                token_type:
+                  type: Symbol
+                  symbol: "->"
+              trailing_trivia:
+                - start_position:
+                    bytes: 25
+                    line: 1
+                    character: 26
+                  end_position:
+                    bytes: 26
+                    line: 1
+                    character: 27
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            return_type:
+              Tuple:
+                parentheses:
+                  tokens:
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 26
+                          line: 1
+                          character: 27
+                        end_position:
+                          bytes: 27
+                          line: 1
+                          character: 28
+                        token_type:
+                          type: Symbol
+                          symbol: (
+                      trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 27
+                          line: 1
+                          character: 28
+                        end_position:
+                          bytes: 28
+                          line: 1
+                          character: 29
+                        token_type:
+                          type: Symbol
+                          symbol: )
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 28
+                            line: 1
+                            character: 29
+                          end_position:
+                            bytes: 29
+                            line: 1
+                            character: 29
+                          token_type:
+                            type: Whitespace
+                            characters: "\n"
+                types:
+                  pairs: []
+    - ~
+  - - FunctionDeclaration:
+        function_token:
+          leading_trivia:
+            - start_position:
+                bytes: 29
+                line: 2
+                character: 1
+              end_position:
+                bytes: 30
+                line: 2
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 30
+              line: 3
+              character: 1
+            end_position:
+              bytes: 38
+              line: 3
+              character: 9
+            token_type:
+              type: Symbol
+              symbol: function
+          trailing_trivia:
+            - start_position:
+                bytes: 38
+                line: 3
+                character: 9
+              end_position:
+                bytes: 39
+                line: 3
+                character: 10
+              token_type:
+                type: Whitespace
+                characters: " "
+        name:
+          names:
+            pairs:
+              - End:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 39
+                      line: 3
+                      character: 10
+                    end_position:
+                      bytes: 42
+                      line: 3
+                      character: 13
+                    token_type:
+                      type: Identifier
+                      identifier: bar
+                  trailing_trivia: []
+          colon_name: ~
+        body:
+          parameters_parentheses:
+            tokens:
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 42
+                    line: 3
+                    character: 13
+                  end_position:
+                    bytes: 43
+                    line: 3
+                    character: 14
+                  token_type:
+                    type: Symbol
+                    symbol: (
+                trailing_trivia: []
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 54
+                    line: 3
+                    character: 25
+                  end_position:
+                    bytes: 55
+                    line: 3
+                    character: 26
+                  token_type:
+                    type: Symbol
+                    symbol: )
+                trailing_trivia:
+                  - start_position:
+                      bytes: 55
+                      line: 3
+                      character: 26
+                    end_position:
+                      bytes: 56
+                      line: 3
+                      character: 26
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
+          parameters:
+            pairs:
+              - End:
+                  Ellipse:
+                    leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 43
+                        line: 3
+                        character: 14
+                      end_position:
+                        bytes: 46
+                        line: 3
+                        character: 17
+                      token_type:
+                        type: Symbol
+                        symbol: "..."
+                    trailing_trivia: []
+          type_specifiers:
+            - punctuation:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 46
+                    line: 3
+                    character: 17
+                  end_position:
+                    bytes: 47
+                    line: 3
+                    character: 18
+                  token_type:
+                    type: Symbol
+                    symbol: ":"
+                trailing_trivia:
+                  - start_position:
+                      bytes: 47
+                      line: 3
+                      character: 18
+                    end_position:
+                      bytes: 48
+                      line: 3
+                      character: 19
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+              type_info:
+                Basic:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 48
+                      line: 3
+                      character: 19
+                    end_position:
+                      bytes: 54
+                      line: 3
+                      character: 25
+                    token_type:
+                      type: Identifier
+                      identifier: number
+                  trailing_trivia: []
+          block:
+            stmts: []
+          end_token:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 56
+                line: 4
+                character: 1
+              end_position:
+                bytes: 59
+                line: 4
+                character: 4
+              token_type:
+                type: Symbol
+                symbol: end
+            trailing_trivia: []
+    - ~
+

--- a/full-moon/tests/roblox_cases/pass/types_variadic/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_variadic/source.lua
@@ -1,0 +1,4 @@
+type Foo = (...number) -> ()
+
+function foo(...: number)
+end

--- a/full-moon/tests/roblox_cases/pass/types_variadic/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_variadic/source.lua
@@ -1,4 +1,4 @@
 type Foo = (...number) -> ()
 
-function foo(...: number)
+function bar(...: number)
 end

--- a/full-moon/tests/roblox_cases/pass/types_variadic/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_variadic/tokens.snap
@@ -1,0 +1,324 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 4
+    line: 1
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 4
+    line: 1
+    character: 5
+  end_position:
+    bytes: 5
+    line: 1
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 5
+    line: 1
+    character: 6
+  end_position:
+    bytes: 8
+    line: 1
+    character: 9
+  token_type:
+    type: Identifier
+    identifier: Foo
+- start_position:
+    bytes: 8
+    line: 1
+    character: 9
+  end_position:
+    bytes: 9
+    line: 1
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 9
+    line: 1
+    character: 10
+  end_position:
+    bytes: 10
+    line: 1
+    character: 11
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 10
+    line: 1
+    character: 11
+  end_position:
+    bytes: 11
+    line: 1
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 11
+    line: 1
+    character: 12
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 15
+    line: 1
+    character: 16
+  token_type:
+    type: Symbol
+    symbol: "..."
+- start_position:
+    bytes: 15
+    line: 1
+    character: 16
+  end_position:
+    bytes: 21
+    line: 1
+    character: 22
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 21
+    line: 1
+    character: 22
+  end_position:
+    bytes: 22
+    line: 1
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 22
+    line: 1
+    character: 23
+  end_position:
+    bytes: 23
+    line: 1
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 23
+    line: 1
+    character: 24
+  end_position:
+    bytes: 25
+    line: 1
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 25
+    line: 1
+    character: 26
+  end_position:
+    bytes: 26
+    line: 1
+    character: 27
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 26
+    line: 1
+    character: 27
+  end_position:
+    bytes: 27
+    line: 1
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 27
+    line: 1
+    character: 28
+  end_position:
+    bytes: 28
+    line: 1
+    character: 29
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 28
+    line: 1
+    character: 29
+  end_position:
+    bytes: 29
+    line: 1
+    character: 29
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 29
+    line: 2
+    character: 1
+  end_position:
+    bytes: 30
+    line: 2
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 30
+    line: 3
+    character: 1
+  end_position:
+    bytes: 38
+    line: 3
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: function
+- start_position:
+    bytes: 38
+    line: 3
+    character: 9
+  end_position:
+    bytes: 39
+    line: 3
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 39
+    line: 3
+    character: 10
+  end_position:
+    bytes: 42
+    line: 3
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: bar
+- start_position:
+    bytes: 42
+    line: 3
+    character: 13
+  end_position:
+    bytes: 43
+    line: 3
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 43
+    line: 3
+    character: 14
+  end_position:
+    bytes: 46
+    line: 3
+    character: 17
+  token_type:
+    type: Symbol
+    symbol: "..."
+- start_position:
+    bytes: 46
+    line: 3
+    character: 17
+  end_position:
+    bytes: 47
+    line: 3
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 47
+    line: 3
+    character: 18
+  end_position:
+    bytes: 48
+    line: 3
+    character: 19
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 48
+    line: 3
+    character: 19
+  end_position:
+    bytes: 54
+    line: 3
+    character: 25
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 54
+    line: 3
+    character: 25
+  end_position:
+    bytes: 55
+    line: 3
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 55
+    line: 3
+    character: 26
+  end_position:
+    bytes: 56
+    line: 3
+    character: 26
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 56
+    line: 4
+    character: 1
+  end_position:
+    bytes: 59
+    line: 4
+    character: 4
+  token_type:
+    type: Symbol
+    symbol: end
+- start_position:
+    bytes: 59
+    line: 4
+    character: 4
+  end_position:
+    bytes: 59
+    line: 4
+    character: 4
+  token_type:
+    type: Eof
+


### PR DESCRIPTION
Closes #162 

Tuple types are only permitted as the return type of a function (both for function declarations, or for callback type annotations)
Variadic Types are permitted only as a parameter in a callback type annotation, as a return type, or inside of a tuple acting as a return type.
This PR implements these restrictions, and fails parsing otherwise - fail cases have been added to the tests
Fixes #91 