### PR TITLE
Handle UTF8 BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased changes
 ### Added
 - Added `token()` methods on `BinOp`, `UnOp` and `CompoundOp` to get the token associated with the operator
+- Added handling of UTF8 BOM(Byte order mark)
 
 ## [0.13.1] - 2021-07-07
 ### Fixed

--- a/full-moon/src/lib.rs
+++ b/full-moon/src/lib.rs
@@ -98,6 +98,13 @@ mod tests {
 
     #[test]
     #[allow(non_snake_case)]
+    fn test_parse_code_with_utf8_BOM() {
+        assert!(parse(str_with_BOM("local x = 1").as_str()).is_ok());
+        assert!(parse(str_with_BOM("\nlocal x = 1").as_str()).is_ok());
+    }
+
+    #[test]
+    #[allow(non_snake_case)]
     fn test_skip_utf8_BOM() {
         assert_eq!(skip_utf8_BOM(str_with_BOM("123").as_str()), "123");
         assert_eq!(skip_utf8_BOM(str_with_BOM("").as_str()), "");

--- a/full-moon/src/lib.rs
+++ b/full-moon/src/lib.rs
@@ -66,6 +66,7 @@ impl std::error::Error for Error {}
 /// assert!(full_moon::parse("local x = ").is_err());
 /// ```
 pub fn parse(code: &str) -> Result<ast::Ast, Error> {
+    let code = skip_utf8_BOM(code);
     let tokens = tokenizer::tokens(code).map_err(Error::TokenizerError)?;
     ast::Ast::from_tokens(tokens).map_err(Error::AstError)
 }
@@ -73,4 +74,37 @@ pub fn parse(code: &str) -> Result<ast::Ast, Error> {
 /// Prints back Lua code from an [`Ast`](ast::Ast)
 pub fn print(ast: &ast::Ast) -> String {
     format!("{}{}", ast.nodes(), ast.eof())
+}
+
+/// Clean UTF8 BOM(byte order mark https://en.wikipedia.org/wiki/Byte_order_mark).
+///
+/// IMPORTANT: It doesn't handle UTF16 BOM see wiki.
+///
+/// Original LUA interpretator does this as well.
+/// https://github.com/lua/lua/blob/439e45a2f69549b674d6a6e2023e8debfa00a2b8/lauxlib.c#L742-L753
+#[allow(non_snake_case)]
+fn skip_utf8_BOM(code: &str) -> &str {
+  const BOM: &[u8; 3] = b"\xEF\xBB\xBF";
+  if code.as_bytes().starts_with(BOM) {
+      &code[3..]
+  } else {
+      code
+  }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(non_snake_case)]
+    fn test_skip_utf8_BOM() {
+        assert_eq!(skip_utf8_BOM(str_with_BOM("123").as_str()), "123");
+        assert_eq!(skip_utf8_BOM(str_with_BOM("").as_str()), "");
+    }
+
+    #[allow(non_snake_case)]
+    fn str_with_BOM(s: &str) -> String {
+        format!("{}{}", String::from_utf8(b"\xEF\xBB\xBF".to_vec()).unwrap(), s)
+    }
 }

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -781,7 +781,7 @@ peg::parser! {
                       body.insert(0, shebang)
                   }
                   if let Some(bom) = bom {
-                    body.insert(0, bom)
+                      body.insert(0, bom)
                   }
                   body
               }

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -702,6 +702,10 @@ peg::parser! {
             = line:$("#!" (!line_ending() [_])* line_ending())
               {TokenType::Shebang{line:line.into()}.into()}
 
+        pub(super) rule utf8_bom() -> RawToken
+            = chars:$("\u{feff}") // A BOM sequence in UTF8 "\xEF\xBB\xBF"
+            { TokenType::Whitespace { characters:chars.into() }.into() }
+
         pub(super) rule identifier() -> RawToken
             = id:$(['_'|'a'..='z'|'A'..='Z'] ['_'|'a'..='z'|'A'..='Z'|'0'..='9']*)
               { match parse_keyword(id) {
@@ -768,12 +772,16 @@ peg::parser! {
             / identifier()
 
         pub(crate) rule tokens() -> Vec<(RawToken, usize)>
-            = shebang:(shebang:shebang() pos:position!() {(shebang,pos)})?
+            = bom:(bom:utf8_bom() pos:position!() {(bom,pos)})?
+              shebang:(shebang:shebang() pos:position!() {(shebang,pos)})?
               body:( token:token() pos:position!() {(token,pos)})*
               {
                   let mut body = body;
                   if let Some(shebang) = shebang {
                       body.insert(0, shebang)
+                  }
+                  if let Some(bom) = bom {
+                    body.insert(0, bom)
                   }
                   body
               }
@@ -1176,6 +1184,22 @@ mod tests {
         test_rule!(
             " #!/usr/bin/env lua\n",
             TokenizerErrorType::UnexpectedShebang
+        );
+    }
+
+    #[test]
+    fn test_rule_bom() {
+        let bom = String::from_utf8(b"\xEF\xBB\xBF".to_vec()).unwrap();
+        test_rule!(
+            utf8_bom(&bom),
+            TokenType::Whitespace {
+                characters: ShortString::new(&bom),
+            }
+        );
+        // Don't recognize if not in the beggining.
+        test_rule!(
+            &format!("#!/usr/bin/env lua\n {}", bom),
+            TokenizerErrorType::UnexpectedToken('\u{feff}')
         );
     }
 


### PR DESCRIPTION
closes #117

Curiosity: I was wondering if original Lua intepretator correctly handles this?

From 5 mines of wondering I would say it doesn't?
Because it doesn't skip chars actually?
Am I wrong here?

https://github.com/lua/lua/blob/439e45a2f69549b674d6a6e2023e8debfa00a2b8/lauxlib.c#L742-L753