### PR TITLE
Fix clippy and cargo fmt issues

### DIFF
--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2411,10 +2411,10 @@ mod tests {
                 parentheses: ContainedSpan::new(token.clone(), token.clone()),
             },
         );
-        NumericFor::new(token.clone(), expression.clone(), expression.clone());
+        NumericFor::new(token, expression.clone(), expression.clone());
         Repeat::new(expression.clone());
         Return::new();
         TableConstructor::new();
-        While::new(expression.clone());
+        While::new(expression);
     }
 }

--- a/full-moon/src/ast/parser_util.rs
+++ b/full-moon/src/ast/parser_util.rs
@@ -47,9 +47,7 @@ impl<'a> ParserState<'a> {
             panic!("peek failed, when there should always be an eof");
         }
 
-        let result = self.tokens.get(self.index).expect("couldn't peek, no eof?");
-
-        &result
+        self.tokens.get(self.index).expect("couldn't peek, no eof?")
     }
 }
 

--- a/full-moon/src/node.rs
+++ b/full-moon/src/node.rs
@@ -82,7 +82,7 @@ impl<'a> Iterator for Tokens<'a> {
             TokenItem::TokenReference(reference) => Some(reference),
             TokenItem::MoreTokens(node) => {
                 let mut tokens = node.tokens();
-                tokens.items.extend(self.items.drain(..));
+                tokens.items.append(&mut self.items);
                 self.items = tokens.items;
                 self.next()
             }
@@ -100,7 +100,7 @@ impl<'a> DoubleEndedIterator for Tokens<'a> {
             TokenItem::TokenReference(reference) => Some(reference),
             TokenItem::MoreTokens(node) => {
                 let mut tokens = node.tokens();
-                self.items.extend(tokens.items.drain(..));
+                self.items.append(&mut tokens.items);
                 self.next_back()
             }
         }
@@ -194,7 +194,7 @@ impl Node for TokenReference {
 
     fn tokens(&self) -> Tokens {
         Tokens {
-            items: vec![TokenItem::TokenReference(&self)],
+            items: vec![TokenItem::TokenReference(self)],
         }
     }
 }
@@ -277,7 +277,7 @@ impl<'a, A: Node, B: Node> Node for (A, B) {
 
     fn tokens(&self) -> Tokens {
         let mut items = self.0.tokens().items;
-        items.extend(self.1.tokens().items.drain(..));
+        items.append(&mut self.1.tokens().items);
 
         Tokens { items }
     }

--- a/full-moon/tests/derive_node.rs
+++ b/full-moon/tests/derive_node.rs
@@ -11,15 +11,15 @@ fn test_position_min_max() {
             self.0 = true;
             assert_eq!(
                 MIN_MAX_CODE
-                    .bytes()
-                    .nth(constructor.start_position().unwrap().bytes()),
-                Some(b'{')
+                    .as_bytes()
+                    .get(constructor.start_position().unwrap().bytes()),
+                Some(&b'{')
             );
             assert_eq!(
                 MIN_MAX_CODE
-                    .bytes()
-                    .nth(constructor.end_position().unwrap().bytes() - 1),
-                Some(b'}')
+                    .as_bytes()
+                    .get(constructor.end_position().unwrap().bytes() - 1),
+                Some(&b'}')
             );
         }
     }

--- a/full-moon/tests/node.rs
+++ b/full-moon/tests/node.rs
@@ -26,8 +26,8 @@ fn test_similar() {
 #[test]
 fn test_tokens_collect() {
     let source = parse("local abcd = 1").unwrap();
-    let tokens = source.nodes().tokens().collect::<Vec<_>>();
-    assert_eq!(tokens.len(), 4);
+    let tokens = source.nodes().tokens();
+    assert_eq!(tokens.count(), 4);
 }
 
 #[test]


### PR DESCRIPTION
Have you seen rust analyzer's macro expansion error?

```
Cannot automatically infer format for types with more than 1 fieldrust-analyzer
```

https://github.com/Kampfkarren/full-moon/blob/main/full-moon/src/ast/mod.rs#L250-L306