### PR TITLE
Box anonymous function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[BREAKING CHANGE]** `TokenType::StringLiteral::multi_line` has been replaced with `TokenType::StringLiteral::multi_line_depth`. It serves the same purpose except instead of being an `Option<usize>`, it is now a standard `usize`. It is advised to simply check `quote_type == StringLiteralQuoteType::Brackets` to get the previous behavior.
 - **[BREAKING CHANGE]** Flattened `AstError` into just what used to be `AstError::UnexpectedToken`.
 - **[BREAKING CHANGE]** `Symbol::PlusEqual` and friends are now only available when using Luau.
+- **[BREAKING CHANGE]** `Expression::Function((TokenReference, FunctionBody))` variant is now Boxed to ``Expression::Function(Box<(TokenReference, FunctionBody)>)` to reduce type sizes and reduce stack overflows
 - Shebangs provide their trailing trivia more accurately to the rest of full-moon.
 - Attempting to display `StringLiteralQuoteType::Brackets` now returns an error rather than being marked as unreachable.
 - Significantly optimized the entire codebase, helping both time to parse and wasting less stack, especially in debug mode.

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -307,7 +307,7 @@ pub enum Expression {
 
     /// An anonymous function, such as `function() end)`
     #[display(fmt = "{}{}", "_0.0", "_0.1")]
-    Function((TokenReference, FunctionBody)),
+    Function(Box<(TokenReference, FunctionBody)>),
 
     /// A call of a function, such as `call()`
     #[display(fmt = "{_0}")]

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -1592,7 +1592,10 @@ fn parse_primary_expression(state: &mut ParserState) -> ParserResult<Expression>
                 }
             };
 
-            ParserResult::Value(Expression::Function((function_token, function_body)))
+            ParserResult::Value(Expression::Function(Box::new((
+                function_token,
+                function_body,
+            ))))
         }
 
         TokenType::Symbol {

--- a/full-moon/src/ast/visitors.rs
+++ b/full-moon/src/ast/visitors.rs
@@ -102,9 +102,9 @@ impl Visit for Expression {
                 expression.visit(visitor);
             }
 
-            Expression::Function((function_token, function_body)) => {
-                function_token.visit(visitor);
-                function_body.visit(visitor);
+            Expression::Function(func) => {
+                func.0.visit(visitor);
+                func.1.visit(visitor);
             }
 
             Expression::FunctionCall(function_call) => {
@@ -176,10 +176,10 @@ impl VisitMut for Expression {
                 expression: expression.visit_mut(visitor),
             },
 
-            Expression::Function((function_token, function_body)) => Expression::Function((
-                function_token.visit_mut(visitor),
-                function_body.visit_mut(visitor),
-            )),
+            Expression::Function(func) => Expression::Function(Box::new((
+                func.0.visit_mut(visitor),
+                func.1.visit_mut(visitor),
+            ))),
 
             Expression::FunctionCall(function_call) => {
                 Expression::FunctionCall(function_call.visit_mut(visitor))


### PR DESCRIPTION
We are continuing to see stack overflows in the new parser. This is mainly because the AST type have quite large sizes.

Using the command `cargo +nightly rustc -- -Zprint-type-sizes`, we can find the size of each AST structure.

The most expensive struct in terms of size is `NumericFor`:

```
print-type-size type: `ast::NumericFor`: 3936 bytes, alignment: 8 bytes
print-type-size     field `.for_token`: 136 bytes
print-type-size     field `.index_variable`: 136 bytes
print-type-size     field `.equal_token`: 136 bytes
print-type-size     field `.start_end_comma`: 136 bytes
print-type-size     field `.do_token`: 136 bytes
print-type-size     field `.block`: 320 bytes
print-type-size     field `.end_token`: 136 bytes
print-type-size     field `.end_step_comma`: 136 bytes
print-type-size     field `.start`: 888 bytes
print-type-size     field `.end`: 888 bytes
print-type-size     field `.step`: 888 bytes
```

The biggest sizes come from `start`, `end`  and `step`, which are all `Expression` nodes. So Expression has a size of `888` bytes.

Looking at the size of Expression, we can see the most significant size is used by the `Function` variant, at 888 bytes, whilst the next largest variant is TableConstructor at 304 bytes: a 584 bytes difference:

```
print-type-size type: `ast::Expression`: 888 bytes, alignment: 8 bytes
print-type-size     variant `Function`: 888 bytes
print-type-size         field `.0`: 888 bytes
print-type-size     variant `TableConstructor`: 304 bytes
print-type-size         padding: 8 bytes
print-type-size         field `.0`: 296 bytes, alignment: 8 bytes
```

If we Box the anonymous function variant, we will be able to shave off at least 584 bytes on every single Expression node, which can add up to a significant saving. We do that in this PR.

After doing so, the size of `Expression` is now 296 bytes, taken up by the largest variant `TableConstructor`. `NumericFor` decreases from 3936 bytes to 2160 bytes, a 1176 bytes decrease.

The complete type size list are attached for reference

[type-sizes-before-change.txt](https://github.com/user-attachments/files/15748340/type-sizes-before-change.txt)
[type-sizes-after-change.txt](https://github.com/user-attachments/files/15748341/type-sizes-after-change.txt)

