### PR TITLE
Fix clippy warnings

### DIFF
--- a/full-moon/src/ast/lua52.rs
+++ b/full-moon/src/ast/lua52.rs
@@ -9,7 +9,7 @@ use full_moon_derive::{Node, Visit};
 use serde::{Deserialize, Serialize};
 
 /// A goto statement, such as `goto label`.
-#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[derive(Clone, Debug, Display, PartialEq, Eq, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(fmt = "{}{}", "goto_token", "label_name")]
 pub struct Goto {
@@ -48,7 +48,7 @@ impl Goto {
 }
 
 /// A label, such as `::label::`.
-#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[derive(Clone, Debug, Display, PartialEq, Eq, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(fmt = "{}{}{}", "left_colons", "name", "right_colons")]
 pub struct Label {

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1441,7 +1441,7 @@ impl fmt::Display for FunctionBody {
 }
 
 /// A parameter in a function declaration
-#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[derive(Clone, Debug, Display, PartialEq, Eq, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub enum Parameter {
@@ -1874,7 +1874,7 @@ impl FunctionCall {
 }
 
 /// A function name when being declared as [`FunctionDeclaration`]
-#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[derive(Clone, Debug, Display, PartialEq, Eq, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(
     fmt = "{}{}{}",
@@ -2084,7 +2084,7 @@ impl UnOp {
 }
 
 /// An error that occurs when creating the ast *after* tokenizing
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum AstError {
     /// There were no tokens passed, which shouldn't happen normally
@@ -2252,7 +2252,7 @@ pub(crate) fn extract_token_references(mut tokens: Vec<Token>) -> Vec<TokenRefer
                     // Take all trivia up to and including the newline character. If we see a newline character
                     // we should break once we have taken it in.
                     let should_break =
-                        if let TokenType::Whitespace { ref characters } = &*token.token_type() {
+                        if let TokenType::Whitespace { ref characters } = token.token_type() {
                             // Use contains in order to tolerate \r\n line endings and mixed whitespace tokens
                             characters.contains('\n')
                         } else {

--- a/full-moon/src/ast/parser_util.rs
+++ b/full-moon/src/ast/parser_util.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt};
 
 // This is cloned everywhere, so make sure cloning is as inexpensive as possible
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct ParserState<'a> {
     pub index: usize,
     pub len: usize,
@@ -76,7 +76,7 @@ pub(crate) trait Parser: Sized {
 #[macro_export]
 macro_rules! make_op {
     ($enum:ident, $(#[$outer:meta])* { $($operator:ident,)+ }) => {
-        #[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+        #[derive(Clone, Debug, Display, PartialEq, Eq, Node, Visit)]
         #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
         #[non_exhaustive]
         $(#[$outer])*
@@ -211,7 +211,7 @@ macro_rules! define_lua52_parser {
     };
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum InternalAstError {
     NoMatch,
@@ -221,7 +221,7 @@ pub enum InternalAstError {
     },
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ZeroOrMore<P>(pub P);
 
 impl<P, T> Parser for ZeroOrMore<P>
@@ -271,7 +271,7 @@ macro_rules! test_pairs_logic {
     };
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ZeroOrMoreDelimited<ItemParser, Delimiter>(
     pub ItemParser, // What items to parse, what is actually returned in a vec
     pub Delimiter,  // Delimiter parser between one item and another
@@ -339,7 +339,7 @@ where
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OneOrMore<ItemParser, Delimiter>(
     pub ItemParser, // What items to parse, what is actually returned in a vec
     pub Delimiter,  // Delimiter parser between one item and another
@@ -400,7 +400,7 @@ where
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NoDelimiter;
 
 define_parser!(NoDelimiter, (), |_, state| Ok((state, ())));

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -61,7 +61,7 @@ define_parser!(ParseStringLiteral, TokenReference, |_, state| {
     }
 });
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct ParseBlock;
 define_parser!(ParseBlock, Block, |_, state| {
     let mut stmts = Vec::new();

--- a/full-moon/src/ast/punctuated.rs
+++ b/full-moon/src/ast/punctuated.rs
@@ -29,7 +29,7 @@ use std::{fmt::Display, iter::FromIterator};
 /// A punctuated sequence of node `T` separated by
 /// [`TokenReference`](crate::tokenizer::TokenReference).
 /// Refer to the [module documentation](index.html) for more details.
-#[derive(Clone, Debug, Default, Display, PartialEq)]
+#[derive(Clone, Debug, Default, Display, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[display(bound = "T: Display")]
 #[display(fmt = "{}", "util::join_vec(pairs)")]
@@ -300,7 +300,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
 /// A node `T` followed by the possible trailing
 /// [`TokenReference`](crate::tokenizer::TokenReference).
 /// Refer to the [module documentation](index.html) for more details.
-#[derive(Clone, Debug, Display, PartialEq)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum Pair<T> {
     /// A node `T` with no trailing punctuation

--- a/full-moon/src/ast/span.rs
+++ b/full-moon/src/ast/span.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 
 /// A contained span with the beginning and ending bounds.
 /// Refer to the [module documentation](index.html) for more details.
-#[derive(Clone, Debug, PartialEq, Visit)]
+#[derive(Clone, Debug, PartialEq, Eq, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ContainedSpan {
     pub(crate) tokens: (TokenReference, TokenReference),

--- a/full-moon/src/ast/types.rs
+++ b/full-moon/src/ast/types.rs
@@ -416,7 +416,7 @@ impl TypeDeclaration {
 }
 
 /// A generic declaration parameter used in [`GenericDeclaration`]. Can either be a name or a variadic pack.
-#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[derive(Clone, Debug, Display, PartialEq, Eq, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub enum GenericParameterInfo {

--- a/full-moon/src/lib.rs
+++ b/full-moon/src/lib.rs
@@ -33,7 +33,7 @@ compile_error!("Serde feature must be enabled for tests");
 
 /// An error type that consists of both [`AstError`](ast::AstError) and [`TokenizerError`](tokenizer::TokenizerError)
 /// Used by [`parse`]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {
     /// Triggered if there's an issue creating an AST, but tokenizing must have succeeded
     AstError(ast::AstError),

--- a/full-moon/src/short_string.rs
+++ b/full-moon/src/short_string.rs
@@ -43,7 +43,7 @@ impl Deref for ShortString {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        &*self.0
+        &self.0
     }
 }
 

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -326,7 +326,7 @@ impl Display for Symbol {
 }
 
 /// The possible errors that can happen while tokenizing.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum TokenizerErrorType {
     /// An unclosed multi-line comment was found
@@ -571,7 +571,7 @@ impl fmt::Display for Token {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         use self::TokenType::*;
 
-        match &*self.token_type() {
+        match self.token_type() {
             Eof => Ok(()),
             Number { text } => text.fmt(formatter),
             Identifier { identifier } => identifier.fmt(formatter),
@@ -755,7 +755,7 @@ impl TokenReference {
 
 impl std::borrow::Borrow<Token> for &TokenReference {
     fn borrow(&self) -> &Token {
-        &**self
+        self
     }
 }
 
@@ -1008,7 +1008,7 @@ fn tokenize_code(code: &str) -> Vec<(RawToken, Span)> {
 }
 
 /// Information about an error that occurs while tokenizing
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TokenizerError {
     /// The type of error

--- a/full-moon/src/util.rs
+++ b/full-moon/src/util.rs
@@ -1,8 +1,8 @@
 use crate::tokenizer::TokenReference;
-use std::{
-    borrow::Borrow,
-    fmt::{Display, Write},
-};
+use std::{borrow::Borrow, fmt::Display};
+
+#[cfg(feature = "roblox")]
+use std::fmt::Write;
 
 #[cfg(feature = "roblox")]
 use crate::ast::punctuated::Punctuated;

--- a/full-moon/src/util.rs
+++ b/full-moon/src/util.rs
@@ -1,5 +1,8 @@
 use crate::tokenizer::TokenReference;
-use std::{borrow::Borrow, fmt::Display};
+use std::{
+    borrow::Borrow,
+    fmt::{Display, Write},
+};
 
 #[cfg(feature = "roblox")]
 use crate::ast::punctuated::Punctuated;
@@ -47,12 +50,13 @@ pub fn join_type_specifiers<I: IntoIterator<Item = Option<T2>>, T1: Display, T2:
             .into_iter()
             .chain(std::iter::repeat_with(|| None)),
     ) {
-        string.push_str(&format!(
+        let _ = write!(
+            string,
             "{}{}{}",
             parameter.value(),
             display_option(type_specifier),
             display_option(parameter.punctuation())
-        ));
+        );
     }
 
     string


### PR DESCRIPTION
Cleanup some derefs and a format_push_str.

Note: clippy wants `Eq` defined everywhere that `PartialEq` is - not 100% sure about this