### PR TITLE
Lua 5.2+: Support `\z` escape sequences in strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Support instantiated generics with no parameters, e.g. `Foo<>`
+- Support `\z` escapes (followed by line breaks) in strings for Lua 5.2+
 
 ## [0.16.2] - 2022-09-22
 ### Fixed

--- a/full-moon/src/atom.rs
+++ b/full-moon/src/atom.rs
@@ -30,10 +30,19 @@ fn test_bracket_head(slice: &str) -> Option<usize> {
 
 fn read_string(lex: &mut Lexer<Atom>, quote: char) -> bool {
     let mut escape = false;
+    #[cfg(feature = "lua52")]
+    let mut z_escaped = false;
     for char in lex.remainder().chars() {
         match (escape, char) {
+            #[cfg(feature = "lua52")]
+            (true, 'z') => {
+                escape = false;
+                z_escaped = true
+            }
             (true, ..) => escape = false,
             (false, '\\') => escape = true,
+            #[cfg(feature = "lua52")]
+            (false, '\n' | '\r') if z_escaped => z_escaped = false,
             (false, '\n' | '\r') => break,
             (false, ..) if char == quote => {
                 lex.bump(1);

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -1371,6 +1371,19 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lua52")]
+    fn test_string_z_escape() {
+        test_rule!(
+            "'hello \\\\z\nworld'",
+            TokenType::StringLiteral {
+                literal: "hello \\\\z\nworld".into(),
+                multi_line: None,
+                quote_type: StringLiteralQuoteType::Single,
+            }
+        );
+    }
+
+    #[test]
     fn test_symbols_within_symbols() {
         // "index" should not return "in"
         test_rule!(

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -1374,9 +1374,9 @@ mod tests {
     #[cfg(feature = "lua52")]
     fn test_string_z_escape() {
         test_rule!(
-            "'hello \\\\z\nworld'",
+            "'hello \\z\nworld'",
             TokenType::StringLiteral {
-                literal: "hello \\\\z\nworld".into(),
+                literal: "hello \\z\nworld".into(),
                 multi_line: None,
                 quote_type: StringLiteralQuoteType::Single,
             }

--- a/full-moon/tests/lua52_cases/pass/z-escape-string/ast.snap
+++ b/full-moon/tests/lua52_cases/pass/z-escape-string/ast.snap
@@ -3,106 +3,76 @@ source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
 ---
 stmts:
-  - - LocalAssignment:
-        local_token:
-          leading_trivia: []
-          token:
-            start_position:
-              bytes: 0
-              line: 1
-              character: 1
-            end_position:
-              bytes: 5
-              line: 1
-              character: 6
-            token_type:
-              type: Symbol
-              symbol: local
-          trailing_trivia:
-            - start_position:
+  - - FunctionCall:
+        prefix:
+          Name:
+            leading_trivia: []
+            token:
+              start_position:
+                bytes: 0
+                line: 1
+                character: 1
+              end_position:
                 bytes: 5
                 line: 1
                 character: 6
-              end_position:
-                bytes: 6
-                line: 1
-                character: 7
               token_type:
-                type: Whitespace
-                characters: " "
-        name_list:
-          pairs:
-            - End:
-                leading_trivia: []
-                token:
-                  start_position:
-                    bytes: 6
-                    line: 1
-                    character: 7
-                  end_position:
-                    bytes: 11
-                    line: 1
-                    character: 12
-                  token_type:
-                    type: Identifier
-                    identifier: value
-                trailing_trivia:
-                  - start_position:
-                      bytes: 11
-                      line: 1
-                      character: 12
-                    end_position:
-                      bytes: 12
-                      line: 1
-                      character: 13
-                    token_type:
-                      type: Whitespace
-                      characters: " "
-        equal_token:
-          leading_trivia: []
-          token:
-            start_position:
-              bytes: 12
-              line: 1
-              character: 13
-            end_position:
-              bytes: 13
-              line: 1
-              character: 14
-            token_type:
-              type: Symbol
-              symbol: "="
-          trailing_trivia:
-            - start_position:
-                bytes: 13
-                line: 1
-                character: 14
-              end_position:
-                bytes: 14
-                line: 1
-                character: 15
-              token_type:
-                type: Whitespace
-                characters: " "
-        expr_list:
-          pairs:
-            - End:
-                value:
-                  String:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 14
-                        line: 1
-                        character: 15
-                      end_position:
-                        bytes: 39
-                        line: 2
-                        character: 14
-                      token_type:
-                        type: StringLiteral
-                        literal: "testing \\z\n\t\t\t   twelve"
-                        quote_type: Double
-                    trailing_trivia: []
+                type: Identifier
+                identifier: print
+            trailing_trivia: []
+        suffixes:
+          - Call:
+              AnonymousCall:
+                Parentheses:
+                  parentheses:
+                    tokens:
+                      - leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 5
+                            line: 1
+                            character: 6
+                          end_position:
+                            bytes: 6
+                            line: 1
+                            character: 7
+                          token_type:
+                            type: Symbol
+                            symbol: (
+                        trailing_trivia: []
+                      - leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 29
+                            line: 2
+                            character: 12
+                          end_position:
+                            bytes: 30
+                            line: 2
+                            character: 13
+                          token_type:
+                            type: Symbol
+                            symbol: )
+                        trailing_trivia: []
+                  arguments:
+                    pairs:
+                      - End:
+                          value:
+                            String:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 6
+                                  line: 1
+                                  character: 7
+                                end_position:
+                                  bytes: 29
+                                  line: 2
+                                  character: 12
+                                token_type:
+                                  type: StringLiteral
+                                  literal: "testing \\z\n\t   twelve"
+                                  quote_type: Double
+                              trailing_trivia: []
     - ~
 

--- a/full-moon/tests/lua52_cases/pass/z-escape-string/ast.snap
+++ b/full-moon/tests/lua52_cases/pass/z-escape-string/ast.snap
@@ -1,0 +1,108 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+---
+stmts:
+  - - LocalAssignment:
+        local_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 0
+              line: 1
+              character: 1
+            end_position:
+              bytes: 5
+              line: 1
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 5
+                line: 1
+                character: 6
+              end_position:
+                bytes: 6
+                line: 1
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 6
+                    line: 1
+                    character: 7
+                  end_position:
+                    bytes: 11
+                    line: 1
+                    character: 12
+                  token_type:
+                    type: Identifier
+                    identifier: value
+                trailing_trivia:
+                  - start_position:
+                      bytes: 11
+                      line: 1
+                      character: 12
+                    end_position:
+                      bytes: 12
+                      line: 1
+                      character: 13
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 12
+              line: 1
+              character: 13
+            end_position:
+              bytes: 13
+              line: 1
+              character: 14
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 13
+                line: 1
+                character: 14
+              end_position:
+                bytes: 14
+                line: 1
+                character: 15
+              token_type:
+                type: Whitespace
+                characters: " "
+        expr_list:
+          pairs:
+            - End:
+                value:
+                  String:
+                    leading_trivia: []
+                    token:
+                      start_position:
+                        bytes: 14
+                        line: 1
+                        character: 15
+                      end_position:
+                        bytes: 39
+                        line: 2
+                        character: 14
+                      token_type:
+                        type: StringLiteral
+                        literal: "testing \\z\n\t\t\t   twelve"
+                        quote_type: Double
+                    trailing_trivia: []
+    - ~
+

--- a/full-moon/tests/lua52_cases/pass/z-escape-string/source.lua
+++ b/full-moon/tests/lua52_cases/pass/z-escape-string/source.lua
@@ -1,2 +1,2 @@
-local value = "testing \z
-			   twelve"
+print("testing \z
+	   twelve")

--- a/full-moon/tests/lua52_cases/pass/z-escape-string/source.lua
+++ b/full-moon/tests/lua52_cases/pass/z-escape-string/source.lua
@@ -1,0 +1,2 @@
+local value = "testing \z
+			   twelve"

--- a/full-moon/tests/lua52_cases/pass/z-escape-string/tokens.snap
+++ b/full-moon/tests/lua52_cases/pass/z-escape-string/tokens.snap
@@ -11,8 +11,8 @@ expression: tokens
     line: 1
     character: 6
   token_type:
-    type: Symbol
-    symbol: local
+    type: Identifier
+    identifier: print
 - start_position:
     bytes: 5
     line: 1
@@ -22,72 +22,39 @@ expression: tokens
     line: 1
     character: 7
   token_type:
-    type: Whitespace
-    characters: " "
+    type: Symbol
+    symbol: (
 - start_position:
     bytes: 6
     line: 1
     character: 7
   end_position:
-    bytes: 11
-    line: 1
-    character: 12
-  token_type:
-    type: Identifier
-    identifier: value
-- start_position:
-    bytes: 11
-    line: 1
-    character: 12
-  end_position:
-    bytes: 12
-    line: 1
-    character: 13
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 12
-    line: 1
-    character: 13
-  end_position:
-    bytes: 13
-    line: 1
-    character: 14
-  token_type:
-    type: Symbol
-    symbol: "="
-- start_position:
-    bytes: 13
-    line: 1
-    character: 14
-  end_position:
-    bytes: 14
-    line: 1
-    character: 15
-  token_type:
-    type: Whitespace
-    characters: " "
-- start_position:
-    bytes: 14
-    line: 1
-    character: 15
-  end_position:
-    bytes: 39
+    bytes: 29
     line: 2
-    character: 14
+    character: 12
   token_type:
     type: StringLiteral
-    literal: "testing \\z\n\t\t\t   twelve"
+    literal: "testing \\z\n\t   twelve"
     quote_type: Double
 - start_position:
-    bytes: 39
+    bytes: 29
     line: 2
-    character: 14
+    character: 12
   end_position:
-    bytes: 39
+    bytes: 30
     line: 2
-    character: 14
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 30
+    line: 2
+    character: 13
+  end_position:
+    bytes: 30
+    line: 2
+    character: 13
   token_type:
     type: Eof
 

--- a/full-moon/tests/lua52_cases/pass/z-escape-string/tokens.snap
+++ b/full-moon/tests/lua52_cases/pass/z-escape-string/tokens.snap
@@ -1,0 +1,93 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 5
+    line: 1
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 5
+    line: 1
+    character: 6
+  end_position:
+    bytes: 6
+    line: 1
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 6
+    line: 1
+    character: 7
+  end_position:
+    bytes: 11
+    line: 1
+    character: 12
+  token_type:
+    type: Identifier
+    identifier: value
+- start_position:
+    bytes: 11
+    line: 1
+    character: 12
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 13
+    line: 1
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 13
+    line: 1
+    character: 14
+  end_position:
+    bytes: 14
+    line: 1
+    character: 15
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 14
+    line: 1
+    character: 15
+  end_position:
+    bytes: 39
+    line: 2
+    character: 14
+  token_type:
+    type: StringLiteral
+    literal: "testing \\z\n\t\t\t   twelve"
+    quote_type: Double
+- start_position:
+    bytes: 39
+    line: 2
+    character: 14
+  end_position:
+    bytes: 39
+    line: 2
+    character: 14
+  token_type:
+    type: Eof
+


### PR DESCRIPTION
`\z` escape sequences can be followed by whitespace (including whitespace) which is ignored
Fixes #251 