### PR TITLE
fix: wrap serde usage in a `cfg_attr`.

### DIFF
--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -2216,7 +2216,7 @@ pub struct AstError {
     additional: Cow<'static, str>,
 
     /// If set, this is the complete range of the error
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     range: Option<(Position, Position)>,
 }
 

--- a/full-moon/src/tokenizer/structs.rs
+++ b/full-moon/src/tokenizer/structs.rs
@@ -33,7 +33,7 @@ macro_rules! symbol {
                             $(feature = "" $version),+
                         ))]
                     )*
-                    #[serde(rename = $string)]
+                    #[cfg_attr(feature = "serde", serde(rename = $string))]
                     $name,
                 )+
             }


### PR DESCRIPTION
Hi,

I've noticed 2 usages of serde without any checks for its feature being enabled. This PR addresses them.