### PR TITLE
Fix tokenizer positions when multiple newlines follow eachother

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed parse failed with Chinese token in comment and bump deps.
 - Added `first` method to `Punctuated`.
 - Fixed `\` escapes in strings for Lua 5.2+.
+- Fixed incorrect line number positions when a token contains consecutive newlines (typically multi line strings or comments)
 
 ## [0.17.0] - 2023-01-04
 ### Added

--- a/full-moon/src/tokenizer.rs
+++ b/full-moon/src/tokenizer.rs
@@ -1208,16 +1208,16 @@ fn read_position(code: &str, position: &mut Position) -> bool {
     let mut has_newline = false;
 
     for c in code.chars() {
+        if has_newline {
+            position.line += 1;
+            position.character = 1;
+
+            has_newline = false;
+        }
+
         if c == '\n' {
             has_newline = true;
         } else {
-            if has_newline {
-                position.line += 1;
-                position.character = 1;
-
-                has_newline = false;
-            }
-
             position.character += 1;
         }
     }

--- a/full-moon/tests/cases/pass/multi-line-comments-9/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-9/ast.snap
@@ -1,0 +1,6 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+---
+stmts: []
+

--- a/full-moon/tests/cases/pass/multi-line-comments-9/source.lua
+++ b/full-moon/tests/cases/pass/multi-line-comments-9/source.lua
@@ -1,0 +1,21 @@
+--[=[
+
+	This description starts one line down,
+
+	And has a line in the middle, followed by trailing lines.
+
+	```lua
+	function test()
+		print("indentation")
+
+		do
+			print("more indented")
+		end
+	end
+	```
+
+
+	@class indentation
+
+
+]=]

--- a/full-moon/tests/cases/pass/multi-line-comments-9/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-comments-9/tokens.snap
@@ -1,0 +1,27 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 231
+    line: 21
+    character: 4
+  token_type:
+    type: MultiLineComment
+    blocks: 1
+    comment: "\n\n\tThis description starts one line down,\n\n\tAnd has a line in the middle, followed by trailing lines.\n\n\t```lua\n\tfunction test()\n\t\tprint(\"indentation\")\n\n\t\tdo\n\t\t\tprint(\"more indented\")\n\t\tend\n\tend\n\t```\n\n\n\t@class indentation\n\n\n"
+- start_position:
+    bytes: 231
+    line: 21
+    character: 4
+  end_position:
+    bytes: 231
+    line: 21
+    character: 4
+  token_type:
+    type: Eof
+


### PR DESCRIPTION
There is a bug in `read_position` when multiple newlines follow each other, which manifests into the errors seen in https://github.com/evaera/moonwave/actions/runs/3990359990/jobs/6843912815

This is because the line number is not bumped for consecutive newline characters, it is only bumped once a non-newline character is seen.
We fix this by always bumping when `has_newline` is set, then checking afterwards for the `\n` character and setting `has_newline = true`