### PR TITLE
Upgrade insta and pass yaml feature flag

### DIFF
--- a/full-moon/Cargo.toml
+++ b/full-moon/Cargo.toml
@@ -33,7 +33,7 @@ smol_str = { version = "0.1.17", features = ["serde"] }
 
 [dev-dependencies]
 criterion = "0.2"
-insta = { version = "1.7.0", features = ["glob"] }
+insta = { version = "1.19.0", features = ["glob", "yaml"] }
 pretty_assertions = "0.6.1"
 
 [[bench]]


### PR DESCRIPTION
insta 1.19 now requires `yaml` flag to be enabled (https://github.com/mitsuhiko/insta/blob/master/CHANGELOG.md#1190)

Since we aren't pinned to our current version, CI downloads the latest compatible insta and then runs that. This causes CI to now fail.

We upgrade insta and add in the yaml flag