### PR TITLE
Fix parse issue with complex function type args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed issue with parsing complex function type arguments which began with an indetifier under the `roblox` feature flag
+
 ## [0.12.0] - 2021-06-15
 ### Added
 - Added support for parsing generic functions under the `roblox` feature flag

--- a/full-moon/tests/roblox_cases/pass/types_parentheses/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_parentheses/ast.snap
@@ -2476,6 +2476,691 @@ stmts:
               token_type:
                 type: Symbol
                 symbol: end
-            trailing_trivia: []
+            trailing_trivia:
+              - start_position:
+                  bytes: 401
+                  line: 18
+                  character: 4
+                end_position:
+                  bytes: 402
+                  line: 18
+                  character: 4
+                token_type:
+                  type: Whitespace
+                  characters: "\n"
+    - ~
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 402
+                line: 19
+                character: 1
+              end_position:
+                bytes: 403
+                line: 19
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 403
+              line: 20
+              character: 1
+            end_position:
+              bytes: 407
+              line: 20
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 407
+                line: 20
+                character: 5
+              end_position:
+                bytes: 408
+                line: 20
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 408
+              line: 20
+              character: 6
+            end_position:
+              bytes: 419
+              line: 20
+              character: 17
+            token_type:
+              type: Identifier
+              identifier: IProperties
+          trailing_trivia:
+            - start_position:
+                bytes: 419
+                line: 20
+                character: 17
+              end_position:
+                bytes: 420
+                line: 20
+                character: 18
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 420
+              line: 20
+              character: 18
+            end_position:
+              bytes: 421
+              line: 20
+              character: 19
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 421
+                line: 20
+                character: 19
+              end_position:
+                bytes: 422
+                line: 20
+                character: 20
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Table:
+            braces:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 422
+                      line: 20
+                      character: 20
+                    end_position:
+                      bytes: 423
+                      line: 20
+                      character: 21
+                    token_type:
+                      type: Symbol
+                      symbol: "{"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 423
+                        line: 20
+                        character: 21
+                      end_position:
+                        bytes: 424
+                        line: 20
+                        character: 21
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 533
+                      line: 22
+                      character: 1
+                    end_position:
+                      bytes: 534
+                      line: 22
+                      character: 2
+                    token_type:
+                      type: Symbol
+                      symbol: "}"
+                  trailing_trivia: []
+            fields:
+              pairs:
+                - Punctuated:
+                    - key:
+                        Name:
+                          leading_trivia:
+                            - start_position:
+                                bytes: 424
+                                line: 21
+                                character: 1
+                              end_position:
+                                bytes: 425
+                                line: 21
+                                character: 2
+                              token_type:
+                                type: Whitespace
+                                characters: "\t"
+                          token:
+                            start_position:
+                              bytes: 425
+                              line: 21
+                              character: 2
+                            end_position:
+                              bytes: 442
+                              line: 21
+                              character: 19
+                            token_type:
+                              type: Identifier
+                              identifier: RemoveOnCollision
+                          trailing_trivia: []
+                      colon:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 442
+                            line: 21
+                            character: 19
+                          end_position:
+                            bytes: 443
+                            line: 21
+                            character: 20
+                          token_type:
+                            type: Symbol
+                            symbol: ":"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 443
+                              line: 21
+                              character: 20
+                            end_position:
+                              bytes: 444
+                              line: 21
+                              character: 21
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      value:
+                        Optional:
+                          base:
+                            Tuple:
+                              parentheses:
+                                tokens:
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 444
+                                        line: 21
+                                        character: 21
+                                      end_position:
+                                        bytes: 445
+                                        line: 21
+                                        character: 22
+                                      token_type:
+                                        type: Symbol
+                                        symbol: (
+                                    trailing_trivia: []
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 529
+                                        line: 21
+                                        character: 106
+                                      end_position:
+                                        bytes: 530
+                                        line: 21
+                                        character: 107
+                                      token_type:
+                                        type: Symbol
+                                        symbol: )
+                                    trailing_trivia: []
+                              types:
+                                pairs:
+                                  - End:
+                                      Union:
+                                        left:
+                                          Basic:
+                                            leading_trivia: []
+                                            token:
+                                              start_position:
+                                                bytes: 445
+                                                line: 21
+                                                character: 22
+                                              end_position:
+                                                bytes: 451
+                                                line: 21
+                                                character: 28
+                                              token_type:
+                                                type: Identifier
+                                                identifier: string
+                                            trailing_trivia:
+                                              - start_position:
+                                                  bytes: 451
+                                                  line: 21
+                                                  character: 28
+                                                end_position:
+                                                  bytes: 452
+                                                  line: 21
+                                                  character: 29
+                                                token_type:
+                                                  type: Whitespace
+                                                  characters: " "
+                                        pipe:
+                                          leading_trivia: []
+                                          token:
+                                            start_position:
+                                              bytes: 452
+                                              line: 21
+                                              character: 29
+                                            end_position:
+                                              bytes: 453
+                                              line: 21
+                                              character: 30
+                                            token_type:
+                                              type: Symbol
+                                              symbol: "|"
+                                          trailing_trivia:
+                                            - start_position:
+                                                bytes: 453
+                                                line: 21
+                                                character: 30
+                                              end_position:
+                                                bytes: 454
+                                                line: 21
+                                                character: 31
+                                              token_type:
+                                                type: Whitespace
+                                                characters: " "
+                                        right:
+                                          Callback:
+                                            parentheses:
+                                              tokens:
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 454
+                                                      line: 21
+                                                      character: 31
+                                                    end_position:
+                                                      bytes: 455
+                                                      line: 21
+                                                      character: 32
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: (
+                                                  trailing_trivia: []
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 517
+                                                      line: 21
+                                                      character: 94
+                                                    end_position:
+                                                      bytes: 518
+                                                      line: 21
+                                                      character: 95
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: )
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 518
+                                                        line: 21
+                                                        character: 95
+                                                      end_position:
+                                                        bytes: 519
+                                                        line: 21
+                                                        character: 96
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: " "
+                                            arguments:
+                                              pairs:
+                                                - Punctuated:
+                                                    - name: ~
+                                                      type_info:
+                                                        Basic:
+                                                          leading_trivia: []
+                                                          token:
+                                                            start_position:
+                                                              bytes: 455
+                                                              line: 21
+                                                              character: 32
+                                                            end_position:
+                                                              bytes: 466
+                                                              line: 21
+                                                              character: 43
+                                                            token_type:
+                                                              type: Identifier
+                                                              identifier: IProperties
+                                                          trailing_trivia: []
+                                                    - leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 466
+                                                          line: 21
+                                                          character: 43
+                                                        end_position:
+                                                          bytes: 467
+                                                          line: 21
+                                                          character: 44
+                                                        token_type:
+                                                          type: Symbol
+                                                          symbol: ","
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 467
+                                                            line: 21
+                                                            character: 44
+                                                          end_position:
+                                                            bytes: 468
+                                                            line: 21
+                                                            character: 45
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                - Punctuated:
+                                                    - name: ~
+                                                      type_info:
+                                                        Basic:
+                                                          leading_trivia: []
+                                                          token:
+                                                            start_position:
+                                                              bytes: 468
+                                                              line: 21
+                                                              character: 45
+                                                            end_position:
+                                                              bytes: 476
+                                                              line: 21
+                                                              character: 53
+                                                            token_type:
+                                                              type: Identifier
+                                                              identifier: BasePart
+                                                          trailing_trivia: []
+                                                    - leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 476
+                                                          line: 21
+                                                          character: 53
+                                                        end_position:
+                                                          bytes: 477
+                                                          line: 21
+                                                          character: 54
+                                                        token_type:
+                                                          type: Symbol
+                                                          symbol: ","
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 477
+                                                            line: 21
+                                                            character: 54
+                                                          end_position:
+                                                            bytes: 478
+                                                            line: 21
+                                                            character: 55
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                - Punctuated:
+                                                    - name: ~
+                                                      type_info:
+                                                        Basic:
+                                                          leading_trivia: []
+                                                          token:
+                                                            start_position:
+                                                              bytes: 478
+                                                              line: 21
+                                                              character: 55
+                                                            end_position:
+                                                              bytes: 485
+                                                              line: 21
+                                                              character: 62
+                                                            token_type:
+                                                              type: Identifier
+                                                              identifier: Vector3
+                                                          trailing_trivia: []
+                                                    - leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 485
+                                                          line: 21
+                                                          character: 62
+                                                        end_position:
+                                                          bytes: 486
+                                                          line: 21
+                                                          character: 63
+                                                        token_type:
+                                                          type: Symbol
+                                                          symbol: ","
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 486
+                                                            line: 21
+                                                            character: 63
+                                                          end_position:
+                                                            bytes: 487
+                                                            line: 21
+                                                            character: 64
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                - Punctuated:
+                                                    - name: ~
+                                                      type_info:
+                                                        Basic:
+                                                          leading_trivia: []
+                                                          token:
+                                                            start_position:
+                                                              bytes: 487
+                                                              line: 21
+                                                              character: 64
+                                                            end_position:
+                                                              bytes: 494
+                                                              line: 21
+                                                              character: 71
+                                                            token_type:
+                                                              type: Identifier
+                                                              identifier: Vector3
+                                                          trailing_trivia: []
+                                                    - leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 494
+                                                          line: 21
+                                                          character: 71
+                                                        end_position:
+                                                          bytes: 495
+                                                          line: 21
+                                                          character: 72
+                                                        token_type:
+                                                          type: Symbol
+                                                          symbol: ","
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 495
+                                                            line: 21
+                                                            character: 72
+                                                          end_position:
+                                                            bytes: 496
+                                                            line: 21
+                                                            character: 73
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                - Punctuated:
+                                                    - name: ~
+                                                      type_info:
+                                                        Module:
+                                                          module:
+                                                            leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 496
+                                                                line: 21
+                                                                character: 73
+                                                              end_position:
+                                                                bytes: 500
+                                                                line: 21
+                                                                character: 77
+                                                              token_type:
+                                                                type: Identifier
+                                                                identifier: Enum
+                                                            trailing_trivia: []
+                                                          punctuation:
+                                                            leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 500
+                                                                line: 21
+                                                                character: 77
+                                                              end_position:
+                                                                bytes: 501
+                                                                line: 21
+                                                                character: 78
+                                                              token_type:
+                                                                type: Symbol
+                                                                symbol: "."
+                                                            trailing_trivia: []
+                                                          type_info:
+                                                            Basic:
+                                                              leading_trivia: []
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 501
+                                                                  line: 21
+                                                                  character: 78
+                                                                end_position:
+                                                                  bytes: 509
+                                                                  line: 21
+                                                                  character: 86
+                                                                token_type:
+                                                                  type: Identifier
+                                                                  identifier: Material
+                                                              trailing_trivia: []
+                                                    - leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 509
+                                                          line: 21
+                                                          character: 86
+                                                        end_position:
+                                                          bytes: 510
+                                                          line: 21
+                                                          character: 87
+                                                        token_type:
+                                                          type: Symbol
+                                                          symbol: ","
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 510
+                                                            line: 21
+                                                            character: 87
+                                                          end_position:
+                                                            bytes: 511
+                                                            line: 21
+                                                            character: 88
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                - End:
+                                                    name: ~
+                                                    type_info:
+                                                      Basic:
+                                                        leading_trivia: []
+                                                        token:
+                                                          start_position:
+                                                            bytes: 511
+                                                            line: 21
+                                                            character: 88
+                                                          end_position:
+                                                            bytes: 517
+                                                            line: 21
+                                                            character: 94
+                                                          token_type:
+                                                            type: Identifier
+                                                            identifier: number
+                                                        trailing_trivia: []
+                                            arrow:
+                                              leading_trivia: []
+                                              token:
+                                                start_position:
+                                                  bytes: 519
+                                                  line: 21
+                                                  character: 96
+                                                end_position:
+                                                  bytes: 521
+                                                  line: 21
+                                                  character: 98
+                                                token_type:
+                                                  type: Symbol
+                                                  symbol: "->"
+                                              trailing_trivia:
+                                                - start_position:
+                                                    bytes: 521
+                                                    line: 21
+                                                    character: 98
+                                                  end_position:
+                                                    bytes: 522
+                                                    line: 21
+                                                    character: 99
+                                                  token_type:
+                                                    type: Whitespace
+                                                    characters: " "
+                                            return_type:
+                                              Basic:
+                                                leading_trivia: []
+                                                token:
+                                                  start_position:
+                                                    bytes: 522
+                                                    line: 21
+                                                    character: 99
+                                                  end_position:
+                                                    bytes: 529
+                                                    line: 21
+                                                    character: 106
+                                                  token_type:
+                                                    type: Identifier
+                                                    identifier: boolean
+                                                trailing_trivia: []
+                          question_mark:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 530
+                                line: 21
+                                character: 107
+                              end_position:
+                                bytes: 531
+                                line: 21
+                                character: 108
+                              token_type:
+                                type: Symbol
+                                symbol: "?"
+                            trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 531
+                          line: 21
+                          character: 108
+                        end_position:
+                          bytes: 532
+                          line: 21
+                          character: 109
+                        token_type:
+                          type: Symbol
+                          symbol: ","
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 532
+                            line: 21
+                            character: 109
+                          end_position:
+                            bytes: 533
+                            line: 21
+                            character: 109
+                          token_type:
+                            type: Whitespace
+                            characters: "\n"
     - ~
 

--- a/full-moon/tests/roblox_cases/pass/types_parentheses/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_parentheses/source.lua
@@ -16,3 +16,7 @@ function GError.new(
 	originalError: (Error & { extensions: any? }) -- new syntax
 ): GError
 end
+
+type IProperties = {
+	RemoveOnCollision: (string | (IProperties, BasePart, Vector3, Vector3, Enum.Material, number) -> boolean)?,
+}

--- a/full-moon/tests/roblox_cases/pass/types_parentheses/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_parentheses/tokens.snap
@@ -1900,9 +1900,537 @@ expression: tokens
     line: 18
     character: 4
   end_position:
-    bytes: 401
+    bytes: 402
     line: 18
     character: 4
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 402
+    line: 19
+    character: 1
+  end_position:
+    bytes: 403
+    line: 19
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 403
+    line: 20
+    character: 1
+  end_position:
+    bytes: 407
+    line: 20
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 407
+    line: 20
+    character: 5
+  end_position:
+    bytes: 408
+    line: 20
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 408
+    line: 20
+    character: 6
+  end_position:
+    bytes: 419
+    line: 20
+    character: 17
+  token_type:
+    type: Identifier
+    identifier: IProperties
+- start_position:
+    bytes: 419
+    line: 20
+    character: 17
+  end_position:
+    bytes: 420
+    line: 20
+    character: 18
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 420
+    line: 20
+    character: 18
+  end_position:
+    bytes: 421
+    line: 20
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 421
+    line: 20
+    character: 19
+  end_position:
+    bytes: 422
+    line: 20
+    character: 20
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 422
+    line: 20
+    character: 20
+  end_position:
+    bytes: 423
+    line: 20
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 423
+    line: 20
+    character: 21
+  end_position:
+    bytes: 424
+    line: 20
+    character: 21
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 424
+    line: 21
+    character: 1
+  end_position:
+    bytes: 425
+    line: 21
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\t"
+- start_position:
+    bytes: 425
+    line: 21
+    character: 2
+  end_position:
+    bytes: 442
+    line: 21
+    character: 19
+  token_type:
+    type: Identifier
+    identifier: RemoveOnCollision
+- start_position:
+    bytes: 442
+    line: 21
+    character: 19
+  end_position:
+    bytes: 443
+    line: 21
+    character: 20
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 443
+    line: 21
+    character: 20
+  end_position:
+    bytes: 444
+    line: 21
+    character: 21
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 444
+    line: 21
+    character: 21
+  end_position:
+    bytes: 445
+    line: 21
+    character: 22
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 445
+    line: 21
+    character: 22
+  end_position:
+    bytes: 451
+    line: 21
+    character: 28
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 451
+    line: 21
+    character: 28
+  end_position:
+    bytes: 452
+    line: 21
+    character: 29
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 452
+    line: 21
+    character: 29
+  end_position:
+    bytes: 453
+    line: 21
+    character: 30
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 453
+    line: 21
+    character: 30
+  end_position:
+    bytes: 454
+    line: 21
+    character: 31
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 454
+    line: 21
+    character: 31
+  end_position:
+    bytes: 455
+    line: 21
+    character: 32
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 455
+    line: 21
+    character: 32
+  end_position:
+    bytes: 466
+    line: 21
+    character: 43
+  token_type:
+    type: Identifier
+    identifier: IProperties
+- start_position:
+    bytes: 466
+    line: 21
+    character: 43
+  end_position:
+    bytes: 467
+    line: 21
+    character: 44
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 467
+    line: 21
+    character: 44
+  end_position:
+    bytes: 468
+    line: 21
+    character: 45
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 468
+    line: 21
+    character: 45
+  end_position:
+    bytes: 476
+    line: 21
+    character: 53
+  token_type:
+    type: Identifier
+    identifier: BasePart
+- start_position:
+    bytes: 476
+    line: 21
+    character: 53
+  end_position:
+    bytes: 477
+    line: 21
+    character: 54
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 477
+    line: 21
+    character: 54
+  end_position:
+    bytes: 478
+    line: 21
+    character: 55
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 478
+    line: 21
+    character: 55
+  end_position:
+    bytes: 485
+    line: 21
+    character: 62
+  token_type:
+    type: Identifier
+    identifier: Vector3
+- start_position:
+    bytes: 485
+    line: 21
+    character: 62
+  end_position:
+    bytes: 486
+    line: 21
+    character: 63
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 486
+    line: 21
+    character: 63
+  end_position:
+    bytes: 487
+    line: 21
+    character: 64
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 487
+    line: 21
+    character: 64
+  end_position:
+    bytes: 494
+    line: 21
+    character: 71
+  token_type:
+    type: Identifier
+    identifier: Vector3
+- start_position:
+    bytes: 494
+    line: 21
+    character: 71
+  end_position:
+    bytes: 495
+    line: 21
+    character: 72
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 495
+    line: 21
+    character: 72
+  end_position:
+    bytes: 496
+    line: 21
+    character: 73
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 496
+    line: 21
+    character: 73
+  end_position:
+    bytes: 500
+    line: 21
+    character: 77
+  token_type:
+    type: Identifier
+    identifier: Enum
+- start_position:
+    bytes: 500
+    line: 21
+    character: 77
+  end_position:
+    bytes: 501
+    line: 21
+    character: 78
+  token_type:
+    type: Symbol
+    symbol: "."
+- start_position:
+    bytes: 501
+    line: 21
+    character: 78
+  end_position:
+    bytes: 509
+    line: 21
+    character: 86
+  token_type:
+    type: Identifier
+    identifier: Material
+- start_position:
+    bytes: 509
+    line: 21
+    character: 86
+  end_position:
+    bytes: 510
+    line: 21
+    character: 87
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 510
+    line: 21
+    character: 87
+  end_position:
+    bytes: 511
+    line: 21
+    character: 88
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 511
+    line: 21
+    character: 88
+  end_position:
+    bytes: 517
+    line: 21
+    character: 94
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 517
+    line: 21
+    character: 94
+  end_position:
+    bytes: 518
+    line: 21
+    character: 95
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 518
+    line: 21
+    character: 95
+  end_position:
+    bytes: 519
+    line: 21
+    character: 96
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 519
+    line: 21
+    character: 96
+  end_position:
+    bytes: 521
+    line: 21
+    character: 98
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 521
+    line: 21
+    character: 98
+  end_position:
+    bytes: 522
+    line: 21
+    character: 99
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 522
+    line: 21
+    character: 99
+  end_position:
+    bytes: 529
+    line: 21
+    character: 106
+  token_type:
+    type: Identifier
+    identifier: boolean
+- start_position:
+    bytes: 529
+    line: 21
+    character: 106
+  end_position:
+    bytes: 530
+    line: 21
+    character: 107
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 530
+    line: 21
+    character: 107
+  end_position:
+    bytes: 531
+    line: 21
+    character: 108
+  token_type:
+    type: Symbol
+    symbol: "?"
+- start_position:
+    bytes: 531
+    line: 21
+    character: 108
+  end_position:
+    bytes: 532
+    line: 21
+    character: 109
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 532
+    line: 21
+    character: 109
+  end_position:
+    bytes: 533
+    line: 21
+    character: 109
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 533
+    line: 22
+    character: 1
+  end_position:
+    bytes: 534
+    line: 22
+    character: 2
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 534
+    line: 22
+    character: 2
+  end_position:
+    bytes: 534
+    line: 22
+    character: 2
   token_type:
     type: Eof
 


### PR DESCRIPTION
They begin with an identifier, but we assumed it would've been a name, but it might not be