### PR TITLE
Fix parsing of Luau table types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed semicolon used as delimeters in Luau type tables leading to a syntax error under the `roblox` feature flag
+- Fixed nested type arrays failing to parse under the `roblox` feature flag
+
 ## [0.13.0] - 2021-06-26
 ### Changed
 - **[BREAKING CHANGE]** The ast lifetime has been removed from practically everything.

--- a/full-moon/tests/roblox_cases/pass/types_nested_array/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_nested_array/ast.snap
@@ -1,0 +1,535 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+
+---
+stmts:
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 0
+              line: 1
+              character: 1
+            end_position:
+              bytes: 4
+              line: 1
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 4
+                line: 1
+                character: 5
+              end_position:
+                bytes: 5
+                line: 1
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 5
+              line: 1
+              character: 6
+            end_position:
+              bytes: 8
+              line: 1
+              character: 9
+            token_type:
+              type: Identifier
+              identifier: Foo
+          trailing_trivia:
+            - start_position:
+                bytes: 8
+                line: 1
+                character: 9
+              end_position:
+                bytes: 9
+                line: 1
+                character: 10
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 9
+              line: 1
+              character: 10
+            end_position:
+              bytes: 10
+              line: 1
+              character: 11
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 10
+                line: 1
+                character: 11
+              end_position:
+                bytes: 11
+                line: 1
+                character: 12
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Array:
+            braces:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 11
+                      line: 1
+                      character: 12
+                    end_position:
+                      bytes: 12
+                      line: 1
+                      character: 13
+                    token_type:
+                      type: Symbol
+                      symbol: "{"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 12
+                        line: 1
+                        character: 13
+                      end_position:
+                        bytes: 13
+                        line: 1
+                        character: 14
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 24
+                      line: 1
+                      character: 25
+                    end_position:
+                      bytes: 25
+                      line: 1
+                      character: 26
+                    token_type:
+                      type: Symbol
+                      symbol: "}"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 25
+                        line: 1
+                        character: 26
+                      end_position:
+                        bytes: 26
+                        line: 1
+                        character: 26
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+            type_info:
+              Array:
+                braces:
+                  tokens:
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 13
+                          line: 1
+                          character: 14
+                        end_position:
+                          bytes: 14
+                          line: 1
+                          character: 15
+                        token_type:
+                          type: Symbol
+                          symbol: "{"
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 14
+                            line: 1
+                            character: 15
+                          end_position:
+                            bytes: 15
+                            line: 1
+                            character: 16
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 22
+                          line: 1
+                          character: 23
+                        end_position:
+                          bytes: 23
+                          line: 1
+                          character: 24
+                        token_type:
+                          type: Symbol
+                          symbol: "}"
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 23
+                            line: 1
+                            character: 24
+                          end_position:
+                            bytes: 24
+                            line: 1
+                            character: 25
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                type_info:
+                  Basic:
+                    leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 15
+                        line: 1
+                        character: 16
+                      end_position:
+                        bytes: 21
+                        line: 1
+                        character: 22
+                      token_type:
+                        type: Identifier
+                        identifier: string
+                    trailing_trivia:
+                      - start_position:
+                          bytes: 21
+                          line: 1
+                          character: 22
+                        end_position:
+                          bytes: 22
+                          line: 1
+                          character: 23
+                        token_type:
+                          type: Whitespace
+                          characters: " "
+    - ~
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 26
+              line: 2
+              character: 1
+            end_position:
+              bytes: 30
+              line: 2
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 30
+                line: 2
+                character: 5
+              end_position:
+                bytes: 31
+                line: 2
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 31
+              line: 2
+              character: 6
+            end_position:
+              bytes: 34
+              line: 2
+              character: 9
+            token_type:
+              type: Identifier
+              identifier: Foo
+          trailing_trivia:
+            - start_position:
+                bytes: 34
+                line: 2
+                character: 9
+              end_position:
+                bytes: 35
+                line: 2
+                character: 10
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 35
+              line: 2
+              character: 10
+            end_position:
+              bytes: 36
+              line: 2
+              character: 11
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 36
+                line: 2
+                character: 11
+              end_position:
+                bytes: 37
+                line: 2
+                character: 12
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Array:
+            braces:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 37
+                      line: 2
+                      character: 12
+                    end_position:
+                      bytes: 38
+                      line: 2
+                      character: 13
+                    token_type:
+                      type: Symbol
+                      symbol: "{"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 38
+                        line: 2
+                        character: 13
+                      end_position:
+                        bytes: 39
+                        line: 2
+                        character: 14
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 67
+                      line: 2
+                      character: 42
+                    end_position:
+                      bytes: 68
+                      line: 2
+                      character: 43
+                    token_type:
+                      type: Symbol
+                      symbol: "}"
+                  trailing_trivia: []
+            type_info:
+              Table:
+                braces:
+                  tokens:
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 39
+                          line: 2
+                          character: 14
+                        end_position:
+                          bytes: 40
+                          line: 2
+                          character: 15
+                        token_type:
+                          type: Symbol
+                          symbol: "{"
+                      trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 65
+                          line: 2
+                          character: 40
+                        end_position:
+                          bytes: 66
+                          line: 2
+                          character: 41
+                        token_type:
+                          type: Symbol
+                          symbol: "}"
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 66
+                            line: 2
+                            character: 41
+                          end_position:
+                            bytes: 67
+                            line: 2
+                            character: 42
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                fields:
+                  pairs:
+                    - Punctuated:
+                        - key:
+                            Name:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 40
+                                  line: 2
+                                  character: 15
+                                end_position:
+                                  bytes: 44
+                                  line: 2
+                                  character: 19
+                                token_type:
+                                  type: Identifier
+                                  identifier: Name
+                              trailing_trivia: []
+                          colon:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 44
+                                line: 2
+                                character: 19
+                              end_position:
+                                bytes: 45
+                                line: 2
+                                character: 20
+                              token_type:
+                                type: Symbol
+                                symbol: ":"
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 45
+                                  line: 2
+                                  character: 20
+                                end_position:
+                                  bytes: 46
+                                  line: 2
+                                  character: 21
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                          value:
+                            Basic:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 46
+                                  line: 2
+                                  character: 21
+                                end_position:
+                                  bytes: 52
+                                  line: 2
+                                  character: 27
+                                token_type:
+                                  type: Identifier
+                                  identifier: string
+                              trailing_trivia: []
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 52
+                              line: 2
+                              character: 27
+                            end_position:
+                              bytes: 53
+                              line: 2
+                              character: 28
+                            token_type:
+                              type: Symbol
+                              symbol: ","
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 53
+                                line: 2
+                                character: 28
+                              end_position:
+                                bytes: 54
+                                line: 2
+                                character: 29
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        key:
+                          Name:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 54
+                                line: 2
+                                character: 29
+                              end_position:
+                                bytes: 57
+                                line: 2
+                                character: 32
+                              token_type:
+                                type: Identifier
+                                identifier: Foo
+                            trailing_trivia: []
+                        colon:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 57
+                              line: 2
+                              character: 32
+                            end_position:
+                              bytes: 58
+                              line: 2
+                              character: 33
+                            token_type:
+                              type: Symbol
+                              symbol: ":"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 58
+                                line: 2
+                                character: 33
+                              end_position:
+                                bytes: 59
+                                line: 2
+                                character: 34
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                        value:
+                          Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 59
+                                line: 2
+                                character: 34
+                              end_position:
+                                bytes: 65
+                                line: 2
+                                character: 40
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia: []
+    - ~
+

--- a/full-moon/tests/roblox_cases/pass/types_nested_array/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_nested_array/source.lua
@@ -1,0 +1,2 @@
+type Foo = { { string } }
+type Foo = { {Name: string, Foo: number} }

--- a/full-moon/tests/roblox_cases/pass/types_nested_array/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_nested_array/tokens.snap
@@ -1,0 +1,434 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 4
+    line: 1
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 4
+    line: 1
+    character: 5
+  end_position:
+    bytes: 5
+    line: 1
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 5
+    line: 1
+    character: 6
+  end_position:
+    bytes: 8
+    line: 1
+    character: 9
+  token_type:
+    type: Identifier
+    identifier: Foo
+- start_position:
+    bytes: 8
+    line: 1
+    character: 9
+  end_position:
+    bytes: 9
+    line: 1
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 9
+    line: 1
+    character: 10
+  end_position:
+    bytes: 10
+    line: 1
+    character: 11
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 10
+    line: 1
+    character: 11
+  end_position:
+    bytes: 11
+    line: 1
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 11
+    line: 1
+    character: 12
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 13
+    line: 1
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 13
+    line: 1
+    character: 14
+  end_position:
+    bytes: 14
+    line: 1
+    character: 15
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 14
+    line: 1
+    character: 15
+  end_position:
+    bytes: 15
+    line: 1
+    character: 16
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 15
+    line: 1
+    character: 16
+  end_position:
+    bytes: 21
+    line: 1
+    character: 22
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 21
+    line: 1
+    character: 22
+  end_position:
+    bytes: 22
+    line: 1
+    character: 23
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 22
+    line: 1
+    character: 23
+  end_position:
+    bytes: 23
+    line: 1
+    character: 24
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 23
+    line: 1
+    character: 24
+  end_position:
+    bytes: 24
+    line: 1
+    character: 25
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 24
+    line: 1
+    character: 25
+  end_position:
+    bytes: 25
+    line: 1
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 25
+    line: 1
+    character: 26
+  end_position:
+    bytes: 26
+    line: 1
+    character: 26
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 26
+    line: 2
+    character: 1
+  end_position:
+    bytes: 30
+    line: 2
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 30
+    line: 2
+    character: 5
+  end_position:
+    bytes: 31
+    line: 2
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 31
+    line: 2
+    character: 6
+  end_position:
+    bytes: 34
+    line: 2
+    character: 9
+  token_type:
+    type: Identifier
+    identifier: Foo
+- start_position:
+    bytes: 34
+    line: 2
+    character: 9
+  end_position:
+    bytes: 35
+    line: 2
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 35
+    line: 2
+    character: 10
+  end_position:
+    bytes: 36
+    line: 2
+    character: 11
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 36
+    line: 2
+    character: 11
+  end_position:
+    bytes: 37
+    line: 2
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 37
+    line: 2
+    character: 12
+  end_position:
+    bytes: 38
+    line: 2
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 38
+    line: 2
+    character: 13
+  end_position:
+    bytes: 39
+    line: 2
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 39
+    line: 2
+    character: 14
+  end_position:
+    bytes: 40
+    line: 2
+    character: 15
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 40
+    line: 2
+    character: 15
+  end_position:
+    bytes: 44
+    line: 2
+    character: 19
+  token_type:
+    type: Identifier
+    identifier: Name
+- start_position:
+    bytes: 44
+    line: 2
+    character: 19
+  end_position:
+    bytes: 45
+    line: 2
+    character: 20
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 45
+    line: 2
+    character: 20
+  end_position:
+    bytes: 46
+    line: 2
+    character: 21
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 46
+    line: 2
+    character: 21
+  end_position:
+    bytes: 52
+    line: 2
+    character: 27
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 52
+    line: 2
+    character: 27
+  end_position:
+    bytes: 53
+    line: 2
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 53
+    line: 2
+    character: 28
+  end_position:
+    bytes: 54
+    line: 2
+    character: 29
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 54
+    line: 2
+    character: 29
+  end_position:
+    bytes: 57
+    line: 2
+    character: 32
+  token_type:
+    type: Identifier
+    identifier: Foo
+- start_position:
+    bytes: 57
+    line: 2
+    character: 32
+  end_position:
+    bytes: 58
+    line: 2
+    character: 33
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 58
+    line: 2
+    character: 33
+  end_position:
+    bytes: 59
+    line: 2
+    character: 34
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 59
+    line: 2
+    character: 34
+  end_position:
+    bytes: 65
+    line: 2
+    character: 40
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 65
+    line: 2
+    character: 40
+  end_position:
+    bytes: 66
+    line: 2
+    character: 41
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 66
+    line: 2
+    character: 41
+  end_position:
+    bytes: 67
+    line: 2
+    character: 42
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 67
+    line: 2
+    character: 42
+  end_position:
+    bytes: 68
+    line: 2
+    character: 43
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 68
+    line: 2
+    character: 43
+  end_position:
+    bytes: 68
+    line: 2
+    character: 43
+  token_type:
+    type: Eof
+

--- a/full-moon/tests/roblox_cases/pass/types_semicolon_delimeter/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_semicolon_delimeter/ast.snap
@@ -1,0 +1,323 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+
+---
+stmts:
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 0
+              line: 1
+              character: 1
+            end_position:
+              bytes: 4
+              line: 1
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 4
+                line: 1
+                character: 5
+              end_position:
+                bytes: 5
+                line: 1
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 5
+              line: 1
+              character: 6
+            end_position:
+              bytes: 8
+              line: 1
+              character: 9
+            token_type:
+              type: Identifier
+              identifier: Foo
+          trailing_trivia:
+            - start_position:
+                bytes: 8
+                line: 1
+                character: 9
+              end_position:
+                bytes: 9
+                line: 1
+                character: 10
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 9
+              line: 1
+              character: 10
+            end_position:
+              bytes: 10
+              line: 1
+              character: 11
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 10
+                line: 1
+                character: 11
+              end_position:
+                bytes: 11
+                line: 1
+                character: 12
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Table:
+            braces:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 11
+                      line: 1
+                      character: 12
+                    end_position:
+                      bytes: 12
+                      line: 1
+                      character: 13
+                    token_type:
+                      type: Symbol
+                      symbol: "{"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 12
+                        line: 1
+                        character: 13
+                      end_position:
+                        bytes: 13
+                        line: 1
+                        character: 13
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 41
+                      line: 4
+                      character: 1
+                    end_position:
+                      bytes: 42
+                      line: 4
+                      character: 2
+                    token_type:
+                      type: Symbol
+                      symbol: "}"
+                  trailing_trivia: []
+            fields:
+              pairs:
+                - Punctuated:
+                    - key:
+                        Name:
+                          leading_trivia:
+                            - start_position:
+                                bytes: 13
+                                line: 2
+                                character: 1
+                              end_position:
+                                bytes: 14
+                                line: 2
+                                character: 2
+                              token_type:
+                                type: Whitespace
+                                characters: "\t"
+                          token:
+                            start_position:
+                              bytes: 14
+                              line: 2
+                              character: 2
+                            end_position:
+                              bytes: 17
+                              line: 2
+                              character: 5
+                            token_type:
+                              type: Identifier
+                              identifier: bar
+                          trailing_trivia: []
+                      colon:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 17
+                            line: 2
+                            character: 5
+                          end_position:
+                            bytes: 18
+                            line: 2
+                            character: 6
+                          token_type:
+                            type: Symbol
+                            symbol: ":"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 18
+                              line: 2
+                              character: 6
+                            end_position:
+                              bytes: 19
+                              line: 2
+                              character: 7
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      value:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 19
+                              line: 2
+                              character: 7
+                            end_position:
+                              bytes: 25
+                              line: 2
+                              character: 13
+                            token_type:
+                              type: Identifier
+                              identifier: number
+                          trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 25
+                          line: 2
+                          character: 13
+                        end_position:
+                          bytes: 26
+                          line: 2
+                          character: 14
+                        token_type:
+                          type: Symbol
+                          symbol: ;
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 26
+                            line: 2
+                            character: 14
+                          end_position:
+                            bytes: 27
+                            line: 2
+                            character: 14
+                          token_type:
+                            type: Whitespace
+                            characters: "\n"
+                - Punctuated:
+                    - key:
+                        Name:
+                          leading_trivia:
+                            - start_position:
+                                bytes: 27
+                                line: 3
+                                character: 1
+                              end_position:
+                                bytes: 28
+                                line: 3
+                                character: 2
+                              token_type:
+                                type: Whitespace
+                                characters: "\t"
+                          token:
+                            start_position:
+                              bytes: 28
+                              line: 3
+                              character: 2
+                            end_position:
+                              bytes: 31
+                              line: 3
+                              character: 5
+                            token_type:
+                              type: Identifier
+                              identifier: baz
+                          trailing_trivia: []
+                      colon:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 31
+                            line: 3
+                            character: 5
+                          end_position:
+                            bytes: 32
+                            line: 3
+                            character: 6
+                          token_type:
+                            type: Symbol
+                            symbol: ":"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 32
+                              line: 3
+                              character: 6
+                            end_position:
+                              bytes: 33
+                              line: 3
+                              character: 7
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      value:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 33
+                              line: 3
+                              character: 7
+                            end_position:
+                              bytes: 39
+                              line: 3
+                              character: 13
+                            token_type:
+                              type: Identifier
+                              identifier: number
+                          trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 39
+                          line: 3
+                          character: 13
+                        end_position:
+                          bytes: 40
+                          line: 3
+                          character: 14
+                        token_type:
+                          type: Symbol
+                          symbol: ;
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 40
+                            line: 3
+                            character: 14
+                          end_position:
+                            bytes: 41
+                            line: 3
+                            character: 14
+                          token_type:
+                            type: Whitespace
+                            characters: "\n"
+    - ~
+

--- a/full-moon/tests/roblox_cases/pass/types_semicolon_delimeter/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_semicolon_delimeter/source.lua
@@ -1,0 +1,4 @@
+type Foo = {
+	bar: number;
+	baz: number;
+}

--- a/full-moon/tests/roblox_cases/pass/types_semicolon_delimeter/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_semicolon_delimeter/tokens.snap
@@ -1,0 +1,269 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 4
+    line: 1
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 4
+    line: 1
+    character: 5
+  end_position:
+    bytes: 5
+    line: 1
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 5
+    line: 1
+    character: 6
+  end_position:
+    bytes: 8
+    line: 1
+    character: 9
+  token_type:
+    type: Identifier
+    identifier: Foo
+- start_position:
+    bytes: 8
+    line: 1
+    character: 9
+  end_position:
+    bytes: 9
+    line: 1
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 9
+    line: 1
+    character: 10
+  end_position:
+    bytes: 10
+    line: 1
+    character: 11
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 10
+    line: 1
+    character: 11
+  end_position:
+    bytes: 11
+    line: 1
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 11
+    line: 1
+    character: 12
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 13
+    line: 1
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 13
+    line: 2
+    character: 1
+  end_position:
+    bytes: 14
+    line: 2
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\t"
+- start_position:
+    bytes: 14
+    line: 2
+    character: 2
+  end_position:
+    bytes: 17
+    line: 2
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: bar
+- start_position:
+    bytes: 17
+    line: 2
+    character: 5
+  end_position:
+    bytes: 18
+    line: 2
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 18
+    line: 2
+    character: 6
+  end_position:
+    bytes: 19
+    line: 2
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 19
+    line: 2
+    character: 7
+  end_position:
+    bytes: 25
+    line: 2
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 25
+    line: 2
+    character: 13
+  end_position:
+    bytes: 26
+    line: 2
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: ;
+- start_position:
+    bytes: 26
+    line: 2
+    character: 14
+  end_position:
+    bytes: 27
+    line: 2
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 27
+    line: 3
+    character: 1
+  end_position:
+    bytes: 28
+    line: 3
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\t"
+- start_position:
+    bytes: 28
+    line: 3
+    character: 2
+  end_position:
+    bytes: 31
+    line: 3
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: baz
+- start_position:
+    bytes: 31
+    line: 3
+    character: 5
+  end_position:
+    bytes: 32
+    line: 3
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 32
+    line: 3
+    character: 6
+  end_position:
+    bytes: 33
+    line: 3
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 33
+    line: 3
+    character: 7
+  end_position:
+    bytes: 39
+    line: 3
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 39
+    line: 3
+    character: 13
+  end_position:
+    bytes: 40
+    line: 3
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: ;
+- start_position:
+    bytes: 40
+    line: 3
+    character: 14
+  end_position:
+    bytes: 41
+    line: 3
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 41
+    line: 4
+    character: 1
+  end_position:
+    bytes: 42
+    line: 4
+    character: 2
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 42
+    line: 4
+    character: 2
+  end_position:
+    bytes: 42
+    line: 4
+    character: 2
+  token_type:
+    type: Eof
+


### PR DESCRIPTION
This PR splits parsing of Luau type tables/arrays into smaller parts.
It allows the use of semicolons as delimiters in type tables - fixes #185 

As this change removed the use of `ZeroOrMoreDelimited`, it also fixes the issue regarding nested array types - fixes #188 

This PR reverses the parsing strategy - now we attempt to parse a type array before attempting to parse a type table (required for #188 fix). This is fine if the syntax is valid, but if we get incorrect syntax, error messages may be slightly different (a quick test didn't produce anything though). Some better error messages may be lost when attempting parsing a `TypeInfo::Array`, but it will still *error* from attempting to parse a `TypeInfo::Table`