### PR TITLE
Switch `multi_line` from `Option<usize>` to `usize`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The Lua version used to parse is no longer strictly based on features set, and can now be configured precisely using `LuaVersion`. `LuaVersion` is a bitfield that can attempt to parse multiple versions of Lua at once, or be used to pin down a specific version. `parse` will use the most completely available set possible (`LuaVersion::new()`), but `parse_fallible` accepts a `LuaVersion`.
 - Added support for parsing Luau's floor division assignment `//=`
 
+### Changed
+- **[BREAKING CHANGE]** `TokenType::StringLiteral::multi_line` has been replaced with `TokenType::StringLiteral::multi_line_depth`. It serves the same purpose except instead of being an `Option<usize>`, it is now a standard `usize`. It is advised to simply check `quote_type == StringLiteralQuoteType::Brackets` to get the previous behavior.
+- Attempting to display `StringLiteralQuoteType::Brackets` now returns an error rather than being marked as unreachable.
+
 ## [0.19.0] - 2023-11-10
 ### Added
 - Added support for parsing Luau's floor division `//`

--- a/full-moon/src/tokenizer/lexer.rs
+++ b/full-moon/src/tokenizer/lexer.rs
@@ -438,7 +438,7 @@ impl Lexer {
                             start_position,
                             TokenType::StringLiteral {
                                 literal: body.into(),
-                                multi_line: Some(blocks),
+                                multi_line_depth: blocks,
                                 quote_type: StringLiteralQuoteType::Brackets,
                             },
                         ),
@@ -447,7 +447,7 @@ impl Lexer {
                             start_position,
                             TokenType::StringLiteral {
                                 literal: body.into(),
-                                multi_line: Some(blocks),
+                                multi_line_depth: blocks,
                                 quote_type: StringLiteralQuoteType::Brackets,
                             },
                             vec![TokenizerError {
@@ -1072,7 +1072,7 @@ impl Lexer {
                     return (
                         TokenType::StringLiteral {
                             literal: literal.into(),
-                            multi_line: None,
+                            multi_line_depth: 0,
                             quote_type,
                         },
                         true,
@@ -1111,7 +1111,7 @@ impl Lexer {
                     return (
                         TokenType::StringLiteral {
                             literal: literal.into(),
-                            multi_line: None,
+                            multi_line_depth: 0,
                             quote_type,
                         },
                         true,
@@ -1122,7 +1122,7 @@ impl Lexer {
                     return (
                         TokenType::StringLiteral {
                             literal: literal.into(),
-                            multi_line: None,
+                            multi_line_depth: 0,
                             quote_type,
                         },
                         false,

--- a/full-moon/tests/cases/fail/tokenizer/unclosed-string-3/ast.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unclosed-string-3/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-assertion_line: 19
 expression: result.ast
-input_file: full-moon/tests/cases/fail/tokenizer/unclosed-string-3
 ---
 nodes:
   stmts:
@@ -104,7 +102,6 @@ nodes:
                       token_type:
                         type: StringLiteral
                         literal: "hello\nworld"
-                        multi_line: 0
                         quote_type: Brackets
                     trailing_trivia: []
       - ~

--- a/full-moon/tests/cases/fail/tokenizer/unclosed-string-3/tokens_result.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unclosed-string-3/tokens_result.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-assertion_line: 42
 expression: tokens
-input_file: full-moon/tests/cases/fail/tokenizer/unclosed-string-3
 ---
 Recovered:
   - - start_position:
@@ -82,7 +80,6 @@ Recovered:
       token_type:
         type: StringLiteral
         literal: "hello\nworld"
-        multi_line: 0
         quote_type: Brackets
     - start_position:
         bytes: 23

--- a/full-moon/tests/cases/pass/multi-line-string-1/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-1/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-string-1
 ---
 stmts:
   - - LocalAssignment:
@@ -103,7 +101,6 @@ stmts:
                     token_type:
                       type: StringLiteral
                       literal: "Full Moon\nis a\nlossless\nLua parser"
-                      multi_line: 0
                       quote_type: Brackets
                   trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-1/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-1/tokens.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: tokens
-input_file: full-moon/tests/cases/pass/multi-line-string-1
-
 ---
 - start_position:
     bytes: 0
@@ -81,7 +79,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-1
   token_type:
     type: StringLiteral
     literal: "Full Moon\nis a\nlossless\nLua parser"
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 48

--- a/full-moon/tests/cases/pass/multi-line-string-2/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-2/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-string-2
 ---
 stmts:
   - - LocalAssignment:
@@ -103,7 +101,7 @@ stmts:
                     token_type:
                       type: StringLiteral
                       literal: "This is\nseveral equal\nsigns"
-                      multi_line: 1
+                      multi_line_depth: 1
                       quote_type: Brackets
                   trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-2/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-2/tokens.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: tokens
-input_file: full-moon/tests/cases/pass/multi-line-string-2
-
 ---
 - start_position:
     bytes: 0
@@ -81,7 +79,7 @@ input_file: full-moon/tests/cases/pass/multi-line-string-2
   token_type:
     type: StringLiteral
     literal: "This is\nseveral equal\nsigns"
-    multi_line: 1
+    multi_line_depth: 1
     quote_type: Brackets
 - start_position:
     bytes: 43

--- a/full-moon/tests/cases/pass/multi-line-string-3/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-3/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-string-3
 ---
 stmts:
   - - LocalAssignment:
@@ -103,7 +101,6 @@ stmts:
                     token_type:
                       type: StringLiteral
                       literal: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
-                      multi_line: 0
                       quote_type: Brackets
                   trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-3/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-3/tokens.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: tokens
-input_file: full-moon/tests/cases/pass/multi-line-string-3
-
 ---
 - start_position:
     bytes: 0
@@ -81,7 +79,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-3
   token_type:
     type: StringLiteral
     literal: "\nlocal emotes = {\n\t[\":thinking:\"] = \"http://www.roblox.com/asset/?id=643340245\",\n\t[\":bug:\"] = \"http://www.roblox.com/asset/?id=860037275\"\n}\n"
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 154

--- a/full-moon/tests/cases/pass/multi-line-string-4/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-4/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-string-4
 ---
 stmts:
   - - FunctionCall:
@@ -73,7 +71,6 @@ stmts:
                               token_type:
                                 type: StringLiteral
                                 literal: doge
-                                multi_line: 0
                                 quote_type: Brackets
                             trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-4/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-4/tokens.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: tokens
-input_file: full-moon/tests/cases/pass/multi-line-string-4
-
 ---
 - start_position:
     bytes: 0
@@ -37,7 +35,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-4
   token_type:
     type: StringLiteral
     literal: doge
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 13

--- a/full-moon/tests/cases/pass/multi-line-string-5/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-5/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-string-5
 ---
 stmts:
   - - LocalAssignment:
@@ -103,7 +101,6 @@ stmts:
                     token_type:
                       type: StringLiteral
                       literal: 🧓🏽
-                      multi_line: 0
                       quote_type: Brackets
                   trailing_trivia:
                     - start_position:

--- a/full-moon/tests/cases/pass/multi-line-string-5/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-5/tokens.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: tokens
-input_file: full-moon/tests/cases/pass/multi-line-string-5
-
 ---
 - start_position:
     bytes: 0
@@ -81,7 +79,6 @@ input_file: full-moon/tests/cases/pass/multi-line-string-5
   token_type:
     type: StringLiteral
     literal: 🧓🏽
-    multi_line: 0
     quote_type: Brackets
 - start_position:
     bytes: 26

--- a/full-moon/tests/cases/pass/multi-line-string-7/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-7/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-string-7
 ---
 stmts:
   - - LocalAssignment:
@@ -103,7 +101,7 @@ stmts:
                     token_type:
                       type: StringLiteral
                       literal: "[%s]"
-                      multi_line: 1
+                      multi_line_depth: 1
                       quote_type: Brackets
                   trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-7/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-7/tokens.snap
@@ -1,6 +1,5 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 38
 expression: tokens
 ---
 - start_position:
@@ -80,7 +79,7 @@ expression: tokens
   token_type:
     type: StringLiteral
     literal: "[%s]"
-    multi_line: 1
+    multi_line_depth: 1
     quote_type: Brackets
 - start_position:
     bytes: 20

--- a/full-moon/tests/cases/pass/multi-line-string-8/ast.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-8/ast.snap
@@ -1,8 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
 expression: ast.nodes()
-input_file: full-moon/tests/cases/pass/multi-line-string-8
 ---
 stmts:
   - - LocalAssignment:
@@ -103,7 +101,7 @@ stmts:
                     token_type:
                       type: StringLiteral
                       literal: "\\v<((do|load)file|require)\\s*\\(?['\"]\\zs[^'\"]+\\ze['\"]"
-                      multi_line: 1
+                      multi_line_depth: 1
                       quote_type: Brackets
                   trailing_trivia: []
     - ~

--- a/full-moon/tests/cases/pass/multi-line-string-8/tokens.snap
+++ b/full-moon/tests/cases/pass/multi-line-string-8/tokens.snap
@@ -1,6 +1,5 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 38
 expression: tokens
 ---
 - start_position:
@@ -80,7 +79,7 @@ expression: tokens
   token_type:
     type: StringLiteral
     literal: "\\v<((do|load)file|require)\\s*\\(?['\"]\\zs[^'\"]+\\ze['\"]"
-    multi_line: 1
+    multi_line_depth: 1
     quote_type: Brackets
 - start_position:
     bytes: 68


### PR DESCRIPTION
Saves 8 bytes per TokenReference. The old behaviour of `None` can be inferred from the `quote_type`

Originally done in #172 