### PR TITLE
Replace multi_line with multi_line_depth (non-Option), save 8 bytes per Token. Change unreachable panic on Brackets display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- **[BREAKING CHANGE]** `TokenType::StringLiteral::multi_line` has been replaced with `TokenType::StringLiteral::multi_line_depth`. It serves the same purpose except instead of being an `Option<usize>`, it is now a standard `usize`. It is advised to simply check `quote_type == StringLiteralQuoteType::Brackets` to get the previous behavior.
+- Attempting to display `StringLiteralQuoteType::Brackets` now returns an error rather than being marked as unreachable.
+
 ## [0.11.0] - 2021-05-12
 ### Added
 - Made `TokenizerError` fields accessible through methods

--- a/full-moon/src/ast/owned.rs
+++ b/full-moon/src/ast/owned.rs
@@ -106,11 +106,11 @@ impl Owned for TokenType<'_> {
             },
             TokenType::StringLiteral {
                 literal,
-                multi_line,
+                multi_line_depth,
                 quote_type,
             } => TokenType::StringLiteral {
                 literal: Cow::Owned(literal.clone().into_owned()),
-                multi_line: *multi_line,
+                multi_line_depth: *multi_line_depth,
                 quote_type: *quote_type,
             },
             TokenType::Symbol { symbol } => TokenType::Symbol { symbol: *symbol },

--- a/full-moon/tests/cases/pass/multi-line-string-1/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-1/ast.snap
@@ -104,7 +104,6 @@ stmts:
                       token_type:
                         type: StringLiteral
                         literal: "Full Moon\nis a\nlossless\nLua parser"
-                        multi_line: 0
                         quote_type: Brackets
                     trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-1/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-1/tokens.snap
@@ -81,7 +81,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-1
   token_type:
     type: StringLiteral
     literal: "Full Moon\nis a\nlossless\nLua parser"
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 48

--- a/full-moon/tests/cases/pass/multi-line-string-2/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-2/ast.snap
@@ -104,7 +104,7 @@ stmts:
                       token_type:
                         type: StringLiteral
                         literal: "This is\nseveral equal\nsigns"
-                        multi_line: 1
+                        multi_line_depth: 1
                         quote_type: Brackets
                     trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-2/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-2/tokens.snap
@@ -81,7 +81,7 @@ input_file: full-moon/tests/cases/pass/multi-line-string-2
   token_type:
     type: StringLiteral
     literal: "This is\nseveral equal\nsigns"
-    multi_line: 1
+    multi_line_depth: 1
     quote_type: Brackets
 - start_position:
     bytes: 43

--- a/full-moon/tests/cases/pass/multi-line-string-3/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-3/ast.snap
@@ -104,7 +104,6 @@ stmts:
                       token_type:
                         type: StringLiteral
                         literal: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
-                        multi_line: 0
                         quote_type: Brackets
                     trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-3/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-3/tokens.snap
@@ -81,7 +81,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-3
   token_type:
     type: StringLiteral
     literal: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 154

--- a/full-moon/tests/cases/pass/multi-line-string-4/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-4/ast.snap
@@ -74,7 +74,6 @@ stmts:
                                 token_type:
                                   type: StringLiteral
                                   literal: doge
-                                  multi_line: 0
                                   quote_type: Brackets
                               trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-4/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-4/tokens.snap
@@ -37,7 +37,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-4
   token_type:
     type: StringLiteral
     literal: doge
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 13

--- a/full-moon/tests/cases/pass/multi-line-string-5/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-5/ast.snap
@@ -104,7 +104,6 @@ stmts:
                       token_type:
                         type: StringLiteral
                         literal: 🧓🏽
-                        multi_line: 0
                         quote_type: Brackets
                     trailing_trivia:
                       - start_position:

--- a/full-moon/tests/cases/pass/multi-line-string-5/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-5/tokens.snap
@@ -81,7 +81,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-5
   token_type:
     type: StringLiteral
     literal: 🧓🏽
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 26

--- a/full-moon/tests/visitors.rs
+++ b/full-moon/tests/visitors.rs
@@ -8,7 +8,7 @@ use full_moon::{
 fn test_visitor() {
     struct FunctionCallVisitor {
         called: Vec<String>,
-    };
+    }
 
     impl<'ast> Visitor<'ast> for FunctionCallVisitor {
         fn visit_function_call(&mut self, call: &ast::FunctionCall<'ast>) {
@@ -81,7 +81,7 @@ fn test_visit_token() {
     #[derive(Default)]
     struct CommentVisitor {
         comments: Vec<String>,
-    };
+    }
 
     impl Visitor<'_> for CommentVisitor {
         fn visit_single_line_comment(&mut self, token: &Token<'_>) {


### PR DESCRIPTION
Saves 8 bytes per Token. Stmt turns from 4,072 bytes to 3,872 bytes.

This is going to require a slight change in one part of selene, but this behavior is easily replicatable by checking for BracketType.

Name was changed just to be more clear, the old one was not very good.