### PR TITLE
Fix print of `LocalAssignment` when in Lua 5.4 or Luau mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fixed `print` on a LocalAssignment in Lua 5.4 or Luau mode not including the variable name when no type specifier or attribute is included
 
 ## [0.18.0] - 2023-03-12
 ### Added

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2480,4 +2480,39 @@ mod tests {
         TableConstructor::new();
         While::new(expression);
     }
+
+    #[test]
+    fn test_local_assignment_print() {
+        let block = Block::new().with_stmts(vec![(
+            Stmt::LocalAssignment(
+                LocalAssignment::new(
+                    std::iter::once(Pair::End(TokenReference::new(
+                        vec![],
+                        Token::new(TokenType::Identifier {
+                            identifier: "variable".into(),
+                        }),
+                        vec![],
+                    )))
+                    .collect(),
+                )
+                .with_equal_token(Some(TokenReference::symbol(" = ").unwrap()))
+                .with_expressions(
+                    std::iter::once(Pair::End(Expression::Value {
+                        value: Box::new(Value::Number(TokenReference::new(
+                            vec![],
+                            Token::new(TokenType::Number { text: "1".into() }),
+                            vec![],
+                        ))),
+                        #[cfg(feature = "roblox")]
+                        type_assertion: None,
+                    }))
+                    .collect(),
+                ),
+            ),
+            None,
+        )]);
+
+        let ast = parse("").unwrap().with_nodes(block);
+        assert_eq!(print(&ast), "local variable = 1");
+    }
 }

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1778,11 +1778,11 @@ impl LocalAssignment {
 impl fmt::Display for LocalAssignment {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(feature = "lua54")]
-        let attributes = self.attributes();
+        let attributes = self.attributes().chain(std::iter::repeat(None));
         #[cfg(not(feature = "lua54"))]
         let attributes = std::iter::repeat_with(|| None::<TokenReference>);
         #[cfg(feature = "roblox")]
-        let type_specifiers = self.type_specifiers();
+        let type_specifiers = self.type_specifiers().chain(std::iter::repeat(None));
         #[cfg(not(feature = "roblox"))]
         let type_specifiers = std::iter::repeat_with(|| None::<TokenReference>);
 


### PR DESCRIPTION
When `roblox` or `lua54` feature flag is enabled, printing a LocalAssignment node does not include the variable names if no type specifier or attribute is included, resulting it:

```lua
local  = 1
```

This fixes this by making the iterators infinite for when we zip them for display

No idea how this slipped through the tests...