### PR TITLE
Show feature gates on documentation

### DIFF
--- a/full-moon/Cargo.toml
+++ b/full-moon/Cargo.toml
@@ -11,7 +11,9 @@ keywords = ["lua", "parser", "lua51"]
 edition = "2018"
 
 [package.metadata.docs.rs]
+# Build Locally: RUSTDOCFLAGS="--cfg doc_cfg" cargo +nightly doc --features roblox,lua52  --no-deps --open
 features = ["roblox", "lua52"]
+rustdoc-args = ["--cfg", "doc_cfg"]
 
 [features]
 default = ["serde"]

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2013,7 +2013,7 @@ make_op!(BinOp,
 
 impl BinOp {
     /// The precedence of the operator, from a scale of 1 to 8. The larger the number, the higher the precedence.
-    /// See more at http://www.lua.org/manual/5.1/manual.html#2.5.6
+    /// See more at <http://www.lua.org/manual/5.1/manual.html#2.5.6>
     pub fn precedence(&self) -> u8 {
         match *self {
             BinOp::Caret(_) => 8,
@@ -2032,7 +2032,7 @@ impl BinOp {
     }
 
     /// Whether the operator is right associative. If not, it is left associative.
-    /// See more at https://www.lua.org/pil/3.5.html
+    /// See more at <https://www.lua.org/pil/3.5.html>
     pub fn is_right_associative(&self) -> bool {
         matches!(*self, BinOp::Caret(_) | BinOp::TwoDots(_))
     }
@@ -2070,7 +2070,7 @@ make_op!(UnOp,
 
 impl UnOp {
     /// The precedence of the operator, from a scale of 1 to 8. The larger the number, the higher the precedence.
-    /// See more at http://www.lua.org/manual/5.1/manual.html#2.5.6
+    /// See more at <http://www.lua.org/manual/5.1/manual.html#2.5.6>
     pub fn precedence(&self) -> u8 {
         7
     }

--- a/full-moon/src/ast/types.rs
+++ b/full-moon/src/ast/types.rs
@@ -1,5 +1,4 @@
-//! Contains the types necessary to parse [Roblox's typed Lua](https://devforum.roblox.com/t/luau-type-checking-beta/435382).
-//! Only usable when the "roblox" feature flag is enabled.
+//! Contains the types necessary to parse [Luau](https://luau-lang.org/).
 use super::{punctuated::Punctuated, span::ContainedSpan, *};
 use crate::{util::display_option, ShortString};
 use derive_more::Display;

--- a/full-moon/src/lib.rs
+++ b/full-moon/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 #![allow(clippy::large_enum_variant)]
+#![cfg_attr(doc_cfg, feature(doc_auto_cfg))]
 //! # Full Moon
 //!
 //! `full_moon` is a lossless parser for Lua 5.1


### PR DESCRIPTION
Provides better documentation hints on the docs.rs page for nodes gated behind feature flags.
Example:
![image](https://user-images.githubusercontent.com/19635171/156931899-a0cf1279-57fe-4bf1-ab40-5b2a73553104.png)
