### PR TITLE
Fix clippy warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,10 @@ jobs:
       run: |
         cd full-moon
         cargo test --no-default-features --features serde
-    - name: Clippy
+    - name: Clippy (default)
+      run: |
+        cargo clippy -- -D warnings
+    - name: Clippy (all features)
       run: |
         cargo clippy --all-features -- -D warnings
     - name: Rustfmt

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -1096,6 +1096,7 @@ define_parser!(ParseIdentifier, TokenReference, |_, state| {
 #[derive(Clone, Copy, Debug, PartialEq)]
 enum TypeInfoContext {
     /// A standard type info, with no context
+    #[cfg(feature = "roblox")]
     None,
     /// A type inside of parentheses, either for the parameters in a `TypeInfo::Callback`, or for a `TypeInfo::Tuple`
     /// Variadic type infos are only permitted inside of here


### PR DESCRIPTION
Fixes a clippy warning which shows up when running clippy with no features enabled - this is currently not showing up in CI, so I added a new CI check for this too.