### PR TITLE
Allocate 200% less stack space on debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Switched from using nom to peg for lexing.
 
 ### Fixed
-- full_moon will now allocate a bit less stack space in debug mode. Current consumers may have faced an issue with stack overflows with relatively simple code. The core of this problem has not been fixed yet, but this extremely minor tweak might make some files work again.
+- full_moon will now allocate about 200% less stack space in debug mode.
 
 ## [0.10.0] - 2021-03-26
 ### Added


### PR DESCRIPTION
Before:

https://pastebin.com/6Y86UE7M (202,424 bytes allocated)

After:

https://pastebin.com/nUxmukbz (88,120 bytes allocated)

Used to have an effect on release, but after a recent test doesn't seem to anymore?