### PR TITLE
Fix Lua5.3 DoubleGreaterThan incompatibility

### DIFF
--- a/full-moon/src/atom.rs
+++ b/full-moon/src/atom.rs
@@ -210,11 +210,7 @@ pub(crate) enum Atom {
     GreaterThanEqual,
 
     #[token(">")]
-    GreaterThan,
-
-    #[cfg(feature = "lua53")]
-    #[token(">>")]
-    DoubleGreaterThan,
+    GreaterThan, // Lua 5.3: we cannot include DoubleGreaterThan '>>' in the tokenizer as it collides with Luau generics
 
     #[token("#")]
     Hash,

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -239,8 +239,6 @@ impl TryFrom<Atom> for Symbol {
             Atom::Equal => Symbol::Equal,
             Atom::GreaterThanEqual => Symbol::GreaterThanEqual,
             Atom::GreaterThan => Symbol::GreaterThan,
-            #[cfg(feature = "lua53")]
-            Atom::DoubleGreaterThan => Symbol::DoubleGreaterThan,
             Atom::Hash => Symbol::Hash,
             Atom::LeftBracket => Symbol::LeftBracket,
             Atom::LeftBrace => Symbol::LeftBrace,

--- a/full-moon/tests/fail_cases.rs
+++ b/full-moon/tests/fail_cases.rs
@@ -83,6 +83,27 @@ fn test_lua52_parser_fail_cases() {
 }
 
 #[test]
+#[cfg(feature = "lua53")]
+#[cfg_attr(feature = "no-source-tests", ignore)]
+fn test_lua53_parser_fail_cases() {
+    run_test_folder("./tests/lua53_cases/fail/parser", |path| {
+        let source = fs::read_to_string(path.join("source.lua")).expect("couldn't read source.lua");
+
+        let tokens = tokenizer::tokens(&source).expect("couldn't tokenize");
+
+        assert_yaml_snapshot!("tokens", tokens);
+
+        match ast::Ast::from_tokens(tokens) {
+            Ok(_) => panic!("fail case passed for {:?}", path),
+            Err(error) => {
+                println!("error {:#?}", error);
+                assert_yaml_snapshot!("error", error);
+            }
+        }
+    })
+}
+
+#[test]
 #[cfg(feature = "lua54")]
 #[cfg_attr(feature = "no-source-tests", ignore)]
 fn test_lua54_parser_fail_cases() {

--- a/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/error.snap
+++ b/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/error.snap
@@ -1,0 +1,19 @@
+---
+source: full-moon/tests/fail_cases.rs
+expression: error
+---
+UnexpectedToken:
+  token:
+    start_position:
+      bytes: 75
+      line: 2
+      character: 11
+    end_position:
+      bytes: 76
+      line: 2
+      character: 12
+    token_type:
+      type: Number
+      text: "1"
+  additional: expected expression
+

--- a/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/source.lua
+++ b/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/source.lua
@@ -1,0 +1,2 @@
+-- We shouldn't parse this as >> since it has a space in between
+local x = 1 > > 2

--- a/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/tokens.snap
+++ b/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/tokens.snap
@@ -1,0 +1,180 @@
+---
+source: full-moon/tests/fail_cases.rs
+expression: tokens
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 64
+    line: 1
+    character: 65
+  token_type:
+    type: SingleLineComment
+    comment: " We shouldn't parse this as >> since it has a space in between"
+- start_position:
+    bytes: 64
+    line: 1
+    character: 65
+  end_position:
+    bytes: 65
+    line: 1
+    character: 65
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 65
+    line: 2
+    character: 1
+  end_position:
+    bytes: 70
+    line: 2
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 70
+    line: 2
+    character: 6
+  end_position:
+    bytes: 71
+    line: 2
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 71
+    line: 2
+    character: 7
+  end_position:
+    bytes: 72
+    line: 2
+    character: 8
+  token_type:
+    type: Identifier
+    identifier: x
+- start_position:
+    bytes: 72
+    line: 2
+    character: 8
+  end_position:
+    bytes: 73
+    line: 2
+    character: 9
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 73
+    line: 2
+    character: 9
+  end_position:
+    bytes: 74
+    line: 2
+    character: 10
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 74
+    line: 2
+    character: 10
+  end_position:
+    bytes: 75
+    line: 2
+    character: 11
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 75
+    line: 2
+    character: 11
+  end_position:
+    bytes: 76
+    line: 2
+    character: 12
+  token_type:
+    type: Number
+    text: "1"
+- start_position:
+    bytes: 76
+    line: 2
+    character: 12
+  end_position:
+    bytes: 77
+    line: 2
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 77
+    line: 2
+    character: 13
+  end_position:
+    bytes: 78
+    line: 2
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 78
+    line: 2
+    character: 14
+  end_position:
+    bytes: 79
+    line: 2
+    character: 15
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 79
+    line: 2
+    character: 15
+  end_position:
+    bytes: 80
+    line: 2
+    character: 16
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 80
+    line: 2
+    character: 16
+  end_position:
+    bytes: 81
+    line: 2
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 81
+    line: 2
+    character: 17
+  end_position:
+    bytes: 82
+    line: 2
+    character: 18
+  token_type:
+    type: Number
+    text: "2"
+- start_position:
+    bytes: 82
+    line: 2
+    character: 18
+  end_position:
+    bytes: 82
+    line: 2
+    character: 18
+  token_type:
+    type: Eof
+

--- a/full-moon/tests/lua53_cases/pass/binary-operators/tokens.snap
+++ b/full-moon/tests/lua53_cases/pass/binary-operators/tokens.snap
@@ -491,12 +491,23 @@ expression: tokens
     line: 4
     character: 13
   end_position:
+    bytes: 62
+    line: 4
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 62
+    line: 4
+    character: 14
+  end_position:
     bytes: 63
     line: 4
     character: 15
   token_type:
     type: Symbol
-    symbol: ">>"
+    symbol: ">"
 - start_position:
     bytes: 63
     line: 4

--- a/full-moon/tests/roblox_cases/pass/types_generic/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_generic/ast.snap
@@ -1,0 +1,418 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+---
+stmts:
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 0
+              line: 1
+              character: 1
+            end_position:
+              bytes: 4
+              line: 1
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 4
+                line: 1
+                character: 5
+              end_position:
+                bytes: 5
+                line: 1
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 5
+              line: 1
+              character: 6
+            end_position:
+              bytes: 10
+              line: 1
+              character: 11
+            token_type:
+              type: Identifier
+              identifier: Array
+          trailing_trivia: []
+        generics:
+          arrows:
+            tokens:
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 10
+                    line: 1
+                    character: 11
+                  end_position:
+                    bytes: 11
+                    line: 1
+                    character: 12
+                  token_type:
+                    type: Symbol
+                    symbol: "<"
+                trailing_trivia: []
+              - leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 12
+                    line: 1
+                    character: 13
+                  end_position:
+                    bytes: 13
+                    line: 1
+                    character: 14
+                  token_type:
+                    type: Symbol
+                    symbol: ">"
+                trailing_trivia:
+                  - start_position:
+                      bytes: 13
+                      line: 1
+                      character: 14
+                    end_position:
+                      bytes: 14
+                      line: 1
+                      character: 15
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+          generics:
+            pairs:
+              - End:
+                  parameter:
+                    Name:
+                      leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 11
+                          line: 1
+                          character: 12
+                        end_position:
+                          bytes: 12
+                          line: 1
+                          character: 13
+                        token_type:
+                          type: Identifier
+                          identifier: T
+                      trailing_trivia: []
+                  default: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 14
+              line: 1
+              character: 15
+            end_position:
+              bytes: 15
+              line: 1
+              character: 16
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 15
+                line: 1
+                character: 16
+              end_position:
+                bytes: 16
+                line: 1
+                character: 17
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Array:
+            braces:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 16
+                      line: 1
+                      character: 17
+                    end_position:
+                      bytes: 17
+                      line: 1
+                      character: 18
+                    token_type:
+                      type: Symbol
+                      symbol: "{"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 17
+                        line: 1
+                        character: 18
+                      end_position:
+                        bytes: 18
+                        line: 1
+                        character: 19
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 20
+                      line: 1
+                      character: 21
+                    end_position:
+                      bytes: 21
+                      line: 1
+                      character: 22
+                    token_type:
+                      type: Symbol
+                      symbol: "}"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 21
+                        line: 1
+                        character: 22
+                      end_position:
+                        bytes: 22
+                        line: 1
+                        character: 22
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+            type_info:
+              Basic:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 18
+                    line: 1
+                    character: 19
+                  end_position:
+                    bytes: 19
+                    line: 1
+                    character: 20
+                  token_type:
+                    type: Identifier
+                    identifier: T
+                trailing_trivia:
+                  - start_position:
+                      bytes: 19
+                      line: 1
+                      character: 20
+                    end_position:
+                      bytes: 20
+                      line: 1
+                      character: 21
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+    - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 22
+              line: 2
+              character: 1
+            end_position:
+              bytes: 27
+              line: 2
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 27
+                line: 2
+                character: 6
+              end_position:
+                bytes: 28
+                line: 2
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        type_specifiers:
+          - punctuation:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 29
+                  line: 2
+                  character: 8
+                end_position:
+                  bytes: 30
+                  line: 2
+                  character: 9
+                token_type:
+                  type: Symbol
+                  symbol: ":"
+              trailing_trivia:
+                - start_position:
+                    bytes: 30
+                    line: 2
+                    character: 9
+                  end_position:
+                    bytes: 31
+                    line: 2
+                    character: 10
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            type_info:
+              Generic:
+                base:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 31
+                      line: 2
+                      character: 10
+                    end_position:
+                      bytes: 36
+                      line: 2
+                      character: 15
+                    token_type:
+                      type: Identifier
+                      identifier: Array
+                  trailing_trivia: []
+                arrows:
+                  tokens:
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 36
+                          line: 2
+                          character: 15
+                        end_position:
+                          bytes: 37
+                          line: 2
+                          character: 16
+                        token_type:
+                          type: Symbol
+                          symbol: "<"
+                      trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 50
+                          line: 2
+                          character: 29
+                        end_position:
+                          bytes: 51
+                          line: 2
+                          character: 30
+                        token_type:
+                          type: Symbol
+                          symbol: ">"
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 51
+                            line: 2
+                            character: 30
+                          end_position:
+                            bytes: 52
+                            line: 2
+                            character: 30
+                          token_type:
+                            type: Whitespace
+                            characters: "\n"
+                generics:
+                  pairs:
+                    - End:
+                        Generic:
+                          base:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 37
+                                line: 2
+                                character: 16
+                              end_position:
+                                bytes: 42
+                                line: 2
+                                character: 21
+                              token_type:
+                                type: Identifier
+                                identifier: Array
+                            trailing_trivia: []
+                          arrows:
+                            tokens:
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 42
+                                    line: 2
+                                    character: 21
+                                  end_position:
+                                    bytes: 43
+                                    line: 2
+                                    character: 22
+                                  token_type:
+                                    type: Symbol
+                                    symbol: "<"
+                                trailing_trivia: []
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 49
+                                    line: 2
+                                    character: 28
+                                  end_position:
+                                    bytes: 50
+                                    line: 2
+                                    character: 29
+                                  token_type:
+                                    type: Symbol
+                                    symbol: ">"
+                                trailing_trivia: []
+                          generics:
+                            pairs:
+                              - End:
+                                  Basic:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 43
+                                        line: 2
+                                        character: 22
+                                      end_position:
+                                        bytes: 49
+                                        line: 2
+                                        character: 28
+                                      token_type:
+                                        type: Identifier
+                                        identifier: number
+                                    trailing_trivia: []
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 28
+                    line: 2
+                    character: 7
+                  end_position:
+                    bytes: 29
+                    line: 2
+                    character: 8
+                  token_type:
+                    type: Identifier
+                    identifier: x
+                trailing_trivia: []
+        equal_token: ~
+        expr_list:
+          pairs: []
+    - ~
+

--- a/full-moon/tests/roblox_cases/pass/types_generic/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_generic/source.lua
@@ -1,0 +1,2 @@
+type Array<T> = { T }
+local x: Array<Array<number>>

--- a/full-moon/tests/roblox_cases/pass/types_generic/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_generic/tokens.snap
@@ -1,0 +1,324 @@
+---
+source: full-moon/tests/pass_cases.rs
+assertion_line: 38
+expression: tokens
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 4
+    line: 1
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 4
+    line: 1
+    character: 5
+  end_position:
+    bytes: 5
+    line: 1
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 5
+    line: 1
+    character: 6
+  end_position:
+    bytes: 10
+    line: 1
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: Array
+- start_position:
+    bytes: 10
+    line: 1
+    character: 11
+  end_position:
+    bytes: 11
+    line: 1
+    character: 12
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 11
+    line: 1
+    character: 12
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 13
+    line: 1
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 13
+    line: 1
+    character: 14
+  end_position:
+    bytes: 14
+    line: 1
+    character: 15
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 14
+    line: 1
+    character: 15
+  end_position:
+    bytes: 15
+    line: 1
+    character: 16
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 15
+    line: 1
+    character: 16
+  end_position:
+    bytes: 16
+    line: 1
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 16
+    line: 1
+    character: 17
+  end_position:
+    bytes: 17
+    line: 1
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 17
+    line: 1
+    character: 18
+  end_position:
+    bytes: 18
+    line: 1
+    character: 19
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 18
+    line: 1
+    character: 19
+  end_position:
+    bytes: 19
+    line: 1
+    character: 20
+  token_type:
+    type: Identifier
+    identifier: T
+- start_position:
+    bytes: 19
+    line: 1
+    character: 20
+  end_position:
+    bytes: 20
+    line: 1
+    character: 21
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 20
+    line: 1
+    character: 21
+  end_position:
+    bytes: 21
+    line: 1
+    character: 22
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 21
+    line: 1
+    character: 22
+  end_position:
+    bytes: 22
+    line: 1
+    character: 22
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 22
+    line: 2
+    character: 1
+  end_position:
+    bytes: 27
+    line: 2
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 27
+    line: 2
+    character: 6
+  end_position:
+    bytes: 28
+    line: 2
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 28
+    line: 2
+    character: 7
+  end_position:
+    bytes: 29
+    line: 2
+    character: 8
+  token_type:
+    type: Identifier
+    identifier: x
+- start_position:
+    bytes: 29
+    line: 2
+    character: 8
+  end_position:
+    bytes: 30
+    line: 2
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 30
+    line: 2
+    character: 9
+  end_position:
+    bytes: 31
+    line: 2
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 31
+    line: 2
+    character: 10
+  end_position:
+    bytes: 36
+    line: 2
+    character: 15
+  token_type:
+    type: Identifier
+    identifier: Array
+- start_position:
+    bytes: 36
+    line: 2
+    character: 15
+  end_position:
+    bytes: 37
+    line: 2
+    character: 16
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 37
+    line: 2
+    character: 16
+  end_position:
+    bytes: 42
+    line: 2
+    character: 21
+  token_type:
+    type: Identifier
+    identifier: Array
+- start_position:
+    bytes: 42
+    line: 2
+    character: 21
+  end_position:
+    bytes: 43
+    line: 2
+    character: 22
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 43
+    line: 2
+    character: 22
+  end_position:
+    bytes: 49
+    line: 2
+    character: 28
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 49
+    line: 2
+    character: 28
+  end_position:
+    bytes: 50
+    line: 2
+    character: 29
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 50
+    line: 2
+    character: 29
+  end_position:
+    bytes: 51
+    line: 2
+    character: 30
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 51
+    line: 2
+    character: 30
+  end_position:
+    bytes: 52
+    line: 2
+    character: 30
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 52
+    line: 3
+    character: 1
+  end_position:
+    bytes: 52
+    line: 3
+    character: 1
+  token_type:
+    type: Eof
+


### PR DESCRIPTION
We introduced DoubleGreaterThan (`>>`) as a token in the tokenizer.
This conflicts with Luau generics, e.g. `Array<Array<number>>`.

We solve this by removing `>>` from the tokenizer.
We instead handle it when parsing BinOp. If we see a `>` and another `>` straight afterwards, we parse it as a `>>`. We must take care to ensure there is no trivia in between when we merge them together.
These symbols get merged into a `Symbol::DoubleGreaterThan`, and everything else is "business as usual".