### PR TITLE
Fix a single type wrapped in parentheses failing parsing

### DIFF
--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -1409,9 +1409,13 @@ cfg_if::cfg_if! {
                     match this.0 {
                         TypeInfoContext::ReturnType => {},
                         _ => {
-                            if types.len() != 1 {
+                            let num_types_present = types.len();
+                            if num_types_present != 1 {
                                 return Err(InternalAstError::UnexpectedToken {
-                                    token: state.peek().clone(), // TODO: this is pointing to the wrong thing
+                                    token: match num_types_present {
+                                        0 => end_parenthese,
+                                        _ => types.pairs().next().unwrap().punctuation().unwrap().clone(), // A comma after the first type must exist if > 1 types present
+                                    },
                                     additional: Some("tuples are only permitted as a return type"),
                                 });
                             };

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -1406,15 +1406,20 @@ cfg_if::cfg_if! {
                     // Tuples are only permitted as the return type of a function
                     // However, if we just have a single type wrapped around in parentheses, its not really a tuple - this is allowed anywhere.
 
+                    // Check our current context to see if tuples are allowed
                     match this.0 {
                         TypeInfoContext::ReturnType => {},
                         _ => {
+                            // We aren't in a return type context, so tuples aren't allowed here
+                            // If we have only one type wrapped in parentheses, then it is OK. Otherwise, we must fail
                             let num_types_present = types.len();
                             if num_types_present != 1 {
                                 return Err(InternalAstError::UnexpectedToken {
+                                    // We have already consumed relevant tokens in state. We will set the token error
+                                    // to a useful token.
                                     token: match num_types_present {
                                         0 => end_parenthese,
-                                        _ => types.pairs().next().unwrap().punctuation().unwrap().clone(), // A comma after the first type must exist if > 1 types present
+                                        _ => types.pairs().next().expect("no types present even though we have >1 types").punctuation().expect("no comma on first type in tuple even though we have >1 types").clone(),
                                     },
                                     additional: Some("tuples are only permitted as a return type"),
                                 });

--- a/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/error.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/error.snap
@@ -6,15 +6,15 @@ expression: error
 UnexpectedToken:
   token:
     start_position:
-      bytes: 35
+      bytes: 26
       line: 1
-      character: 36
+      character: 27
     end_position:
-      bytes: 36
+      bytes: 27
       line: 1
-      character: 37
+      character: 28
     token_type:
       type: Symbol
-      symbol: )
+      symbol: ","
   additional: tuples are only permitted as a return type
 

--- a/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/error.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/error.snap
@@ -16,5 +16,5 @@ UnexpectedToken:
     token_type:
       type: Symbol
       symbol: )
-  additional: "expected `->` when parsing function type"
+  additional: tuples are only permitted as a return type
 

--- a/full-moon/tests/roblox_cases/pass/aa/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/aa/ast.snap
@@ -1,0 +1,2471 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+
+---
+stmts:
+  - - FunctionDeclaration:
+        function_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 0
+              line: 1
+              character: 1
+            end_position:
+              bytes: 8
+              line: 1
+              character: 9
+            token_type:
+              type: Symbol
+              symbol: function
+          trailing_trivia:
+            - start_position:
+                bytes: 8
+                line: 1
+                character: 9
+              end_position:
+                bytes: 9
+                line: 1
+                character: 10
+              token_type:
+                type: Whitespace
+                characters: " "
+        name:
+          names:
+            pairs:
+              - Punctuated:
+                  - leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 9
+                        line: 1
+                        character: 10
+                      end_position:
+                        bytes: 17
+                        line: 1
+                        character: 18
+                      token_type:
+                        type: Identifier
+                        identifier: TypeInfo
+                    trailing_trivia: []
+                  - leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 17
+                        line: 1
+                        character: 18
+                      end_position:
+                        bytes: 18
+                        line: 1
+                        character: 19
+                      token_type:
+                        type: Symbol
+                        symbol: "."
+                    trailing_trivia: []
+              - End:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 18
+                      line: 1
+                      character: 19
+                    end_position:
+                      bytes: 21
+                      line: 1
+                      character: 22
+                    token_type:
+                      type: Identifier
+                      identifier: new
+                  trailing_trivia: []
+          colon_name: ~
+        body:
+          parameters_parentheses:
+            tokens:
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 21
+                    line: 1
+                    character: 22
+                  end_position:
+                    bytes: 22
+                    line: 1
+                    character: 23
+                  token_type:
+                    type: Symbol
+                    symbol: (
+                trailing_trivia:
+                  - start_position:
+                      bytes: 22
+                      line: 1
+                      character: 23
+                    end_position:
+                      bytes: 23
+                      line: 1
+                      character: 23
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 66
+                    line: 3
+                    character: 1
+                  end_position:
+                    bytes: 67
+                    line: 3
+                    character: 2
+                  token_type:
+                    type: Symbol
+                    symbol: )
+                trailing_trivia:
+                  - start_position:
+                      bytes: 67
+                      line: 3
+                      character: 2
+                    end_position:
+                      bytes: 68
+                      line: 3
+                      character: 2
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
+          parameters:
+            pairs:
+              - End:
+                  Name:
+                    leading_trivia:
+                      - start_position:
+                          bytes: 23
+                          line: 2
+                          character: 1
+                        end_position:
+                          bytes: 24
+                          line: 2
+                          character: 2
+                        token_type:
+                          type: Whitespace
+                          characters: "\t"
+                    token:
+                      start_position:
+                        bytes: 24
+                        line: 2
+                        character: 2
+                      end_position:
+                        bytes: 37
+                        line: 2
+                        character: 15
+                      token_type:
+                        type: Identifier
+                        identifier: getFieldDefFn
+                    trailing_trivia: []
+          type_specifiers:
+            - punctuation:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 37
+                    line: 2
+                    character: 15
+                  end_position:
+                    bytes: 38
+                    line: 2
+                    character: 16
+                  token_type:
+                    type: Symbol
+                    symbol: ":"
+                trailing_trivia:
+                  - start_position:
+                      bytes: 38
+                      line: 2
+                      character: 16
+                    end_position:
+                      bytes: 39
+                      line: 2
+                      character: 17
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+              type_info:
+                Optional:
+                  base:
+                    Tuple:
+                      parentheses:
+                        tokens:
+                          - leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 39
+                                line: 2
+                                character: 17
+                              end_position:
+                                bytes: 40
+                                line: 2
+                                character: 18
+                              token_type:
+                                type: Symbol
+                                symbol: (
+                            trailing_trivia: []
+                          - leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 63
+                                line: 2
+                                character: 41
+                              end_position:
+                                bytes: 64
+                                line: 2
+                                character: 42
+                              token_type:
+                                type: Symbol
+                                symbol: )
+                            trailing_trivia: []
+                      types:
+                        pairs:
+                          - End:
+                              Callback:
+                                parentheses:
+                                  tokens:
+                                    - leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 40
+                                          line: 2
+                                          character: 18
+                                        end_position:
+                                          bytes: 41
+                                          line: 2
+                                          character: 19
+                                        token_type:
+                                          type: Symbol
+                                          symbol: (
+                                      trailing_trivia: []
+                                    - leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 41
+                                          line: 2
+                                          character: 19
+                                        end_position:
+                                          bytes: 42
+                                          line: 2
+                                          character: 20
+                                        token_type:
+                                          type: Symbol
+                                          symbol: )
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 42
+                                            line: 2
+                                            character: 20
+                                          end_position:
+                                            bytes: 43
+                                            line: 2
+                                            character: 21
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                arguments:
+                                  pairs: []
+                                arrow:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 43
+                                      line: 2
+                                      character: 21
+                                    end_position:
+                                      bytes: 45
+                                      line: 2
+                                      character: 23
+                                    token_type:
+                                      type: Symbol
+                                      symbol: "->"
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 45
+                                        line: 2
+                                        character: 23
+                                      end_position:
+                                        bytes: 46
+                                        line: 2
+                                        character: 24
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                                return_type:
+                                  Optional:
+                                    base:
+                                      Generic:
+                                        base:
+                                          leading_trivia: []
+                                          token:
+                                            start_position:
+                                              bytes: 46
+                                              line: 2
+                                              character: 24
+                                            end_position:
+                                              bytes: 52
+                                              line: 2
+                                              character: 30
+                                            token_type:
+                                              type: Identifier
+                                              identifier: GField
+                                          trailing_trivia: []
+                                        arrows:
+                                          tokens:
+                                            - leading_trivia: []
+                                              token:
+                                                start_position:
+                                                  bytes: 52
+                                                  line: 2
+                                                  character: 30
+                                                end_position:
+                                                  bytes: 53
+                                                  line: 2
+                                                  character: 31
+                                                token_type:
+                                                  type: Symbol
+                                                  symbol: "<"
+                                              trailing_trivia: []
+                                            - leading_trivia: []
+                                              token:
+                                                start_position:
+                                                  bytes: 61
+                                                  line: 2
+                                                  character: 39
+                                                end_position:
+                                                  bytes: 62
+                                                  line: 2
+                                                  character: 40
+                                                token_type:
+                                                  type: Symbol
+                                                  symbol: ">"
+                                              trailing_trivia: []
+                                        generics:
+                                          pairs:
+                                            - Punctuated:
+                                                - Basic:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 53
+                                                        line: 2
+                                                        character: 31
+                                                      end_position:
+                                                        bytes: 56
+                                                        line: 2
+                                                        character: 34
+                                                      token_type:
+                                                        type: Identifier
+                                                        identifier: any
+                                                    trailing_trivia: []
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 56
+                                                      line: 2
+                                                      character: 34
+                                                    end_position:
+                                                      bytes: 57
+                                                      line: 2
+                                                      character: 35
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: ","
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 57
+                                                        line: 2
+                                                        character: 35
+                                                      end_position:
+                                                        bytes: 58
+                                                        line: 2
+                                                        character: 36
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: " "
+                                            - End:
+                                                Basic:
+                                                  leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 58
+                                                      line: 2
+                                                      character: 36
+                                                    end_position:
+                                                      bytes: 61
+                                                      line: 2
+                                                      character: 39
+                                                    token_type:
+                                                      type: Identifier
+                                                      identifier: any
+                                                  trailing_trivia: []
+                                    question_mark:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 62
+                                          line: 2
+                                          character: 40
+                                        end_position:
+                                          bytes: 63
+                                          line: 2
+                                          character: 41
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "?"
+                                      trailing_trivia: []
+                  question_mark:
+                    leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 64
+                        line: 2
+                        character: 42
+                      end_position:
+                        bytes: 65
+                        line: 2
+                        character: 43
+                      token_type:
+                        type: Symbol
+                        symbol: "?"
+                    trailing_trivia:
+                      - start_position:
+                          bytes: 65
+                          line: 2
+                          character: 43
+                        end_position:
+                          bytes: 66
+                          line: 2
+                          character: 43
+                        token_type:
+                          type: Whitespace
+                          characters: "\n"
+          block:
+            stmts: []
+          end_token:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 68
+                line: 4
+                character: 1
+              end_position:
+                bytes: 71
+                line: 4
+                character: 4
+              token_type:
+                type: Symbol
+                symbol: end
+            trailing_trivia:
+              - start_position:
+                  bytes: 71
+                  line: 4
+                  character: 4
+                end_position:
+                  bytes: 72
+                  line: 4
+                  character: 4
+                token_type:
+                  type: Whitespace
+                  characters: "\n"
+    - ~
+  - - ExportedTypeDeclaration:
+        export_token:
+          leading_trivia:
+            - start_position:
+                bytes: 72
+                line: 5
+                character: 1
+              end_position:
+                bytes: 73
+                line: 5
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 73
+              line: 6
+              character: 1
+            end_position:
+              bytes: 79
+              line: 6
+              character: 7
+            token_type:
+              type: Identifier
+              identifier: export
+          trailing_trivia:
+            - start_position:
+                bytes: 79
+                line: 6
+                character: 7
+              end_position:
+                bytes: 80
+                line: 6
+                character: 8
+              token_type:
+                type: Whitespace
+                characters: " "
+        type_declaration:
+          type_token:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 80
+                line: 6
+                character: 8
+              end_position:
+                bytes: 84
+                line: 6
+                character: 12
+              token_type:
+                type: Identifier
+                identifier: type
+            trailing_trivia:
+              - start_position:
+                  bytes: 84
+                  line: 6
+                  character: 12
+                end_position:
+                  bytes: 85
+                  line: 6
+                  character: 13
+                token_type:
+                  type: Whitespace
+                  characters: " "
+          base:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 85
+                line: 6
+                character: 13
+              end_position:
+                bytes: 90
+                line: 6
+                character: 18
+              token_type:
+                type: Identifier
+                identifier: Thunk
+            trailing_trivia: []
+          generics:
+            arrows:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 90
+                      line: 6
+                      character: 18
+                    end_position:
+                      bytes: 91
+                      line: 6
+                      character: 19
+                    token_type:
+                      type: Symbol
+                      symbol: "<"
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 92
+                      line: 6
+                      character: 20
+                    end_position:
+                      bytes: 93
+                      line: 6
+                      character: 21
+                    token_type:
+                      type: Symbol
+                      symbol: ">"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 93
+                        line: 6
+                        character: 21
+                      end_position:
+                        bytes: 94
+                        line: 6
+                        character: 22
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+            generics:
+              pairs:
+                - End:
+                    leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 91
+                        line: 6
+                        character: 19
+                      end_position:
+                        bytes: 92
+                        line: 6
+                        character: 20
+                      token_type:
+                        type: Identifier
+                        identifier: T
+                    trailing_trivia: []
+          equal_token:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 94
+                line: 6
+                character: 22
+              end_position:
+                bytes: 95
+                line: 6
+                character: 23
+              token_type:
+                type: Symbol
+                symbol: "="
+            trailing_trivia:
+              - start_position:
+                  bytes: 95
+                  line: 6
+                  character: 23
+                end_position:
+                  bytes: 96
+                  line: 6
+                  character: 24
+                token_type:
+                  type: Whitespace
+                  characters: " "
+          declare_as:
+            Union:
+              left:
+                Tuple:
+                  parentheses:
+                    tokens:
+                      - leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 96
+                            line: 6
+                            character: 24
+                          end_position:
+                            bytes: 97
+                            line: 6
+                            character: 25
+                          token_type:
+                            type: Symbol
+                            symbol: (
+                        trailing_trivia: []
+                      - leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 104
+                            line: 6
+                            character: 32
+                          end_position:
+                            bytes: 105
+                            line: 6
+                            character: 33
+                          token_type:
+                            type: Symbol
+                            symbol: )
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 105
+                              line: 6
+                              character: 33
+                            end_position:
+                              bytes: 106
+                              line: 6
+                              character: 34
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                  types:
+                    pairs:
+                      - End:
+                          Callback:
+                            parentheses:
+                              tokens:
+                                - leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 97
+                                      line: 6
+                                      character: 25
+                                    end_position:
+                                      bytes: 98
+                                      line: 6
+                                      character: 26
+                                    token_type:
+                                      type: Symbol
+                                      symbol: (
+                                  trailing_trivia: []
+                                - leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 98
+                                      line: 6
+                                      character: 26
+                                    end_position:
+                                      bytes: 99
+                                      line: 6
+                                      character: 27
+                                    token_type:
+                                      type: Symbol
+                                      symbol: )
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 99
+                                        line: 6
+                                        character: 27
+                                      end_position:
+                                        bytes: 100
+                                        line: 6
+                                        character: 28
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                            arguments:
+                              pairs: []
+                            arrow:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 100
+                                  line: 6
+                                  character: 28
+                                end_position:
+                                  bytes: 102
+                                  line: 6
+                                  character: 30
+                                token_type:
+                                  type: Symbol
+                                  symbol: "->"
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 102
+                                    line: 6
+                                    character: 30
+                                  end_position:
+                                    bytes: 103
+                                    line: 6
+                                    character: 31
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                            return_type:
+                              Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 103
+                                    line: 6
+                                    character: 31
+                                  end_position:
+                                    bytes: 104
+                                    line: 6
+                                    character: 32
+                                  token_type:
+                                    type: Identifier
+                                    identifier: T
+                                trailing_trivia: []
+              pipe:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 106
+                    line: 6
+                    character: 34
+                  end_position:
+                    bytes: 107
+                    line: 6
+                    character: 35
+                  token_type:
+                    type: Symbol
+                    symbol: "|"
+                trailing_trivia:
+                  - start_position:
+                      bytes: 107
+                      line: 6
+                      character: 35
+                    end_position:
+                      bytes: 108
+                      line: 6
+                      character: 36
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+              right:
+                Basic:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 108
+                      line: 6
+                      character: 36
+                    end_position:
+                      bytes: 109
+                      line: 6
+                      character: 37
+                    token_type:
+                      type: Identifier
+                      identifier: T
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 109
+                        line: 6
+                        character: 37
+                      end_position:
+                        bytes: 110
+                        line: 6
+                        character: 37
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+    - ~
+  - - ExportedTypeDeclaration:
+        export_token:
+          leading_trivia:
+            - start_position:
+                bytes: 110
+                line: 7
+                character: 1
+              end_position:
+                bytes: 111
+                line: 7
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 111
+              line: 8
+              character: 1
+            end_position:
+              bytes: 117
+              line: 8
+              character: 7
+            token_type:
+              type: Identifier
+              identifier: export
+          trailing_trivia:
+            - start_position:
+                bytes: 117
+                line: 8
+                character: 7
+              end_position:
+                bytes: 118
+                line: 8
+                character: 8
+              token_type:
+                type: Whitespace
+                characters: " "
+        type_declaration:
+          type_token:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 118
+                line: 8
+                character: 8
+              end_position:
+                bytes: 122
+                line: 8
+                character: 12
+              token_type:
+                type: Identifier
+                identifier: type
+            trailing_trivia:
+              - start_position:
+                  bytes: 122
+                  line: 8
+                  character: 12
+                end_position:
+                  bytes: 123
+                  line: 8
+                  character: 13
+                token_type:
+                  type: Whitespace
+                  characters: " "
+          base:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 123
+                line: 8
+                character: 13
+              end_position:
+                bytes: 134
+                line: 8
+                character: 24
+              token_type:
+                type: Identifier
+                identifier: PromiseLike
+            trailing_trivia: []
+          generics:
+            arrows:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 134
+                      line: 8
+                      character: 24
+                    end_position:
+                      bytes: 135
+                      line: 8
+                      character: 25
+                    token_type:
+                      type: Symbol
+                      symbol: "<"
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 136
+                      line: 8
+                      character: 26
+                    end_position:
+                      bytes: 137
+                      line: 8
+                      character: 27
+                    token_type:
+                      type: Symbol
+                      symbol: ">"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 137
+                        line: 8
+                        character: 27
+                      end_position:
+                        bytes: 138
+                        line: 8
+                        character: 28
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+            generics:
+              pairs:
+                - End:
+                    leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 135
+                        line: 8
+                        character: 25
+                      end_position:
+                        bytes: 136
+                        line: 8
+                        character: 26
+                      token_type:
+                        type: Identifier
+                        identifier: T
+                    trailing_trivia: []
+          equal_token:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 138
+                line: 8
+                character: 28
+              end_position:
+                bytes: 139
+                line: 8
+                character: 29
+              token_type:
+                type: Symbol
+                symbol: "="
+            trailing_trivia:
+              - start_position:
+                  bytes: 139
+                  line: 8
+                  character: 29
+                end_position:
+                  bytes: 140
+                  line: 8
+                  character: 30
+                token_type:
+                  type: Whitespace
+                  characters: " "
+          declare_as:
+            Table:
+              braces:
+                tokens:
+                  - leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 140
+                        line: 8
+                        character: 30
+                      end_position:
+                        bytes: 141
+                        line: 8
+                        character: 31
+                      token_type:
+                        type: Symbol
+                        symbol: "{"
+                    trailing_trivia:
+                      - start_position:
+                          bytes: 141
+                          line: 8
+                          character: 31
+                        end_position:
+                          bytes: 142
+                          line: 8
+                          character: 31
+                        token_type:
+                          type: Whitespace
+                          characters: "\n"
+                  - leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 303
+                        line: 13
+                        character: 1
+                      end_position:
+                        bytes: 304
+                        line: 13
+                        character: 2
+                      token_type:
+                        type: Symbol
+                        symbol: "}"
+                    trailing_trivia:
+                      - start_position:
+                          bytes: 304
+                          line: 13
+                          character: 2
+                        end_position:
+                          bytes: 305
+                          line: 13
+                          character: 2
+                        token_type:
+                          type: Whitespace
+                          characters: "\n"
+              fields:
+                pairs:
+                  - End:
+                      key:
+                        Name:
+                          leading_trivia:
+                            - start_position:
+                                bytes: 142
+                                line: 9
+                                character: 1
+                              end_position:
+                                bytes: 146
+                                line: 9
+                                character: 5
+                              token_type:
+                                type: Whitespace
+                                characters: "    "
+                          token:
+                            start_position:
+                              bytes: 146
+                              line: 9
+                              character: 5
+                            end_position:
+                              bytes: 153
+                              line: 9
+                              character: 12
+                            token_type:
+                              type: Identifier
+                              identifier: andThen
+                          trailing_trivia: []
+                      colon:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 153
+                            line: 9
+                            character: 12
+                          end_position:
+                            bytes: 154
+                            line: 9
+                            character: 13
+                          token_type:
+                            type: Symbol
+                            symbol: ":"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 154
+                              line: 9
+                              character: 13
+                            end_position:
+                              bytes: 155
+                              line: 9
+                              character: 14
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      value:
+                        Callback:
+                          parentheses:
+                            tokens:
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 155
+                                    line: 9
+                                    character: 14
+                                  end_position:
+                                    bytes: 156
+                                    line: 9
+                                    character: 15
+                                  token_type:
+                                    type: Symbol
+                                    symbol: (
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 156
+                                      line: 9
+                                      character: 15
+                                    end_position:
+                                      bytes: 157
+                                      line: 9
+                                      character: 15
+                                    token_type:
+                                      type: Whitespace
+                                      characters: "\n"
+                              - leading_trivia:
+                                  - start_position:
+                                      bytes: 275
+                                      line: 12
+                                      character: 1
+                                    end_position:
+                                      bytes: 283
+                                      line: 12
+                                      character: 9
+                                    token_type:
+                                      type: Whitespace
+                                      characters: "        "
+                                token:
+                                  start_position:
+                                    bytes: 283
+                                    line: 12
+                                    character: 9
+                                  end_position:
+                                    bytes: 284
+                                    line: 12
+                                    character: 10
+                                  token_type:
+                                    type: Symbol
+                                    symbol: )
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 284
+                                      line: 12
+                                      character: 10
+                                    end_position:
+                                      bytes: 285
+                                      line: 12
+                                      character: 11
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                          arguments:
+                            pairs:
+                              - Punctuated:
+                                  - Union:
+                                      left:
+                                        Optional:
+                                          base:
+                                            Tuple:
+                                              parentheses:
+                                                tokens:
+                                                  - leading_trivia:
+                                                      - start_position:
+                                                          bytes: 157
+                                                          line: 10
+                                                          character: 1
+                                                        end_position:
+                                                          bytes: 173
+                                                          line: 10
+                                                          character: 17
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: "                "
+                                                    token:
+                                                      start_position:
+                                                        bytes: 173
+                                                        line: 10
+                                                        character: 17
+                                                      end_position:
+                                                        bytes: 174
+                                                        line: 10
+                                                        character: 18
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: (
+                                                    trailing_trivia: []
+                                                  - leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 182
+                                                        line: 10
+                                                        character: 26
+                                                      end_position:
+                                                        bytes: 183
+                                                        line: 10
+                                                        character: 27
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: )
+                                                    trailing_trivia: []
+                                              types:
+                                                pairs:
+                                                  - End:
+                                                      Callback:
+                                                        parentheses:
+                                                          tokens:
+                                                            - leading_trivia: []
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 174
+                                                                  line: 10
+                                                                  character: 18
+                                                                end_position:
+                                                                  bytes: 175
+                                                                  line: 10
+                                                                  character: 19
+                                                                token_type:
+                                                                  type: Symbol
+                                                                  symbol: (
+                                                              trailing_trivia: []
+                                                            - leading_trivia: []
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 176
+                                                                  line: 10
+                                                                  character: 20
+                                                                end_position:
+                                                                  bytes: 177
+                                                                  line: 10
+                                                                  character: 21
+                                                                token_type:
+                                                                  type: Symbol
+                                                                  symbol: )
+                                                              trailing_trivia:
+                                                                - start_position:
+                                                                    bytes: 177
+                                                                    line: 10
+                                                                    character: 21
+                                                                  end_position:
+                                                                    bytes: 178
+                                                                    line: 10
+                                                                    character: 22
+                                                                  token_type:
+                                                                    type: Whitespace
+                                                                    characters: " "
+                                                        arguments:
+                                                          pairs:
+                                                            - End:
+                                                                Basic:
+                                                                  leading_trivia: []
+                                                                  token:
+                                                                    start_position:
+                                                                      bytes: 175
+                                                                      line: 10
+                                                                      character: 19
+                                                                    end_position:
+                                                                      bytes: 176
+                                                                      line: 10
+                                                                      character: 20
+                                                                    token_type:
+                                                                      type: Identifier
+                                                                      identifier: T
+                                                                  trailing_trivia: []
+                                                        arrow:
+                                                          leading_trivia: []
+                                                          token:
+                                                            start_position:
+                                                              bytes: 178
+                                                              line: 10
+                                                              character: 22
+                                                            end_position:
+                                                              bytes: 180
+                                                              line: 10
+                                                              character: 24
+                                                            token_type:
+                                                              type: Symbol
+                                                              symbol: "->"
+                                                          trailing_trivia:
+                                                            - start_position:
+                                                                bytes: 180
+                                                                line: 10
+                                                                character: 24
+                                                              end_position:
+                                                                bytes: 181
+                                                                line: 10
+                                                                character: 25
+                                                              token_type:
+                                                                type: Whitespace
+                                                                characters: " "
+                                                        return_type:
+                                                          Basic:
+                                                            leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 181
+                                                                line: 10
+                                                                character: 25
+                                                              end_position:
+                                                                bytes: 182
+                                                                line: 10
+                                                                character: 26
+                                                              token_type:
+                                                                type: Identifier
+                                                                identifier: T
+                                                            trailing_trivia: []
+                                          question_mark:
+                                            leading_trivia: []
+                                            token:
+                                              start_position:
+                                                bytes: 183
+                                                line: 10
+                                                character: 27
+                                              end_position:
+                                                bytes: 184
+                                                line: 10
+                                                character: 28
+                                              token_type:
+                                                type: Symbol
+                                                symbol: "?"
+                                            trailing_trivia:
+                                              - start_position:
+                                                  bytes: 184
+                                                  line: 10
+                                                  character: 28
+                                                end_position:
+                                                  bytes: 185
+                                                  line: 10
+                                                  character: 29
+                                                token_type:
+                                                  type: Whitespace
+                                                  characters: " "
+                                      pipe:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 185
+                                            line: 10
+                                            character: 29
+                                          end_position:
+                                            bytes: 186
+                                            line: 10
+                                            character: 30
+                                          token_type:
+                                            type: Symbol
+                                            symbol: "|"
+                                        trailing_trivia:
+                                          - start_position:
+                                              bytes: 186
+                                              line: 10
+                                              character: 30
+                                            end_position:
+                                              bytes: 187
+                                              line: 10
+                                              character: 31
+                                            token_type:
+                                              type: Whitespace
+                                              characters: " "
+                                      right:
+                                        Optional:
+                                          base:
+                                            Tuple:
+                                              parentheses:
+                                                tokens:
+                                                  - leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 187
+                                                        line: 10
+                                                        character: 31
+                                                      end_position:
+                                                        bytes: 188
+                                                        line: 10
+                                                        character: 32
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: (
+                                                    trailing_trivia: []
+                                                  - leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 202
+                                                        line: 10
+                                                        character: 46
+                                                      end_position:
+                                                        bytes: 203
+                                                        line: 10
+                                                        character: 47
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: )
+                                                    trailing_trivia: []
+                                              types:
+                                                pairs:
+                                                  - End:
+                                                      Generic:
+                                                        base:
+                                                          leading_trivia: []
+                                                          token:
+                                                            start_position:
+                                                              bytes: 188
+                                                              line: 10
+                                                              character: 32
+                                                            end_position:
+                                                              bytes: 199
+                                                              line: 10
+                                                              character: 43
+                                                            token_type:
+                                                              type: Identifier
+                                                              identifier: PromiseLike
+                                                          trailing_trivia: []
+                                                        arrows:
+                                                          tokens:
+                                                            - leading_trivia: []
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 199
+                                                                  line: 10
+                                                                  character: 43
+                                                                end_position:
+                                                                  bytes: 200
+                                                                  line: 10
+                                                                  character: 44
+                                                                token_type:
+                                                                  type: Symbol
+                                                                  symbol: "<"
+                                                              trailing_trivia: []
+                                                            - leading_trivia: []
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 201
+                                                                  line: 10
+                                                                  character: 45
+                                                                end_position:
+                                                                  bytes: 202
+                                                                  line: 10
+                                                                  character: 46
+                                                                token_type:
+                                                                  type: Symbol
+                                                                  symbol: ">"
+                                                              trailing_trivia: []
+                                                        generics:
+                                                          pairs:
+                                                            - End:
+                                                                Basic:
+                                                                  leading_trivia: []
+                                                                  token:
+                                                                    start_position:
+                                                                      bytes: 200
+                                                                      line: 10
+                                                                      character: 44
+                                                                    end_position:
+                                                                      bytes: 201
+                                                                      line: 10
+                                                                      character: 45
+                                                                    token_type:
+                                                                      type: Identifier
+                                                                      identifier: T
+                                                                  trailing_trivia: []
+                                          question_mark:
+                                            leading_trivia: []
+                                            token:
+                                              start_position:
+                                                bytes: 203
+                                                line: 10
+                                                character: 47
+                                              end_position:
+                                                bytes: 204
+                                                line: 10
+                                                character: 48
+                                              token_type:
+                                                type: Symbol
+                                                symbol: "?"
+                                            trailing_trivia: []
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 204
+                                        line: 10
+                                        character: 48
+                                      end_position:
+                                        bytes: 205
+                                        line: 10
+                                        character: 49
+                                      token_type:
+                                        type: Symbol
+                                        symbol: ","
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 205
+                                          line: 10
+                                          character: 49
+                                        end_position:
+                                          bytes: 206
+                                          line: 10
+                                          character: 50
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                                      - start_position:
+                                          bytes: 206
+                                          line: 10
+                                          character: 50
+                                        end_position:
+                                          bytes: 216
+                                          line: 10
+                                          character: 60
+                                        token_type:
+                                          type: SingleLineComment
+                                          comment: " resolve"
+                                      - start_position:
+                                          bytes: 216
+                                          line: 10
+                                          character: 60
+                                        end_position:
+                                          bytes: 217
+                                          line: 10
+                                          character: 60
+                                        token_type:
+                                          type: Whitespace
+                                          characters: "\n"
+                              - End:
+                                  Optional:
+                                    base:
+                                      Tuple:
+                                        parentheses:
+                                          tokens:
+                                            - leading_trivia:
+                                                - start_position:
+                                                    bytes: 217
+                                                    line: 11
+                                                    character: 1
+                                                  end_position:
+                                                    bytes: 233
+                                                    line: 11
+                                                    character: 17
+                                                  token_type:
+                                                    type: Whitespace
+                                                    characters: "                "
+                                              token:
+                                                start_position:
+                                                  bytes: 233
+                                                  line: 11
+                                                  character: 17
+                                                end_position:
+                                                  bytes: 234
+                                                  line: 11
+                                                  character: 18
+                                                token_type:
+                                                  type: Symbol
+                                                  symbol: (
+                                              trailing_trivia: []
+                                            - leading_trivia: []
+                                              token:
+                                                start_position:
+                                                  bytes: 262
+                                                  line: 11
+                                                  character: 46
+                                                end_position:
+                                                  bytes: 263
+                                                  line: 11
+                                                  character: 47
+                                                token_type:
+                                                  type: Symbol
+                                                  symbol: )
+                                              trailing_trivia: []
+                                        types:
+                                          pairs:
+                                            - End:
+                                                Callback:
+                                                  parentheses:
+                                                    tokens:
+                                                      - leading_trivia: []
+                                                        token:
+                                                          start_position:
+                                                            bytes: 234
+                                                            line: 11
+                                                            character: 18
+                                                          end_position:
+                                                            bytes: 235
+                                                            line: 11
+                                                            character: 19
+                                                          token_type:
+                                                            type: Symbol
+                                                            symbol: (
+                                                        trailing_trivia: []
+                                                      - leading_trivia: []
+                                                        token:
+                                                          start_position:
+                                                            bytes: 238
+                                                            line: 11
+                                                            character: 22
+                                                          end_position:
+                                                            bytes: 239
+                                                            line: 11
+                                                            character: 23
+                                                          token_type:
+                                                            type: Symbol
+                                                            symbol: )
+                                                        trailing_trivia:
+                                                          - start_position:
+                                                              bytes: 239
+                                                              line: 11
+                                                              character: 23
+                                                            end_position:
+                                                              bytes: 240
+                                                              line: 11
+                                                              character: 24
+                                                            token_type:
+                                                              type: Whitespace
+                                                              characters: " "
+                                                  arguments:
+                                                    pairs:
+                                                      - End:
+                                                          Basic:
+                                                            leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 235
+                                                                line: 11
+                                                                character: 19
+                                                              end_position:
+                                                                bytes: 238
+                                                                line: 11
+                                                                character: 22
+                                                              token_type:
+                                                                type: Identifier
+                                                                identifier: any
+                                                            trailing_trivia: []
+                                                  arrow:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 240
+                                                        line: 11
+                                                        character: 24
+                                                      end_position:
+                                                        bytes: 242
+                                                        line: 11
+                                                        character: 26
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: "->"
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 242
+                                                          line: 11
+                                                          character: 26
+                                                        end_position:
+                                                          bytes: 243
+                                                          line: 11
+                                                          character: 27
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                                  return_type:
+                                                    Union:
+                                                      left:
+                                                        Tuple:
+                                                          parentheses:
+                                                            tokens:
+                                                              - leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 243
+                                                                    line: 11
+                                                                    character: 27
+                                                                  end_position:
+                                                                    bytes: 244
+                                                                    line: 11
+                                                                    character: 28
+                                                                  token_type:
+                                                                    type: Symbol
+                                                                    symbol: (
+                                                                trailing_trivia: []
+                                                              - leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 244
+                                                                    line: 11
+                                                                    character: 28
+                                                                  end_position:
+                                                                    bytes: 245
+                                                                    line: 11
+                                                                    character: 29
+                                                                  token_type:
+                                                                    type: Symbol
+                                                                    symbol: )
+                                                                trailing_trivia:
+                                                                  - start_position:
+                                                                      bytes: 245
+                                                                      line: 11
+                                                                      character: 29
+                                                                    end_position:
+                                                                      bytes: 246
+                                                                      line: 11
+                                                                      character: 30
+                                                                    token_type:
+                                                                      type: Whitespace
+                                                                      characters: " "
+                                                          types:
+                                                            pairs: []
+                                                      pipe:
+                                                        leading_trivia: []
+                                                        token:
+                                                          start_position:
+                                                            bytes: 246
+                                                            line: 11
+                                                            character: 30
+                                                          end_position:
+                                                            bytes: 247
+                                                            line: 11
+                                                            character: 31
+                                                          token_type:
+                                                            type: Symbol
+                                                            symbol: "|"
+                                                        trailing_trivia:
+                                                          - start_position:
+                                                              bytes: 247
+                                                              line: 11
+                                                              character: 31
+                                                            end_position:
+                                                              bytes: 248
+                                                              line: 11
+                                                              character: 32
+                                                            token_type:
+                                                              type: Whitespace
+                                                              characters: " "
+                                                      right:
+                                                        Generic:
+                                                          base:
+                                                            leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 248
+                                                                line: 11
+                                                                character: 32
+                                                              end_position:
+                                                                bytes: 259
+                                                                line: 11
+                                                                character: 43
+                                                              token_type:
+                                                                type: Identifier
+                                                                identifier: PromiseLike
+                                                            trailing_trivia: []
+                                                          arrows:
+                                                            tokens:
+                                                              - leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 259
+                                                                    line: 11
+                                                                    character: 43
+                                                                  end_position:
+                                                                    bytes: 260
+                                                                    line: 11
+                                                                    character: 44
+                                                                  token_type:
+                                                                    type: Symbol
+                                                                    symbol: "<"
+                                                                trailing_trivia: []
+                                                              - leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 261
+                                                                    line: 11
+                                                                    character: 45
+                                                                  end_position:
+                                                                    bytes: 262
+                                                                    line: 11
+                                                                    character: 46
+                                                                  token_type:
+                                                                    type: Symbol
+                                                                    symbol: ">"
+                                                                trailing_trivia: []
+                                                          generics:
+                                                            pairs:
+                                                              - End:
+                                                                  Basic:
+                                                                    leading_trivia: []
+                                                                    token:
+                                                                      start_position:
+                                                                        bytes: 260
+                                                                        line: 11
+                                                                        character: 44
+                                                                      end_position:
+                                                                        bytes: 261
+                                                                        line: 11
+                                                                        character: 45
+                                                                      token_type:
+                                                                        type: Identifier
+                                                                        identifier: T
+                                                                    trailing_trivia: []
+                                    question_mark:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 263
+                                          line: 11
+                                          character: 47
+                                        end_position:
+                                          bytes: 264
+                                          line: 11
+                                          character: 48
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "?"
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 264
+                                            line: 11
+                                            character: 48
+                                          end_position:
+                                            bytes: 265
+                                            line: 11
+                                            character: 49
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                        - start_position:
+                                            bytes: 265
+                                            line: 11
+                                            character: 49
+                                          end_position:
+                                            bytes: 274
+                                            line: 11
+                                            character: 58
+                                          token_type:
+                                            type: SingleLineComment
+                                            comment: " reject"
+                                        - start_position:
+                                            bytes: 274
+                                            line: 11
+                                            character: 58
+                                          end_position:
+                                            bytes: 275
+                                            line: 11
+                                            character: 58
+                                          token_type:
+                                            type: Whitespace
+                                            characters: "\n"
+                          arrow:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 285
+                                line: 12
+                                character: 11
+                              end_position:
+                                bytes: 287
+                                line: 12
+                                character: 13
+                              token_type:
+                                type: Symbol
+                                symbol: "->"
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 287
+                                  line: 12
+                                  character: 13
+                                end_position:
+                                  bytes: 288
+                                  line: 12
+                                  character: 14
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                          return_type:
+                            Generic:
+                              base:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 288
+                                    line: 12
+                                    character: 14
+                                  end_position:
+                                    bytes: 299
+                                    line: 12
+                                    character: 25
+                                  token_type:
+                                    type: Identifier
+                                    identifier: PromiseLike
+                                trailing_trivia: []
+                              arrows:
+                                tokens:
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 299
+                                        line: 12
+                                        character: 25
+                                      end_position:
+                                        bytes: 300
+                                        line: 12
+                                        character: 26
+                                      token_type:
+                                        type: Symbol
+                                        symbol: "<"
+                                    trailing_trivia: []
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 301
+                                        line: 12
+                                        character: 27
+                                      end_position:
+                                        bytes: 302
+                                        line: 12
+                                        character: 28
+                                      token_type:
+                                        type: Symbol
+                                        symbol: ">"
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 302
+                                          line: 12
+                                          character: 28
+                                        end_position:
+                                          bytes: 303
+                                          line: 12
+                                          character: 28
+                                        token_type:
+                                          type: Whitespace
+                                          characters: "\n"
+                              generics:
+                                pairs:
+                                  - End:
+                                      Basic:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 300
+                                            line: 12
+                                            character: 26
+                                          end_position:
+                                            bytes: 301
+                                            line: 12
+                                            character: 27
+                                          token_type:
+                                            type: Identifier
+                                            identifier: T
+                                        trailing_trivia: []
+    - ~
+  - - FunctionDeclaration:
+        function_token:
+          leading_trivia:
+            - start_position:
+                bytes: 305
+                line: 14
+                character: 1
+              end_position:
+                bytes: 306
+                line: 14
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 306
+              line: 15
+              character: 1
+            end_position:
+              bytes: 314
+              line: 15
+              character: 9
+            token_type:
+              type: Symbol
+              symbol: function
+          trailing_trivia:
+            - start_position:
+                bytes: 314
+                line: 15
+                character: 9
+              end_position:
+                bytes: 315
+                line: 15
+                character: 10
+              token_type:
+                type: Whitespace
+                characters: " "
+        name:
+          names:
+            pairs:
+              - Punctuated:
+                  - leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 315
+                        line: 15
+                        character: 10
+                      end_position:
+                        bytes: 321
+                        line: 15
+                        character: 16
+                      token_type:
+                        type: Identifier
+                        identifier: GError
+                    trailing_trivia: []
+                  - leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 321
+                        line: 15
+                        character: 16
+                      end_position:
+                        bytes: 322
+                        line: 15
+                        character: 17
+                      token_type:
+                        type: Symbol
+                        symbol: "."
+                    trailing_trivia: []
+              - End:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 322
+                      line: 15
+                      character: 17
+                    end_position:
+                      bytes: 325
+                      line: 15
+                      character: 20
+                    token_type:
+                      type: Identifier
+                      identifier: new
+                  trailing_trivia: []
+          colon_name: ~
+        body:
+          parameters_parentheses:
+            tokens:
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 325
+                    line: 15
+                    character: 20
+                  end_position:
+                    bytes: 326
+                    line: 15
+                    character: 21
+                  token_type:
+                    type: Symbol
+                    symbol: (
+                trailing_trivia:
+                  - start_position:
+                      bytes: 326
+                      line: 15
+                      character: 21
+                    end_position:
+                      bytes: 327
+                      line: 15
+                      character: 21
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 388
+                    line: 17
+                    character: 1
+                  end_position:
+                    bytes: 389
+                    line: 17
+                    character: 2
+                  token_type:
+                    type: Symbol
+                    symbol: )
+                trailing_trivia: []
+          parameters:
+            pairs:
+              - End:
+                  Name:
+                    leading_trivia:
+                      - start_position:
+                          bytes: 327
+                          line: 16
+                          character: 1
+                        end_position:
+                          bytes: 328
+                          line: 16
+                          character: 2
+                        token_type:
+                          type: Whitespace
+                          characters: "\t"
+                    token:
+                      start_position:
+                        bytes: 328
+                        line: 16
+                        character: 2
+                      end_position:
+                        bytes: 341
+                        line: 16
+                        character: 15
+                      token_type:
+                        type: Identifier
+                        identifier: originalError
+                    trailing_trivia: []
+          type_specifiers:
+            - punctuation:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 341
+                    line: 16
+                    character: 15
+                  end_position:
+                    bytes: 342
+                    line: 16
+                    character: 16
+                  token_type:
+                    type: Symbol
+                    symbol: ":"
+                trailing_trivia:
+                  - start_position:
+                      bytes: 342
+                      line: 16
+                      character: 16
+                    end_position:
+                      bytes: 343
+                      line: 16
+                      character: 17
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+              type_info:
+                Tuple:
+                  parentheses:
+                    tokens:
+                      - leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 343
+                            line: 16
+                            character: 17
+                          end_position:
+                            bytes: 344
+                            line: 16
+                            character: 18
+                          token_type:
+                            type: Symbol
+                            symbol: (
+                        trailing_trivia: []
+                      - leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 372
+                            line: 16
+                            character: 46
+                          end_position:
+                            bytes: 373
+                            line: 16
+                            character: 47
+                          token_type:
+                            type: Symbol
+                            symbol: )
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 373
+                              line: 16
+                              character: 47
+                            end_position:
+                              bytes: 374
+                              line: 16
+                              character: 48
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                          - start_position:
+                              bytes: 374
+                              line: 16
+                              character: 48
+                            end_position:
+                              bytes: 387
+                              line: 16
+                              character: 61
+                            token_type:
+                              type: SingleLineComment
+                              comment: " new syntax"
+                          - start_position:
+                              bytes: 387
+                              line: 16
+                              character: 61
+                            end_position:
+                              bytes: 388
+                              line: 16
+                              character: 61
+                            token_type:
+                              type: Whitespace
+                              characters: "\n"
+                  types:
+                    pairs:
+                      - End:
+                          Intersection:
+                            left:
+                              Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 344
+                                    line: 16
+                                    character: 18
+                                  end_position:
+                                    bytes: 349
+                                    line: 16
+                                    character: 23
+                                  token_type:
+                                    type: Identifier
+                                    identifier: Error
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 349
+                                      line: 16
+                                      character: 23
+                                    end_position:
+                                      bytes: 350
+                                      line: 16
+                                      character: 24
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                            ampersand:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 350
+                                  line: 16
+                                  character: 24
+                                end_position:
+                                  bytes: 351
+                                  line: 16
+                                  character: 25
+                                token_type:
+                                  type: Symbol
+                                  symbol: "&"
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 351
+                                    line: 16
+                                    character: 25
+                                  end_position:
+                                    bytes: 352
+                                    line: 16
+                                    character: 26
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                            right:
+                              Table:
+                                braces:
+                                  tokens:
+                                    - leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 352
+                                          line: 16
+                                          character: 26
+                                        end_position:
+                                          bytes: 353
+                                          line: 16
+                                          character: 27
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "{"
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 353
+                                            line: 16
+                                            character: 27
+                                          end_position:
+                                            bytes: 354
+                                            line: 16
+                                            character: 28
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                    - leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 371
+                                          line: 16
+                                          character: 45
+                                        end_position:
+                                          bytes: 372
+                                          line: 16
+                                          character: 46
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "}"
+                                      trailing_trivia: []
+                                fields:
+                                  pairs:
+                                    - End:
+                                        key:
+                                          Name:
+                                            leading_trivia: []
+                                            token:
+                                              start_position:
+                                                bytes: 354
+                                                line: 16
+                                                character: 28
+                                              end_position:
+                                                bytes: 364
+                                                line: 16
+                                                character: 38
+                                              token_type:
+                                                type: Identifier
+                                                identifier: extensions
+                                            trailing_trivia: []
+                                        colon:
+                                          leading_trivia: []
+                                          token:
+                                            start_position:
+                                              bytes: 364
+                                              line: 16
+                                              character: 38
+                                            end_position:
+                                              bytes: 365
+                                              line: 16
+                                              character: 39
+                                            token_type:
+                                              type: Symbol
+                                              symbol: ":"
+                                          trailing_trivia:
+                                            - start_position:
+                                                bytes: 365
+                                                line: 16
+                                                character: 39
+                                              end_position:
+                                                bytes: 366
+                                                line: 16
+                                                character: 40
+                                              token_type:
+                                                type: Whitespace
+                                                characters: " "
+                                        value:
+                                          Optional:
+                                            base:
+                                              Basic:
+                                                leading_trivia: []
+                                                token:
+                                                  start_position:
+                                                    bytes: 366
+                                                    line: 16
+                                                    character: 40
+                                                  end_position:
+                                                    bytes: 369
+                                                    line: 16
+                                                    character: 43
+                                                  token_type:
+                                                    type: Identifier
+                                                    identifier: any
+                                                trailing_trivia: []
+                                            question_mark:
+                                              leading_trivia: []
+                                              token:
+                                                start_position:
+                                                  bytes: 369
+                                                  line: 16
+                                                  character: 43
+                                                end_position:
+                                                  bytes: 370
+                                                  line: 16
+                                                  character: 44
+                                                token_type:
+                                                  type: Symbol
+                                                  symbol: "?"
+                                              trailing_trivia:
+                                                - start_position:
+                                                    bytes: 370
+                                                    line: 16
+                                                    character: 44
+                                                  end_position:
+                                                    bytes: 371
+                                                    line: 16
+                                                    character: 45
+                                                  token_type:
+                                                    type: Whitespace
+                                                    characters: " "
+          return_type:
+            punctuation:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 389
+                  line: 17
+                  character: 2
+                end_position:
+                  bytes: 390
+                  line: 17
+                  character: 3
+                token_type:
+                  type: Symbol
+                  symbol: ":"
+              trailing_trivia:
+                - start_position:
+                    bytes: 390
+                    line: 17
+                    character: 3
+                  end_position:
+                    bytes: 391
+                    line: 17
+                    character: 4
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            type_info:
+              Basic:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 391
+                    line: 17
+                    character: 4
+                  end_position:
+                    bytes: 397
+                    line: 17
+                    character: 10
+                  token_type:
+                    type: Identifier
+                    identifier: GError
+                trailing_trivia:
+                  - start_position:
+                      bytes: 397
+                      line: 17
+                      character: 10
+                    end_position:
+                      bytes: 398
+                      line: 17
+                      character: 10
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
+          block:
+            stmts: []
+          end_token:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 398
+                line: 18
+                character: 1
+              end_position:
+                bytes: 401
+                line: 18
+                character: 4
+              token_type:
+                type: Symbol
+                symbol: end
+            trailing_trivia: []
+    - ~
+

--- a/full-moon/tests/roblox_cases/pass/aa/source.lua
+++ b/full-moon/tests/roblox_cases/pass/aa/source.lua
@@ -1,0 +1,18 @@
+function TypeInfo.new(
+	getFieldDefFn: (() -> GField<any, any>?)?
+)
+end
+
+export type Thunk<T> = (() -> T) | T
+
+export type PromiseLike<T> = {
+    andThen: (
+                ((T) -> T)? | (PromiseLike<T>)?, -- resolve
+                ((any) -> () | PromiseLike<T>)? -- reject
+        ) -> PromiseLike<T>
+}
+
+function GError.new(
+	originalError: (Error & { extensions: any? }) -- new syntax
+): GError
+end

--- a/full-moon/tests/roblox_cases/pass/aa/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/aa/tokens.snap
@@ -1,0 +1,1908 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 8
+    line: 1
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: function
+- start_position:
+    bytes: 8
+    line: 1
+    character: 9
+  end_position:
+    bytes: 9
+    line: 1
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 9
+    line: 1
+    character: 10
+  end_position:
+    bytes: 17
+    line: 1
+    character: 18
+  token_type:
+    type: Identifier
+    identifier: TypeInfo
+- start_position:
+    bytes: 17
+    line: 1
+    character: 18
+  end_position:
+    bytes: 18
+    line: 1
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: "."
+- start_position:
+    bytes: 18
+    line: 1
+    character: 19
+  end_position:
+    bytes: 21
+    line: 1
+    character: 22
+  token_type:
+    type: Identifier
+    identifier: new
+- start_position:
+    bytes: 21
+    line: 1
+    character: 22
+  end_position:
+    bytes: 22
+    line: 1
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 22
+    line: 1
+    character: 23
+  end_position:
+    bytes: 23
+    line: 1
+    character: 23
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 23
+    line: 2
+    character: 1
+  end_position:
+    bytes: 24
+    line: 2
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\t"
+- start_position:
+    bytes: 24
+    line: 2
+    character: 2
+  end_position:
+    bytes: 37
+    line: 2
+    character: 15
+  token_type:
+    type: Identifier
+    identifier: getFieldDefFn
+- start_position:
+    bytes: 37
+    line: 2
+    character: 15
+  end_position:
+    bytes: 38
+    line: 2
+    character: 16
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 38
+    line: 2
+    character: 16
+  end_position:
+    bytes: 39
+    line: 2
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 39
+    line: 2
+    character: 17
+  end_position:
+    bytes: 40
+    line: 2
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 40
+    line: 2
+    character: 18
+  end_position:
+    bytes: 41
+    line: 2
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 41
+    line: 2
+    character: 19
+  end_position:
+    bytes: 42
+    line: 2
+    character: 20
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 42
+    line: 2
+    character: 20
+  end_position:
+    bytes: 43
+    line: 2
+    character: 21
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 43
+    line: 2
+    character: 21
+  end_position:
+    bytes: 45
+    line: 2
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 45
+    line: 2
+    character: 23
+  end_position:
+    bytes: 46
+    line: 2
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 46
+    line: 2
+    character: 24
+  end_position:
+    bytes: 52
+    line: 2
+    character: 30
+  token_type:
+    type: Identifier
+    identifier: GField
+- start_position:
+    bytes: 52
+    line: 2
+    character: 30
+  end_position:
+    bytes: 53
+    line: 2
+    character: 31
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 53
+    line: 2
+    character: 31
+  end_position:
+    bytes: 56
+    line: 2
+    character: 34
+  token_type:
+    type: Identifier
+    identifier: any
+- start_position:
+    bytes: 56
+    line: 2
+    character: 34
+  end_position:
+    bytes: 57
+    line: 2
+    character: 35
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 57
+    line: 2
+    character: 35
+  end_position:
+    bytes: 58
+    line: 2
+    character: 36
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 58
+    line: 2
+    character: 36
+  end_position:
+    bytes: 61
+    line: 2
+    character: 39
+  token_type:
+    type: Identifier
+    identifier: any
+- start_position:
+    bytes: 61
+    line: 2
+    character: 39
+  end_position:
+    bytes: 62
+    line: 2
+    character: 40
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 62
+    line: 2
+    character: 40
+  end_position:
+    bytes: 63
+    line: 2
+    character: 41
+  token_type:
+    type: Symbol
+    symbol: "?"
+- start_position:
+    bytes: 63
+    line: 2
+    character: 41
+  end_position:
+    bytes: 64
+    line: 2
+    character: 42
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 64
+    line: 2
+    character: 42
+  end_position:
+    bytes: 65
+    line: 2
+    character: 43
+  token_type:
+    type: Symbol
+    symbol: "?"
+- start_position:
+    bytes: 65
+    line: 2
+    character: 43
+  end_position:
+    bytes: 66
+    line: 2
+    character: 43
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 66
+    line: 3
+    character: 1
+  end_position:
+    bytes: 67
+    line: 3
+    character: 2
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 67
+    line: 3
+    character: 2
+  end_position:
+    bytes: 68
+    line: 3
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 68
+    line: 4
+    character: 1
+  end_position:
+    bytes: 71
+    line: 4
+    character: 4
+  token_type:
+    type: Symbol
+    symbol: end
+- start_position:
+    bytes: 71
+    line: 4
+    character: 4
+  end_position:
+    bytes: 72
+    line: 4
+    character: 4
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 72
+    line: 5
+    character: 1
+  end_position:
+    bytes: 73
+    line: 5
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 73
+    line: 6
+    character: 1
+  end_position:
+    bytes: 79
+    line: 6
+    character: 7
+  token_type:
+    type: Identifier
+    identifier: export
+- start_position:
+    bytes: 79
+    line: 6
+    character: 7
+  end_position:
+    bytes: 80
+    line: 6
+    character: 8
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 80
+    line: 6
+    character: 8
+  end_position:
+    bytes: 84
+    line: 6
+    character: 12
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 84
+    line: 6
+    character: 12
+  end_position:
+    bytes: 85
+    line: 6
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 85
+    line: 6
+    character: 13
+  end_position:
+    bytes: 90
+    line: 6
+    character: 18
+  token_type:
+    type: Identifier
+    identifier: Thunk
+- start_position:
+    bytes: 90
+    line: 6
+    character: 18
+  end_position:
+    bytes: 91
+    line: 6
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 91
+    line: 6
+    character: 19
+  end_position:
+    bytes: 92
+    line: 6
+    character: 20
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 92
+    line: 6
+    character: 20
+  end_position:
+    bytes: 93
+    line: 6
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 93
+    line: 6
+    character: 21
+  end_position:
+    bytes: 94
+    line: 6
+    character: 22
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 94
+    line: 6
+    character: 22
+  end_position:
+    bytes: 95
+    line: 6
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 95
+    line: 6
+    character: 23
+  end_position:
+    bytes: 96
+    line: 6
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 96
+    line: 6
+    character: 24
+  end_position:
+    bytes: 97
+    line: 6
+    character: 25
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 97
+    line: 6
+    character: 25
+  end_position:
+    bytes: 98
+    line: 6
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 98
+    line: 6
+    character: 26
+  end_position:
+    bytes: 99
+    line: 6
+    character: 27
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 99
+    line: 6
+    character: 27
+  end_position:
+    bytes: 100
+    line: 6
+    character: 28
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 100
+    line: 6
+    character: 28
+  end_position:
+    bytes: 102
+    line: 6
+    character: 30
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 102
+    line: 6
+    character: 30
+  end_position:
+    bytes: 103
+    line: 6
+    character: 31
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 103
+    line: 6
+    character: 31
+  end_position:
+    bytes: 104
+    line: 6
+    character: 32
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 104
+    line: 6
+    character: 32
+  end_position:
+    bytes: 105
+    line: 6
+    character: 33
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 105
+    line: 6
+    character: 33
+  end_position:
+    bytes: 106
+    line: 6
+    character: 34
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 106
+    line: 6
+    character: 34
+  end_position:
+    bytes: 107
+    line: 6
+    character: 35
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 107
+    line: 6
+    character: 35
+  end_position:
+    bytes: 108
+    line: 6
+    character: 36
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 108
+    line: 6
+    character: 36
+  end_position:
+    bytes: 109
+    line: 6
+    character: 37
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 109
+    line: 6
+    character: 37
+  end_position:
+    bytes: 110
+    line: 6
+    character: 37
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 110
+    line: 7
+    character: 1
+  end_position:
+    bytes: 111
+    line: 7
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 111
+    line: 8
+    character: 1
+  end_position:
+    bytes: 117
+    line: 8
+    character: 7
+  token_type:
+    type: Identifier
+    identifier: export
+- start_position:
+    bytes: 117
+    line: 8
+    character: 7
+  end_position:
+    bytes: 118
+    line: 8
+    character: 8
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 118
+    line: 8
+    character: 8
+  end_position:
+    bytes: 122
+    line: 8
+    character: 12
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 122
+    line: 8
+    character: 12
+  end_position:
+    bytes: 123
+    line: 8
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 123
+    line: 8
+    character: 13
+  end_position:
+    bytes: 134
+    line: 8
+    character: 24
+  token_type:
+    type: Identifier
+    identifier: PromiseLike
+- start_position:
+    bytes: 134
+    line: 8
+    character: 24
+  end_position:
+    bytes: 135
+    line: 8
+    character: 25
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 135
+    line: 8
+    character: 25
+  end_position:
+    bytes: 136
+    line: 8
+    character: 26
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 136
+    line: 8
+    character: 26
+  end_position:
+    bytes: 137
+    line: 8
+    character: 27
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 137
+    line: 8
+    character: 27
+  end_position:
+    bytes: 138
+    line: 8
+    character: 28
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 138
+    line: 8
+    character: 28
+  end_position:
+    bytes: 139
+    line: 8
+    character: 29
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 139
+    line: 8
+    character: 29
+  end_position:
+    bytes: 140
+    line: 8
+    character: 30
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 140
+    line: 8
+    character: 30
+  end_position:
+    bytes: 141
+    line: 8
+    character: 31
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 141
+    line: 8
+    character: 31
+  end_position:
+    bytes: 142
+    line: 8
+    character: 31
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 142
+    line: 9
+    character: 1
+  end_position:
+    bytes: 146
+    line: 9
+    character: 5
+  token_type:
+    type: Whitespace
+    characters: "    "
+- start_position:
+    bytes: 146
+    line: 9
+    character: 5
+  end_position:
+    bytes: 153
+    line: 9
+    character: 12
+  token_type:
+    type: Identifier
+    identifier: andThen
+- start_position:
+    bytes: 153
+    line: 9
+    character: 12
+  end_position:
+    bytes: 154
+    line: 9
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 154
+    line: 9
+    character: 13
+  end_position:
+    bytes: 155
+    line: 9
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 155
+    line: 9
+    character: 14
+  end_position:
+    bytes: 156
+    line: 9
+    character: 15
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 156
+    line: 9
+    character: 15
+  end_position:
+    bytes: 157
+    line: 9
+    character: 15
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 157
+    line: 10
+    character: 1
+  end_position:
+    bytes: 173
+    line: 10
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: "                "
+- start_position:
+    bytes: 173
+    line: 10
+    character: 17
+  end_position:
+    bytes: 174
+    line: 10
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 174
+    line: 10
+    character: 18
+  end_position:
+    bytes: 175
+    line: 10
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 175
+    line: 10
+    character: 19
+  end_position:
+    bytes: 176
+    line: 10
+    character: 20
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 176
+    line: 10
+    character: 20
+  end_position:
+    bytes: 177
+    line: 10
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 177
+    line: 10
+    character: 21
+  end_position:
+    bytes: 178
+    line: 10
+    character: 22
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 178
+    line: 10
+    character: 22
+  end_position:
+    bytes: 180
+    line: 10
+    character: 24
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 180
+    line: 10
+    character: 24
+  end_position:
+    bytes: 181
+    line: 10
+    character: 25
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 181
+    line: 10
+    character: 25
+  end_position:
+    bytes: 182
+    line: 10
+    character: 26
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 182
+    line: 10
+    character: 26
+  end_position:
+    bytes: 183
+    line: 10
+    character: 27
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 183
+    line: 10
+    character: 27
+  end_position:
+    bytes: 184
+    line: 10
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: "?"
+- start_position:
+    bytes: 184
+    line: 10
+    character: 28
+  end_position:
+    bytes: 185
+    line: 10
+    character: 29
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 185
+    line: 10
+    character: 29
+  end_position:
+    bytes: 186
+    line: 10
+    character: 30
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 186
+    line: 10
+    character: 30
+  end_position:
+    bytes: 187
+    line: 10
+    character: 31
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 187
+    line: 10
+    character: 31
+  end_position:
+    bytes: 188
+    line: 10
+    character: 32
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 188
+    line: 10
+    character: 32
+  end_position:
+    bytes: 199
+    line: 10
+    character: 43
+  token_type:
+    type: Identifier
+    identifier: PromiseLike
+- start_position:
+    bytes: 199
+    line: 10
+    character: 43
+  end_position:
+    bytes: 200
+    line: 10
+    character: 44
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 200
+    line: 10
+    character: 44
+  end_position:
+    bytes: 201
+    line: 10
+    character: 45
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 201
+    line: 10
+    character: 45
+  end_position:
+    bytes: 202
+    line: 10
+    character: 46
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 202
+    line: 10
+    character: 46
+  end_position:
+    bytes: 203
+    line: 10
+    character: 47
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 203
+    line: 10
+    character: 47
+  end_position:
+    bytes: 204
+    line: 10
+    character: 48
+  token_type:
+    type: Symbol
+    symbol: "?"
+- start_position:
+    bytes: 204
+    line: 10
+    character: 48
+  end_position:
+    bytes: 205
+    line: 10
+    character: 49
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 205
+    line: 10
+    character: 49
+  end_position:
+    bytes: 206
+    line: 10
+    character: 50
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 206
+    line: 10
+    character: 50
+  end_position:
+    bytes: 216
+    line: 10
+    character: 60
+  token_type:
+    type: SingleLineComment
+    comment: " resolve"
+- start_position:
+    bytes: 216
+    line: 10
+    character: 60
+  end_position:
+    bytes: 217
+    line: 10
+    character: 60
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 217
+    line: 11
+    character: 1
+  end_position:
+    bytes: 233
+    line: 11
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: "                "
+- start_position:
+    bytes: 233
+    line: 11
+    character: 17
+  end_position:
+    bytes: 234
+    line: 11
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 234
+    line: 11
+    character: 18
+  end_position:
+    bytes: 235
+    line: 11
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 235
+    line: 11
+    character: 19
+  end_position:
+    bytes: 238
+    line: 11
+    character: 22
+  token_type:
+    type: Identifier
+    identifier: any
+- start_position:
+    bytes: 238
+    line: 11
+    character: 22
+  end_position:
+    bytes: 239
+    line: 11
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 239
+    line: 11
+    character: 23
+  end_position:
+    bytes: 240
+    line: 11
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 240
+    line: 11
+    character: 24
+  end_position:
+    bytes: 242
+    line: 11
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 242
+    line: 11
+    character: 26
+  end_position:
+    bytes: 243
+    line: 11
+    character: 27
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 243
+    line: 11
+    character: 27
+  end_position:
+    bytes: 244
+    line: 11
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 244
+    line: 11
+    character: 28
+  end_position:
+    bytes: 245
+    line: 11
+    character: 29
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 245
+    line: 11
+    character: 29
+  end_position:
+    bytes: 246
+    line: 11
+    character: 30
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 246
+    line: 11
+    character: 30
+  end_position:
+    bytes: 247
+    line: 11
+    character: 31
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 247
+    line: 11
+    character: 31
+  end_position:
+    bytes: 248
+    line: 11
+    character: 32
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 248
+    line: 11
+    character: 32
+  end_position:
+    bytes: 259
+    line: 11
+    character: 43
+  token_type:
+    type: Identifier
+    identifier: PromiseLike
+- start_position:
+    bytes: 259
+    line: 11
+    character: 43
+  end_position:
+    bytes: 260
+    line: 11
+    character: 44
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 260
+    line: 11
+    character: 44
+  end_position:
+    bytes: 261
+    line: 11
+    character: 45
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 261
+    line: 11
+    character: 45
+  end_position:
+    bytes: 262
+    line: 11
+    character: 46
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 262
+    line: 11
+    character: 46
+  end_position:
+    bytes: 263
+    line: 11
+    character: 47
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 263
+    line: 11
+    character: 47
+  end_position:
+    bytes: 264
+    line: 11
+    character: 48
+  token_type:
+    type: Symbol
+    symbol: "?"
+- start_position:
+    bytes: 264
+    line: 11
+    character: 48
+  end_position:
+    bytes: 265
+    line: 11
+    character: 49
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 265
+    line: 11
+    character: 49
+  end_position:
+    bytes: 274
+    line: 11
+    character: 58
+  token_type:
+    type: SingleLineComment
+    comment: " reject"
+- start_position:
+    bytes: 274
+    line: 11
+    character: 58
+  end_position:
+    bytes: 275
+    line: 11
+    character: 58
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 275
+    line: 12
+    character: 1
+  end_position:
+    bytes: 283
+    line: 12
+    character: 9
+  token_type:
+    type: Whitespace
+    characters: "        "
+- start_position:
+    bytes: 283
+    line: 12
+    character: 9
+  end_position:
+    bytes: 284
+    line: 12
+    character: 10
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 284
+    line: 12
+    character: 10
+  end_position:
+    bytes: 285
+    line: 12
+    character: 11
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 285
+    line: 12
+    character: 11
+  end_position:
+    bytes: 287
+    line: 12
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 287
+    line: 12
+    character: 13
+  end_position:
+    bytes: 288
+    line: 12
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 288
+    line: 12
+    character: 14
+  end_position:
+    bytes: 299
+    line: 12
+    character: 25
+  token_type:
+    type: Identifier
+    identifier: PromiseLike
+- start_position:
+    bytes: 299
+    line: 12
+    character: 25
+  end_position:
+    bytes: 300
+    line: 12
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 300
+    line: 12
+    character: 26
+  end_position:
+    bytes: 301
+    line: 12
+    character: 27
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 301
+    line: 12
+    character: 27
+  end_position:
+    bytes: 302
+    line: 12
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 302
+    line: 12
+    character: 28
+  end_position:
+    bytes: 303
+    line: 12
+    character: 28
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 303
+    line: 13
+    character: 1
+  end_position:
+    bytes: 304
+    line: 13
+    character: 2
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 304
+    line: 13
+    character: 2
+  end_position:
+    bytes: 305
+    line: 13
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 305
+    line: 14
+    character: 1
+  end_position:
+    bytes: 306
+    line: 14
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 306
+    line: 15
+    character: 1
+  end_position:
+    bytes: 314
+    line: 15
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: function
+- start_position:
+    bytes: 314
+    line: 15
+    character: 9
+  end_position:
+    bytes: 315
+    line: 15
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 315
+    line: 15
+    character: 10
+  end_position:
+    bytes: 321
+    line: 15
+    character: 16
+  token_type:
+    type: Identifier
+    identifier: GError
+- start_position:
+    bytes: 321
+    line: 15
+    character: 16
+  end_position:
+    bytes: 322
+    line: 15
+    character: 17
+  token_type:
+    type: Symbol
+    symbol: "."
+- start_position:
+    bytes: 322
+    line: 15
+    character: 17
+  end_position:
+    bytes: 325
+    line: 15
+    character: 20
+  token_type:
+    type: Identifier
+    identifier: new
+- start_position:
+    bytes: 325
+    line: 15
+    character: 20
+  end_position:
+    bytes: 326
+    line: 15
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 326
+    line: 15
+    character: 21
+  end_position:
+    bytes: 327
+    line: 15
+    character: 21
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 327
+    line: 16
+    character: 1
+  end_position:
+    bytes: 328
+    line: 16
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\t"
+- start_position:
+    bytes: 328
+    line: 16
+    character: 2
+  end_position:
+    bytes: 341
+    line: 16
+    character: 15
+  token_type:
+    type: Identifier
+    identifier: originalError
+- start_position:
+    bytes: 341
+    line: 16
+    character: 15
+  end_position:
+    bytes: 342
+    line: 16
+    character: 16
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 342
+    line: 16
+    character: 16
+  end_position:
+    bytes: 343
+    line: 16
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 343
+    line: 16
+    character: 17
+  end_position:
+    bytes: 344
+    line: 16
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 344
+    line: 16
+    character: 18
+  end_position:
+    bytes: 349
+    line: 16
+    character: 23
+  token_type:
+    type: Identifier
+    identifier: Error
+- start_position:
+    bytes: 349
+    line: 16
+    character: 23
+  end_position:
+    bytes: 350
+    line: 16
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 350
+    line: 16
+    character: 24
+  end_position:
+    bytes: 351
+    line: 16
+    character: 25
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 351
+    line: 16
+    character: 25
+  end_position:
+    bytes: 352
+    line: 16
+    character: 26
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 352
+    line: 16
+    character: 26
+  end_position:
+    bytes: 353
+    line: 16
+    character: 27
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 353
+    line: 16
+    character: 27
+  end_position:
+    bytes: 354
+    line: 16
+    character: 28
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 354
+    line: 16
+    character: 28
+  end_position:
+    bytes: 364
+    line: 16
+    character: 38
+  token_type:
+    type: Identifier
+    identifier: extensions
+- start_position:
+    bytes: 364
+    line: 16
+    character: 38
+  end_position:
+    bytes: 365
+    line: 16
+    character: 39
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 365
+    line: 16
+    character: 39
+  end_position:
+    bytes: 366
+    line: 16
+    character: 40
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 366
+    line: 16
+    character: 40
+  end_position:
+    bytes: 369
+    line: 16
+    character: 43
+  token_type:
+    type: Identifier
+    identifier: any
+- start_position:
+    bytes: 369
+    line: 16
+    character: 43
+  end_position:
+    bytes: 370
+    line: 16
+    character: 44
+  token_type:
+    type: Symbol
+    symbol: "?"
+- start_position:
+    bytes: 370
+    line: 16
+    character: 44
+  end_position:
+    bytes: 371
+    line: 16
+    character: 45
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 371
+    line: 16
+    character: 45
+  end_position:
+    bytes: 372
+    line: 16
+    character: 46
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 372
+    line: 16
+    character: 46
+  end_position:
+    bytes: 373
+    line: 16
+    character: 47
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 373
+    line: 16
+    character: 47
+  end_position:
+    bytes: 374
+    line: 16
+    character: 48
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 374
+    line: 16
+    character: 48
+  end_position:
+    bytes: 387
+    line: 16
+    character: 61
+  token_type:
+    type: SingleLineComment
+    comment: " new syntax"
+- start_position:
+    bytes: 387
+    line: 16
+    character: 61
+  end_position:
+    bytes: 388
+    line: 16
+    character: 61
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 388
+    line: 17
+    character: 1
+  end_position:
+    bytes: 389
+    line: 17
+    character: 2
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 389
+    line: 17
+    character: 2
+  end_position:
+    bytes: 390
+    line: 17
+    character: 3
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 390
+    line: 17
+    character: 3
+  end_position:
+    bytes: 391
+    line: 17
+    character: 4
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 391
+    line: 17
+    character: 4
+  end_position:
+    bytes: 397
+    line: 17
+    character: 10
+  token_type:
+    type: Identifier
+    identifier: GError
+- start_position:
+    bytes: 397
+    line: 17
+    character: 10
+  end_position:
+    bytes: 398
+    line: 17
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 398
+    line: 18
+    character: 1
+  end_position:
+    bytes: 401
+    line: 18
+    character: 4
+  token_type:
+    type: Symbol
+    symbol: end
+- start_position:
+    bytes: 401
+    line: 18
+    character: 4
+  end_position:
+    bytes: 401
+    line: 18
+    character: 4
+  token_type:
+    type: Eof
+


### PR DESCRIPTION
Regression caused by #167, where we accidently disallowed a single type wrapped around in parentheses in places which were not a return type.

This is valid syntax, and is necessary in cases where we want to declare the type as optional, such as:
```lua
type Foo = (Bar & Baz)?
```

Fixes #173 
Fixes #174 
Fixes #175 
Fixes #176 
