### PR TITLE
Add support for leading `|` and `&` in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added structs `TypeUnion` and `TypeIntersection` which both contain a field for a leading `TokenReference` (`|` or `&`), and a field which contains a `Punctuated<TypeInfo>`.
 - Added support for parsing leading `|` and `&` in types.
+
 ### Changed
 - **[BREAKING CHANGE]** Changed `TypeInfo::Union` and `TypeInfo::Intersection` to hold structs `TypeUnion` and `TypeIntersection` respectively.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- **[BREAKING CHANGE]** Changed `TypeInfo::Union` and `TypeInfo::Intersection` to hold structs `TypeUnion` and `TypeIntersection` respectively.
+### Added
+- Added structs `TypeUnion` and `TypeIntersection` which both contain a field for a leading `TokenReference` (`|` or `&`), and a field which contains a `Punctuated<TypeInfo>`.
+- Added support for parsing leading `|` and `&` in types.
+
+
 ## [1.0.0-rc.5] - 2024-07-06
 ### Changed
 - **[BREAKING CHANGE]** The `types` module is now named `luau`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Changed
-- **[BREAKING CHANGE]** Changed `TypeInfo::Union` and `TypeInfo::Intersection` to hold structs `TypeUnion` and `TypeIntersection` respectively.
 ### Added
 - Added structs `TypeUnion` and `TypeIntersection` which both contain a field for a leading `TokenReference` (`|` or `&`), and a field which contains a `Punctuated<TypeInfo>`.
 - Added support for parsing leading `|` and `&` in types.
+### Changed
+- **[BREAKING CHANGE]** Changed `TypeInfo::Union` and `TypeInfo::Intersection` to hold structs `TypeUnion` and `TypeIntersection` respectively.
 
 
 ## [1.0.0-rc.5] - 2024-07-06

--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -190,19 +190,8 @@ impl TypeUnion {
     }
 
     /// Returns a new Union with the given leading pipe.
-    pub fn with_leading(self, leading: TokenReference) -> Self {
-        Self {
-            leading: Some(leading),
-            ..self
-        }
-    }
-
-    /// Returns a new Union without a leading pipe.
-    pub fn without_leading(self) -> Self {
-        Self {
-            leading: None,
-            ..self
-        }
+    pub fn with_leading(self, leading: Option<TokenReference>) -> Self {
+        Self { leading, ..self }
     }
 
     /// The leading pipe, if one is present: `|`.
@@ -237,19 +226,8 @@ impl TypeIntersection {
     }
 
     /// Returns a new Intersection with the given leading pipe.
-    pub fn with_leading(self, leading: TokenReference) -> Self {
-        Self {
-            leading: Some(leading),
-            ..self
-        }
-    }
-
-    /// Returns a new Intersection without a leading pipe.
-    pub fn without_leading(self) -> Self {
-        Self {
-            leading: None,
-            ..self
-        }
+    pub fn with_leading(self, leading: Option<TokenReference>) -> Self {
+        Self { leading, ..self }
     }
 
     /// The leading pipe, if one is present: `&`.

--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -82,6 +82,10 @@ pub enum TypeInfo {
         ellipsis: TokenReference,
     },
 
+    /// An intersection type, such as `string & number`.
+    #[display(fmt = "{_0}")]
+    Intersection(TypeIntersection),
+
     /// A type coming from a module, such as `module.Foo`
     #[display(fmt = "{module}{punctuation}{type_info}")]
     Module {
@@ -142,6 +146,10 @@ pub enum TypeInfo {
         types: Punctuated<TypeInfo>,
     },
 
+    /// A union type, such as `string | number`.
+    #[display(fmt = "{_0}")]
+    Union(TypeUnion),
+
     /// A variadic type: `...number`.
     #[display(fmt = "{ellipsis}{type_info}")]
     Variadic {
@@ -159,14 +167,6 @@ pub enum TypeInfo {
         /// The name of the type that is variadic: `T`
         name: TokenReference,
     },
-
-    /// A union type, such as `string | number`.
-    #[display(fmt = "{_0}")]
-    Union(TypeUnion),
-
-    /// An intersection type, such as `string & number`.
-    #[display(fmt = "{_0}")]
-    Intersection(TypeIntersection),
 }
 
 /// A union type, such as `string | number`.
@@ -179,9 +179,25 @@ pub struct TypeUnion {
 }
 
 impl TypeUnion {
-    /// Creates a new Union from the given types.
+    /// Creates a new Union from the given types and optional leading pipe.
     pub fn new(leading: Option<TokenReference>, types: Punctuated<TypeInfo>) -> Self {
         Self { leading, types }
+    }
+
+    /// Creates a new Union from the given types, with no leading pipe.
+    pub fn with_types(types: Punctuated<TypeInfo>) -> Self {
+        Self {
+            leading: None,
+            types,
+        }
+    }
+
+    /// Creates a new Union with the given leading pipe, and no types.
+    pub fn with_leading(leading: TokenReference) -> Self {
+        Self {
+            leading: Some(leading),
+            types: Punctuated::new(),
+        }
     }
 
     /// The leading pipe, if one is present: `|`.
@@ -208,6 +224,22 @@ impl TypeIntersection {
     /// Creates a new Intersection from the given types.
     pub fn new(leading: Option<TokenReference>, types: Punctuated<TypeInfo>) -> Self {
         Self { leading, types }
+    }
+
+    /// Creates a new Intersection from the given types, with no leading pipe.
+    pub fn with_types(types: Punctuated<TypeInfo>) -> Self {
+        Self {
+            leading: None,
+            types,
+        }
+    }
+
+    /// Creates a new Intersection with the given leading pipe, and no types.
+    pub fn with_leading(leading: TokenReference) -> Self {
+        Self {
+            leading: Some(leading),
+            types: Punctuated::new(),
+        }
     }
 
     /// The leading pipe, if one is present: `&`.

--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -82,17 +82,6 @@ pub enum TypeInfo {
         ellipsis: TokenReference,
     },
 
-    /// An intersection type: `string & number`, denoting both types.
-    #[display(fmt = "{left}{ampersand}{right}")]
-    Intersection {
-        /// The left hand side: `string`.
-        left: Box<TypeInfo>,
-        /// The ampersand (`&`) to separate the types.
-        ampersand: TokenReference,
-        /// The right hand side: `number`.
-        right: Box<TypeInfo>,
-    },
-
     /// A type coming from a module, such as `module.Foo`
     #[display(fmt = "{module}{punctuation}{type_info}")]
     Module {
@@ -153,17 +142,6 @@ pub enum TypeInfo {
         types: Punctuated<TypeInfo>,
     },
 
-    /// A union type: `string | number`, denoting one or the other.
-    #[display(fmt = "{left}{pipe}{right}")]
-    Union {
-        /// The left hand side: `string`.
-        left: Box<TypeInfo>,
-        /// The pipe (`|`) to separate the types.
-        pipe: TokenReference,
-        /// The right hand side: `number`.
-        right: Box<TypeInfo>,
-    },
-
     /// A variadic type: `...number`.
     #[display(fmt = "{ellipsis}{type_info}")]
     Variadic {
@@ -181,6 +159,66 @@ pub enum TypeInfo {
         /// The name of the type that is variadic: `T`
         name: TokenReference,
     },
+
+    /// A union type, such as `string | number`.
+    #[display(fmt = "{_0}")]
+    Union(TypeUnion),
+
+    /// An intersection type, such as `string & number`.
+    #[display(fmt = "{_0}")]
+    Intersection(TypeIntersection),
+}
+
+/// A union type, such as `string | number`.
+#[derive(Clone, Debug, Display, PartialEq, Node)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[display(fmt = "{}{types}", "display_option(leading)")]
+pub struct TypeUnion {
+    pub(crate) leading: Option<TokenReference>,
+    pub(crate) types: Punctuated<TypeInfo>,
+}
+
+impl TypeUnion {
+    /// Creates a new Union from the given types.
+    pub fn new(leading: Option<TokenReference>, types: Punctuated<TypeInfo>) -> Self {
+        Self { leading, types }
+    }
+
+    /// The leading pipe, if one is present: `|`.
+    pub fn leading(&self) -> Option<&TokenReference> {
+        self.leading.as_ref()
+    }
+
+    /// The types being unioned: `string | number`.
+    pub fn types(&self) -> &Punctuated<TypeInfo> {
+        &self.types
+    }
+}
+
+/// An intersection type, such as `string & number`.
+#[derive(Clone, Debug, Display, PartialEq, Node)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[display(fmt = "{}{types}", "display_option(leading)")]
+pub struct TypeIntersection {
+    pub(crate) leading: Option<TokenReference>,
+    pub(crate) types: Punctuated<TypeInfo>,
+}
+
+impl TypeIntersection {
+    /// Creates a new Intersection from the given types.
+    pub fn new(leading: Option<TokenReference>, types: Punctuated<TypeInfo>) -> Self {
+        Self { leading, types }
+    }
+
+    /// The leading pipe, if one is present: `&`.
+    pub fn leading(&self) -> Option<&TokenReference> {
+        self.leading.as_ref()
+    }
+
+    /// The types being intersected: `string & number`.
+    pub fn types(&self) -> &Punctuated<TypeInfo> {
+        &self.types
+    }
 }
 
 /// A subset of TypeInfo that consists of items which can only be used as an index, such as `Foo` and `Foo<Bar>`,

--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -184,19 +184,24 @@ impl TypeUnion {
         Self { leading, types }
     }
 
-    /// Creates a new Union from the given types, with no leading pipe.
-    pub fn with_types(types: Punctuated<TypeInfo>) -> Self {
+    /// Returns a new Union with the given types.
+    pub fn with_types(self, types: Punctuated<TypeInfo>) -> Self {
+        Self { types, ..self }
+    }
+
+    /// Returns a new Union with the given leading pipe.
+    pub fn with_leading(self, leading: TokenReference) -> Self {
         Self {
-            leading: None,
-            types,
+            leading: Some(leading),
+            ..self
         }
     }
 
-    /// Creates a new Union with the given leading pipe, and no types.
-    pub fn with_leading(leading: TokenReference) -> Self {
+    /// Returns a new Union without a leading pipe.
+    pub fn without_leading(self) -> Self {
         Self {
-            leading: Some(leading),
-            types: Punctuated::new(),
+            leading: None,
+            ..self
         }
     }
 
@@ -226,19 +231,24 @@ impl TypeIntersection {
         Self { leading, types }
     }
 
-    /// Creates a new Intersection from the given types, with no leading pipe.
-    pub fn with_types(types: Punctuated<TypeInfo>) -> Self {
+    /// Returns a new Intersection with the given types.
+    pub fn with_types(self, types: Punctuated<TypeInfo>) -> Self {
+        Self { types, ..self }
+    }
+
+    /// Returns a new Intersection with the given leading pipe.
+    pub fn with_leading(self, leading: TokenReference) -> Self {
         Self {
-            leading: None,
-            types,
+            leading: Some(leading),
+            ..self
         }
     }
 
-    /// Creates a new Intersection with the given leading pipe, and no types.
-    pub fn with_leading(leading: TokenReference) -> Self {
+    /// Returns a new Intersection without a leading pipe.
+    pub fn without_leading(self) -> Self {
         Self {
-            leading: Some(leading),
-            types: Punctuated::new(),
+            leading: None,
+            ..self
         }
     }
 

--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -225,12 +225,12 @@ impl TypeIntersection {
         Self { types, ..self }
     }
 
-    /// Returns a new Intersection with the given leading pipe.
+    /// Returns a new Intersection with the given leading ampersand.
     pub fn with_leading(self, leading: Option<TokenReference>) -> Self {
         Self { leading, ..self }
     }
 
-    /// The leading pipe, if one is present: `&`.
+    /// The leading ampersand, if one is present: `&`.
     pub fn leading(&self) -> Option<&TokenReference> {
         self.leading.as_ref()
     }

--- a/full-moon/src/ast/luau_visitors.rs
+++ b/full-moon/src/ast/luau_visitors.rs
@@ -90,20 +90,8 @@ impl Visit for TypeInfo {
                 types.visit(visitor);
                 parentheses.tokens.1.visit(visitor);
             }
-            TypeInfo::Union { left, pipe, right } => {
-                left.visit(visitor);
-                pipe.visit(visitor);
-                right.visit(visitor);
-            }
-            TypeInfo::Intersection {
-                left,
-                ampersand,
-                right,
-            } => {
-                left.visit(visitor);
-                ampersand.visit(visitor);
-                right.visit(visitor);
-            }
+            TypeInfo::Union(union) => union.visit(visitor),
+            TypeInfo::Intersection(intersection) => intersection.visit(visitor),
             TypeInfo::Variadic {
                 ellipsis,
                 type_info,
@@ -250,21 +238,11 @@ impl VisitMut for TypeInfo {
                 TypeInfo::Tuple { parentheses, types }
             }
 
-            TypeInfo::Union { left, pipe, right } => TypeInfo::Union {
-                left: left.visit_mut(visitor),
-                pipe: pipe.visit_mut(visitor),
-                right: right.visit_mut(visitor),
-            },
+            TypeInfo::Union(union) => TypeInfo::Union(union.visit_mut(visitor)),
 
-            TypeInfo::Intersection {
-                left,
-                ampersand,
-                right,
-            } => TypeInfo::Intersection {
-                left: left.visit_mut(visitor),
-                ampersand: ampersand.visit_mut(visitor),
-                right: right.visit_mut(visitor),
-            },
+            TypeInfo::Intersection(intersection) => {
+                TypeInfo::Intersection(intersection.visit_mut(visitor))
+            }
 
             TypeInfo::Variadic {
                 ellipsis,
@@ -281,6 +259,50 @@ impl VisitMut for TypeInfo {
         };
         self = visitor.visit_type_info_end(self);
         self
+    }
+}
+
+impl Visit for TypeUnion {
+    fn visit<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_type_union(self);
+
+        self.leading.visit(visitor);
+        self.types.visit(visitor);
+
+        visitor.visit_type_union_end(self);
+    }
+}
+
+impl VisitMut for TypeUnion {
+    fn visit_mut<V: VisitorMut>(mut self, visitor: &mut V) -> Self {
+        self = visitor.visit_type_union(self);
+
+        self.leading = self.leading.visit_mut(visitor);
+        self.types = self.types.visit_mut(visitor);
+
+        visitor.visit_type_union_end(self)
+    }
+}
+
+impl Visit for TypeIntersection {
+    fn visit<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_type_intersection(self);
+
+        self.leading.visit(visitor);
+        self.types.visit(visitor);
+
+        visitor.visit_type_intersection_end(self);
+    }
+}
+
+impl VisitMut for TypeIntersection {
+    fn visit_mut<V: VisitorMut>(mut self, visitor: &mut V) -> Self {
+        self = visitor.visit_type_intersection(self);
+
+        self.leading = self.leading.visit_mut(visitor);
+        self.types = self.types.visit_mut(visitor);
+
+        visitor.visit_type_intersection_end(self)
     }
 }
 

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2483,11 +2483,11 @@ fn parse_type_suffix(
         let type_info = if current_type.is_some() {
             current_type.take().unwrap()
         } else {
-            let ParserResult::Value(ty) = parse_simple_type(state, SimpleTypeStyle::Default) else {
+            let ParserResult::Value(type_info) = parse_simple_type(state, SimpleTypeStyle::Default) else {
                 return ParserResult::LexerMoved;
             };
 
-            ty
+            type_info
         };
 
         let Ok(current_token) = state.current() else {

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2484,7 +2484,7 @@ fn parse_type_suffix(
     let mut current_type = simple_type;
 
     loop {
-        let ty = if current_type.is_some() {
+        let type_info = if current_type.is_some() {
             current_type.take().unwrap()
         } else {
             let ParserResult::Value(ty) = parse_simple_type(state, SimpleTypeStyle::Default) else {
@@ -2497,7 +2497,7 @@ fn parse_type_suffix(
         let current_token = match state.current() {
             Ok(token) => token,
             Err(()) => {
-                types.push(Pair::End(ty));
+                types.push(Pair::End(type_info));
                 break;
             }
         };
@@ -2517,7 +2517,7 @@ fn parse_type_suffix(
                 let question_mark = state.consume().unwrap();
 
                 current_type = Some(ast::TypeInfo::Optional {
-                    base: Box::new(ty),
+                    base: Box::new(type_info),
                     question_mark,
                 });
 
@@ -2536,7 +2536,7 @@ fn parse_type_suffix(
                 }
 
                 let pipe = state.consume().unwrap();
-                types.push(Pair::new(ty, Some(pipe)));
+                types.push(Pair::new(type_info, Some(pipe)));
                 is_union = true;
             }
 
@@ -2552,14 +2552,14 @@ fn parse_type_suffix(
                 }
 
                 let ampersand = state.consume().unwrap();
-                types.push(Pair::new(ty, Some(ampersand)));
+                types.push(Pair::new(type_info, Some(ampersand)));
                 is_intersection = true;
             }
 
-            _ if types.is_empty() => return ParserResult::Value(ty),
+            _ if types.is_empty() => return ParserResult::Value(type_info),
 
             _ => {
-                types.push(Pair::End(ty));
+                types.push(Pair::End(type_info));
                 break;
             }
         }

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2549,7 +2549,7 @@ fn parse_type_suffix(
                 is_intersection = true;
             }
 
-            _ if types.is_empty() => return ParserResult::Value(type_info),
+            _ if types.is_empty() && leading.is_none() => return ParserResult::Value(type_info),
 
             _ => {
                 types.push(Pair::End(type_info));

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2225,9 +2225,8 @@ fn expect_interpolated_string(
 
 #[cfg(feature = "luau")]
 fn parse_type(state: &mut ParserState) -> ParserResult<ast::TypeInfo> {
-    let current_token = match state.current() {
-        Ok(token) => token,
-        Err(()) => return ParserResult::NotFound,
+    let Ok(current_token) = state.current() else {
+        return ParserResult::NotFound;
     };
 
     if let TokenType::Symbol {
@@ -2459,11 +2458,8 @@ fn parse_type_suffix(
     let leading = if simple_type.is_some() {
         None
     } else {
-        let current_token = match state.current() {
-            Ok(token) => token,
-            Err(()) => {
-                unreachable!("parse_type_suffix called with no simple_type and no current token")
-            }
+        let Ok(current_token) = state.current() else {
+            unreachable!("parse_type_suffix called with no simple_type and no current token")
         };
 
         match current_token.token_type() {
@@ -2494,12 +2490,9 @@ fn parse_type_suffix(
             ty
         };
 
-        let current_token = match state.current() {
-            Ok(token) => token,
-            Err(()) => {
-                types.push(Pair::End(type_info));
-                break;
-            }
+        let Ok(current_token) = state.current() else {
+            types.push(Pair::End(type_info));
+            break;
         };
 
         match current_token.token_type() {

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2483,7 +2483,8 @@ fn parse_type_suffix(
         let type_info = if current_type.is_some() {
             current_type.take().unwrap()
         } else {
-            let ParserResult::Value(type_info) = parse_simple_type(state, SimpleTypeStyle::Default) else {
+            let ParserResult::Value(type_info) = parse_simple_type(state, SimpleTypeStyle::Default)
+            else {
                 return ParserResult::LexerMoved;
             };
 

--- a/full-moon/src/visitors.rs
+++ b/full-moon/src/visitors.rs
@@ -294,9 +294,9 @@ create_visitor!(ast: {
         visit_type_field => TypeField,
         visit_type_field_key => TypeFieldKey,
         visit_type_info => TypeInfo,
+        visit_type_intersection => TypeIntersection,
         visit_type_specifier => TypeSpecifier,
         visit_type_union => TypeUnion,
-        visit_type_intersection => TypeIntersection,
     }
 
     // Lua 5.2

--- a/full-moon/src/visitors.rs
+++ b/full-moon/src/visitors.rs
@@ -295,6 +295,8 @@ create_visitor!(ast: {
         visit_type_field_key => TypeFieldKey,
         visit_type_info => TypeInfo,
         visit_type_specifier => TypeSpecifier,
+        visit_type_union => TypeUnion,
+        visit_type_intersection => TypeIntersection,
     }
 
     // Lua 5.2

--- a/full-moon/tests/roblox_cases/pass/generic_functions/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/generic_functions/ast.snap
@@ -1,6 +1,8 @@
 ---
 source: full-moon/tests/pass_cases.rs
+assertion_line: 48
 expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/generic_functions
 ---
 stmts:
   - - FunctionDeclaration:
@@ -936,141 +938,140 @@ stmts:
                                               characters: " "
                                     type_info:
                                       Union:
-                                        left:
-                                          Union:
-                                            left:
-                                              Basic:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 112
-                                                    line: 11
-                                                    character: 6
-                                                  end_position:
-                                                    bytes: 115
-                                                    line: 11
-                                                    character: 9
-                                                  token_type:
-                                                    type: Symbol
-                                                    symbol: nil
-                                                trailing_trivia:
-                                                  - start_position:
-                                                      bytes: 115
-                                                      line: 11
-                                                      character: 9
-                                                    end_position:
+                                        leading: ~
+                                        types:
+                                          pairs:
+                                            - Punctuated:
+                                                - Basic:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 112
+                                                        line: 11
+                                                        character: 6
+                                                      end_position:
+                                                        bytes: 115
+                                                        line: 11
+                                                        character: 9
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: nil
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 115
+                                                          line: 11
+                                                          character: 9
+                                                        end_position:
+                                                          bytes: 116
+                                                          line: 11
+                                                          character: 10
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
                                                       bytes: 116
                                                       line: 11
                                                       character: 10
-                                                    token_type:
-                                                      type: Whitespace
-                                                      characters: " "
-                                            pipe:
-                                              leading_trivia: []
-                                              token:
-                                                start_position:
-                                                  bytes: 116
-                                                  line: 11
-                                                  character: 10
-                                                end_position:
-                                                  bytes: 117
-                                                  line: 11
-                                                  character: 11
-                                                token_type:
-                                                  type: Symbol
-                                                  symbol: "|"
-                                              trailing_trivia:
-                                                - start_position:
-                                                    bytes: 117
-                                                    line: 11
-                                                    character: 11
-                                                  end_position:
-                                                    bytes: 118
-                                                    line: 11
-                                                    character: 12
-                                                  token_type:
-                                                    type: Whitespace
-                                                    characters: " "
-                                            right:
-                                              Basic:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 118
-                                                    line: 11
-                                                    character: 12
-                                                  end_position:
-                                                    bytes: 124
-                                                    line: 11
-                                                    character: 18
-                                                  token_type:
-                                                    type: Identifier
-                                                    identifier: number
-                                                trailing_trivia:
-                                                  - start_position:
-                                                      bytes: 124
-                                                      line: 11
-                                                      character: 18
                                                     end_position:
+                                                      bytes: 117
+                                                      line: 11
+                                                      character: 11
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: "|"
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 117
+                                                        line: 11
+                                                        character: 11
+                                                      end_position:
+                                                        bytes: 118
+                                                        line: 11
+                                                        character: 12
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: " "
+                                            - Punctuated:
+                                                - Basic:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 118
+                                                        line: 11
+                                                        character: 12
+                                                      end_position:
+                                                        bytes: 124
+                                                        line: 11
+                                                        character: 18
+                                                      token_type:
+                                                        type: Identifier
+                                                        identifier: number
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 124
+                                                          line: 11
+                                                          character: 18
+                                                        end_position:
+                                                          bytes: 125
+                                                          line: 11
+                                                          character: 19
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
                                                       bytes: 125
                                                       line: 11
                                                       character: 19
+                                                    end_position:
+                                                      bytes: 126
+                                                      line: 11
+                                                      character: 20
                                                     token_type:
-                                                      type: Whitespace
-                                                      characters: " "
-                                        pipe:
-                                          leading_trivia: []
-                                          token:
-                                            start_position:
-                                              bytes: 125
-                                              line: 11
-                                              character: 19
-                                            end_position:
-                                              bytes: 126
-                                              line: 11
-                                              character: 20
-                                            token_type:
-                                              type: Symbol
-                                              symbol: "|"
-                                          trailing_trivia:
-                                            - start_position:
-                                                bytes: 126
-                                                line: 11
-                                                character: 20
-                                              end_position:
-                                                bytes: 127
-                                                line: 11
-                                                character: 21
-                                              token_type:
-                                                type: Whitespace
-                                                characters: " "
-                                        right:
-                                          Basic:
-                                            leading_trivia: []
-                                            token:
-                                              start_position:
-                                                bytes: 127
-                                                line: 11
-                                                character: 21
-                                              end_position:
-                                                bytes: 134
-                                                line: 11
-                                                character: 28
-                                              token_type:
-                                                type: Identifier
-                                                identifier: boolean
-                                            trailing_trivia:
-                                              - start_position:
-                                                  bytes: 134
-                                                  line: 11
-                                                  character: 28
-                                                end_position:
-                                                  bytes: 135
-                                                  line: 11
-                                                  character: 28
-                                                token_type:
-                                                  type: Whitespace
-                                                  characters: "\n"
+                                                      type: Symbol
+                                                      symbol: "|"
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 126
+                                                        line: 11
+                                                        character: 20
+                                                      end_position:
+                                                        bytes: 127
+                                                        line: 11
+                                                        character: 21
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: " "
+                                            - End:
+                                                Basic:
+                                                  leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 127
+                                                      line: 11
+                                                      character: 21
+                                                    end_position:
+                                                      bytes: 134
+                                                      line: 11
+                                                      character: 28
+                                                    token_type:
+                                                      type: Identifier
+                                                      identifier: boolean
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 134
+                                                        line: 11
+                                                        character: 28
+                                                      end_position:
+                                                        bytes: 135
+                                                        line: 11
+                                                        character: 28
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: "\n"
                             arrow:
                               leading_trivia: []
                               token:
@@ -1680,141 +1681,140 @@ stmts:
                                               characters: " "
                                     type_info:
                                       Union:
-                                        left:
-                                          Union:
-                                            left:
-                                              Basic:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 202
-                                                    line: 18
-                                                    character: 6
-                                                  end_position:
-                                                    bytes: 205
-                                                    line: 18
-                                                    character: 9
-                                                  token_type:
-                                                    type: Symbol
-                                                    symbol: nil
-                                                trailing_trivia:
-                                                  - start_position:
-                                                      bytes: 205
-                                                      line: 18
-                                                      character: 9
-                                                    end_position:
+                                        leading: ~
+                                        types:
+                                          pairs:
+                                            - Punctuated:
+                                                - Basic:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 202
+                                                        line: 18
+                                                        character: 6
+                                                      end_position:
+                                                        bytes: 205
+                                                        line: 18
+                                                        character: 9
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: nil
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 205
+                                                          line: 18
+                                                          character: 9
+                                                        end_position:
+                                                          bytes: 206
+                                                          line: 18
+                                                          character: 10
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
                                                       bytes: 206
                                                       line: 18
                                                       character: 10
-                                                    token_type:
-                                                      type: Whitespace
-                                                      characters: " "
-                                            pipe:
-                                              leading_trivia: []
-                                              token:
-                                                start_position:
-                                                  bytes: 206
-                                                  line: 18
-                                                  character: 10
-                                                end_position:
-                                                  bytes: 207
-                                                  line: 18
-                                                  character: 11
-                                                token_type:
-                                                  type: Symbol
-                                                  symbol: "|"
-                                              trailing_trivia:
-                                                - start_position:
-                                                    bytes: 207
-                                                    line: 18
-                                                    character: 11
-                                                  end_position:
-                                                    bytes: 208
-                                                    line: 18
-                                                    character: 12
-                                                  token_type:
-                                                    type: Whitespace
-                                                    characters: " "
-                                            right:
-                                              Basic:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 208
-                                                    line: 18
-                                                    character: 12
-                                                  end_position:
-                                                    bytes: 214
-                                                    line: 18
-                                                    character: 18
-                                                  token_type:
-                                                    type: Identifier
-                                                    identifier: number
-                                                trailing_trivia:
-                                                  - start_position:
-                                                      bytes: 214
-                                                      line: 18
-                                                      character: 18
                                                     end_position:
+                                                      bytes: 207
+                                                      line: 18
+                                                      character: 11
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: "|"
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 207
+                                                        line: 18
+                                                        character: 11
+                                                      end_position:
+                                                        bytes: 208
+                                                        line: 18
+                                                        character: 12
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: " "
+                                            - Punctuated:
+                                                - Basic:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 208
+                                                        line: 18
+                                                        character: 12
+                                                      end_position:
+                                                        bytes: 214
+                                                        line: 18
+                                                        character: 18
+                                                      token_type:
+                                                        type: Identifier
+                                                        identifier: number
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 214
+                                                          line: 18
+                                                          character: 18
+                                                        end_position:
+                                                          bytes: 215
+                                                          line: 18
+                                                          character: 19
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
                                                       bytes: 215
                                                       line: 18
                                                       character: 19
+                                                    end_position:
+                                                      bytes: 216
+                                                      line: 18
+                                                      character: 20
                                                     token_type:
-                                                      type: Whitespace
-                                                      characters: " "
-                                        pipe:
-                                          leading_trivia: []
-                                          token:
-                                            start_position:
-                                              bytes: 215
-                                              line: 18
-                                              character: 19
-                                            end_position:
-                                              bytes: 216
-                                              line: 18
-                                              character: 20
-                                            token_type:
-                                              type: Symbol
-                                              symbol: "|"
-                                          trailing_trivia:
-                                            - start_position:
-                                                bytes: 216
-                                                line: 18
-                                                character: 20
-                                              end_position:
-                                                bytes: 217
-                                                line: 18
-                                                character: 21
-                                              token_type:
-                                                type: Whitespace
-                                                characters: " "
-                                        right:
-                                          Basic:
-                                            leading_trivia: []
-                                            token:
-                                              start_position:
-                                                bytes: 217
-                                                line: 18
-                                                character: 21
-                                              end_position:
-                                                bytes: 224
-                                                line: 18
-                                                character: 28
-                                              token_type:
-                                                type: Identifier
-                                                identifier: boolean
-                                            trailing_trivia:
-                                              - start_position:
-                                                  bytes: 224
-                                                  line: 18
-                                                  character: 28
-                                                end_position:
-                                                  bytes: 225
-                                                  line: 18
-                                                  character: 28
-                                                token_type:
-                                                  type: Whitespace
-                                                  characters: "\n"
+                                                      type: Symbol
+                                                      symbol: "|"
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 216
+                                                        line: 18
+                                                        character: 20
+                                                      end_position:
+                                                        bytes: 217
+                                                        line: 18
+                                                        character: 21
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: " "
+                                            - End:
+                                                Basic:
+                                                  leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 217
+                                                      line: 18
+                                                      character: 21
+                                                    end_position:
+                                                      bytes: 224
+                                                      line: 18
+                                                      character: 28
+                                                    token_type:
+                                                      type: Identifier
+                                                      identifier: boolean
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 224
+                                                        line: 18
+                                                        character: 28
+                                                      end_position:
+                                                        bytes: 225
+                                                        line: 18
+                                                        character: 28
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: "\n"
                             arrow:
                               leading_trivia: []
                               token:
@@ -2377,130 +2377,129 @@ stmts:
                                 characters: " "
                         type_info:
                           Union:
-                            left:
-                              Union:
-                                left:
-                                  Basic:
-                                    leading_trivia: []
-                                    token:
-                                      start_position:
-                                        bytes: 282
-                                        line: 22
-                                        character: 29
-                                      end_position:
-                                        bytes: 288
-                                        line: 22
-                                        character: 35
-                                      token_type:
-                                        type: Identifier
-                                        identifier: number
-                                    trailing_trivia:
-                                      - start_position:
-                                          bytes: 288
-                                          line: 22
-                                          character: 35
-                                        end_position:
+                            leading: ~
+                            types:
+                              pairs:
+                                - Punctuated:
+                                    - Basic:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 282
+                                            line: 22
+                                            character: 29
+                                          end_position:
+                                            bytes: 288
+                                            line: 22
+                                            character: 35
+                                          token_type:
+                                            type: Identifier
+                                            identifier: number
+                                        trailing_trivia:
+                                          - start_position:
+                                              bytes: 288
+                                              line: 22
+                                              character: 35
+                                            end_position:
+                                              bytes: 289
+                                              line: 22
+                                              character: 36
+                                            token_type:
+                                              type: Whitespace
+                                              characters: " "
+                                    - leading_trivia: []
+                                      token:
+                                        start_position:
                                           bytes: 289
                                           line: 22
                                           character: 36
-                                        token_type:
-                                          type: Whitespace
-                                          characters: " "
-                                pipe:
-                                  leading_trivia: []
-                                  token:
-                                    start_position:
-                                      bytes: 289
-                                      line: 22
-                                      character: 36
-                                    end_position:
-                                      bytes: 290
-                                      line: 22
-                                      character: 37
-                                    token_type:
-                                      type: Symbol
-                                      symbol: "|"
-                                  trailing_trivia:
-                                    - start_position:
-                                        bytes: 290
-                                        line: 22
-                                        character: 37
-                                      end_position:
-                                        bytes: 291
-                                        line: 22
-                                        character: 38
-                                      token_type:
-                                        type: Whitespace
-                                        characters: " "
-                                right:
-                                  Basic:
-                                    leading_trivia: []
-                                    token:
-                                      start_position:
-                                        bytes: 291
-                                        line: 22
-                                        character: 38
-                                      end_position:
-                                        bytes: 298
-                                        line: 22
-                                        character: 45
-                                      token_type:
-                                        type: Identifier
-                                        identifier: boolean
-                                    trailing_trivia:
-                                      - start_position:
-                                          bytes: 298
-                                          line: 22
-                                          character: 45
                                         end_position:
+                                          bytes: 290
+                                          line: 22
+                                          character: 37
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "|"
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 290
+                                            line: 22
+                                            character: 37
+                                          end_position:
+                                            bytes: 291
+                                            line: 22
+                                            character: 38
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                - Punctuated:
+                                    - Basic:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 291
+                                            line: 22
+                                            character: 38
+                                          end_position:
+                                            bytes: 298
+                                            line: 22
+                                            character: 45
+                                          token_type:
+                                            type: Identifier
+                                            identifier: boolean
+                                        trailing_trivia:
+                                          - start_position:
+                                              bytes: 298
+                                              line: 22
+                                              character: 45
+                                            end_position:
+                                              bytes: 299
+                                              line: 22
+                                              character: 46
+                                            token_type:
+                                              type: Whitespace
+                                              characters: " "
+                                    - leading_trivia: []
+                                      token:
+                                        start_position:
                                           bytes: 299
                                           line: 22
                                           character: 46
+                                        end_position:
+                                          bytes: 300
+                                          line: 22
+                                          character: 47
                                         token_type:
-                                          type: Whitespace
-                                          characters: " "
-                            pipe:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 299
-                                  line: 22
-                                  character: 46
-                                end_position:
-                                  bytes: 300
-                                  line: 22
-                                  character: 47
-                                token_type:
-                                  type: Symbol
-                                  symbol: "|"
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 300
-                                    line: 22
-                                    character: 47
-                                  end_position:
-                                    bytes: 301
-                                    line: 22
-                                    character: 48
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                            right:
-                              Basic:
-                                leading_trivia: []
-                                token:
-                                  start_position:
-                                    bytes: 301
-                                    line: 22
-                                    character: 48
-                                  end_position:
-                                    bytes: 304
-                                    line: 22
-                                    character: 51
-                                  token_type:
-                                    type: Symbol
-                                    symbol: nil
-                                trailing_trivia: []
+                                          type: Symbol
+                                          symbol: "|"
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 300
+                                            line: 22
+                                            character: 47
+                                          end_position:
+                                            bytes: 301
+                                            line: 22
+                                            character: 48
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                - End:
+                                    Basic:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 301
+                                          line: 22
+                                          character: 48
+                                        end_position:
+                                          bytes: 304
+                                          line: 22
+                                          character: 51
+                                        token_type:
+                                          type: Symbol
+                                          symbol: nil
+                                      trailing_trivia: []
                     return_type:
                       punctuation:
                         leading_trivia: []
@@ -2530,86 +2529,88 @@ stmts:
                               characters: " "
                       type_info:
                         Union:
-                          left:
-                            Basic:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 307
-                                  line: 22
-                                  character: 54
-                                end_position:
-                                  bytes: 310
-                                  line: 22
-                                  character: 57
-                                token_type:
-                                  type: Symbol
-                                  symbol: nil
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 310
-                                    line: 22
-                                    character: 57
-                                  end_position:
-                                    bytes: 311
-                                    line: 22
-                                    character: 58
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                          pipe:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 311
-                                line: 22
-                                character: 58
-                              end_position:
-                                bytes: 312
-                                line: 22
-                                character: 59
-                              token_type:
-                                type: Symbol
-                                symbol: "|"
-                            trailing_trivia:
-                              - start_position:
-                                  bytes: 312
-                                  line: 22
-                                  character: 59
-                                end_position:
-                                  bytes: 313
-                                  line: 22
-                                  character: 60
-                                token_type:
-                                  type: Whitespace
-                                  characters: " "
-                          right:
-                            Basic:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 313
-                                  line: 22
-                                  character: 60
-                                end_position:
-                                  bytes: 314
-                                  line: 22
-                                  character: 61
-                                token_type:
-                                  type: Identifier
-                                  identifier: T
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 314
-                                    line: 22
-                                    character: 61
-                                  end_position:
-                                    bytes: 315
-                                    line: 22
-                                    character: 61
-                                  token_type:
-                                    type: Whitespace
-                                    characters: "\n"
+                          leading: ~
+                          types:
+                            pairs:
+                              - Punctuated:
+                                  - Basic:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 307
+                                          line: 22
+                                          character: 54
+                                        end_position:
+                                          bytes: 310
+                                          line: 22
+                                          character: 57
+                                        token_type:
+                                          type: Symbol
+                                          symbol: nil
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 310
+                                            line: 22
+                                            character: 57
+                                          end_position:
+                                            bytes: 311
+                                            line: 22
+                                            character: 58
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 311
+                                        line: 22
+                                        character: 58
+                                      end_position:
+                                        bytes: 312
+                                        line: 22
+                                        character: 59
+                                      token_type:
+                                        type: Symbol
+                                        symbol: "|"
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 312
+                                          line: 22
+                                          character: 59
+                                        end_position:
+                                          bytes: 313
+                                          line: 22
+                                          character: 60
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                              - End:
+                                  Basic:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 313
+                                        line: 22
+                                        character: 60
+                                      end_position:
+                                        bytes: 314
+                                        line: 22
+                                        character: 61
+                                      token_type:
+                                        type: Identifier
+                                        identifier: T
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 314
+                                          line: 22
+                                          character: 61
+                                        end_position:
+                                          bytes: 315
+                                          line: 22
+                                          character: 61
+                                        token_type:
+                                          type: Whitespace
+                                          characters: "\n"
                     block:
                       stmts: []
                       last_stmt:
@@ -2697,4 +2698,3 @@ stmts:
                           symbol: end
                       trailing_trivia: []
     - ~
-

--- a/full-moon/tests/roblox_cases/pass/types/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/types
 ---
 stmts:
   - - LocalAssignment:
@@ -1823,88 +1824,90 @@ stmts:
                 characters: " "
         declare_as:
           Union:
-            left:
-              String:
-                leading_trivia: []
-                token:
-                  start_position:
-                    bytes: 233
-                    line: 9
-                    character: 20
-                  end_position:
-                    bytes: 240
-                    line: 9
-                    character: 27
-                  token_type:
-                    type: StringLiteral
-                    literal: alice
-                    quote_type: Double
-                trailing_trivia:
-                  - start_position:
-                      bytes: 240
-                      line: 9
-                      character: 27
-                    end_position:
-                      bytes: 241
-                      line: 9
-                      character: 28
-                    token_type:
-                      type: Whitespace
-                      characters: " "
-            pipe:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 241
-                  line: 9
-                  character: 28
-                end_position:
-                  bytes: 242
-                  line: 9
-                  character: 29
-                token_type:
-                  type: Symbol
-                  symbol: "|"
-              trailing_trivia:
-                - start_position:
-                    bytes: 242
-                    line: 9
-                    character: 29
-                  end_position:
-                    bytes: 243
-                    line: 9
-                    character: 30
-                  token_type:
-                    type: Whitespace
-                    characters: " "
-            right:
-              String:
-                leading_trivia: []
-                token:
-                  start_position:
-                    bytes: 243
-                    line: 9
-                    character: 30
-                  end_position:
-                    bytes: 251
-                    line: 9
-                    character: 38
-                  token_type:
-                    type: StringLiteral
-                    literal: mallet
-                    quote_type: Double
-                trailing_trivia:
-                  - start_position:
-                      bytes: 251
-                      line: 9
-                      character: 38
-                    end_position:
-                      bytes: 252
-                      line: 9
-                      character: 38
-                    token_type:
-                      type: Whitespace
-                      characters: "\n"
+            leading: ~
+            types:
+              pairs:
+                - Punctuated:
+                    - String:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 233
+                            line: 9
+                            character: 20
+                          end_position:
+                            bytes: 240
+                            line: 9
+                            character: 27
+                          token_type:
+                            type: StringLiteral
+                            literal: alice
+                            quote_type: Double
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 240
+                              line: 9
+                              character: 27
+                            end_position:
+                              bytes: 241
+                              line: 9
+                              character: 28
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 241
+                          line: 9
+                          character: 28
+                        end_position:
+                          bytes: 242
+                          line: 9
+                          character: 29
+                        token_type:
+                          type: Symbol
+                          symbol: "|"
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 242
+                            line: 9
+                            character: 29
+                          end_position:
+                            bytes: 243
+                            line: 9
+                            character: 30
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                - End:
+                    String:
+                      leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 243
+                          line: 9
+                          character: 30
+                        end_position:
+                          bytes: 251
+                          line: 9
+                          character: 38
+                        token_type:
+                          type: StringLiteral
+                          literal: mallet
+                          quote_type: Double
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 251
+                            line: 9
+                            character: 38
+                          end_position:
+                            bytes: 252
+                            line: 9
+                            character: 38
+                          token_type:
+                            type: Whitespace
+                            characters: "\n"
     - ~
   - - TypeDeclaration:
         type_token:
@@ -3085,77 +3088,79 @@ stmts:
                     name: ~
                     type_info:
                       Union:
-                        left:
-                          String:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 451
-                                line: 15
-                                character: 28
-                              end_position:
-                                bytes: 458
-                                line: 15
-                                character: 35
-                              token_type:
-                                type: StringLiteral
-                                literal: error
-                                quote_type: Double
-                            trailing_trivia:
-                              - start_position:
-                                  bytes: 458
-                                  line: 15
-                                  character: 35
-                                end_position:
-                                  bytes: 459
-                                  line: 15
-                                  character: 36
-                                token_type:
-                                  type: Whitespace
-                                  characters: " "
-                        pipe:
-                          leading_trivia: []
-                          token:
-                            start_position:
-                              bytes: 459
-                              line: 15
-                              character: 36
-                            end_position:
-                              bytes: 460
-                              line: 15
-                              character: 37
-                            token_type:
-                              type: Symbol
-                              symbol: "|"
-                          trailing_trivia:
-                            - start_position:
-                                bytes: 460
-                                line: 15
-                                character: 37
-                              end_position:
-                                bytes: 461
-                                line: 15
-                                character: 38
-                              token_type:
-                                type: Whitespace
-                                characters: " "
-                        right:
-                          String:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 461
-                                line: 15
-                                character: 38
-                              end_position:
-                                bytes: 470
-                                line: 15
-                                character: 47
-                              token_type:
-                                type: StringLiteral
-                                literal: success
-                                quote_type: Double
-                            trailing_trivia: []
+                        leading: ~
+                        types:
+                          pairs:
+                            - Punctuated:
+                                - String:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 451
+                                        line: 15
+                                        character: 28
+                                      end_position:
+                                        bytes: 458
+                                        line: 15
+                                        character: 35
+                                      token_type:
+                                        type: StringLiteral
+                                        literal: error
+                                        quote_type: Double
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 458
+                                          line: 15
+                                          character: 35
+                                        end_position:
+                                          bytes: 459
+                                          line: 15
+                                          character: 36
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                                - leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 459
+                                      line: 15
+                                      character: 36
+                                    end_position:
+                                      bytes: 460
+                                      line: 15
+                                      character: 37
+                                    token_type:
+                                      type: Symbol
+                                      symbol: "|"
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 460
+                                        line: 15
+                                        character: 37
+                                      end_position:
+                                        bytes: 461
+                                        line: 15
+                                        character: 38
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                            - End:
+                                String:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 461
+                                      line: 15
+                                      character: 38
+                                    end_position:
+                                      bytes: 470
+                                      line: 15
+                                      character: 47
+                                    token_type:
+                                      type: StringLiteral
+                                      literal: success
+                                      quote_type: Double
+                                  trailing_trivia: []
             arrow:
               leading_trivia: []
               token:
@@ -3270,77 +3275,79 @@ stmts:
                                 characters: " "
                     - End:
                         Union:
-                          left:
-                            String:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 484
-                                  line: 15
-                                  character: 61
-                                end_position:
-                                  bytes: 492
-                                  line: 15
-                                  character: 69
-                                token_type:
-                                  type: StringLiteral
-                                  literal: weasel
-                                  quote_type: Double
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 492
-                                    line: 15
-                                    character: 69
-                                  end_position:
-                                    bytes: 493
-                                    line: 15
-                                    character: 70
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                          pipe:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 493
-                                line: 15
-                                character: 70
-                              end_position:
-                                bytes: 494
-                                line: 15
-                                character: 71
-                              token_type:
-                                type: Symbol
-                                symbol: "|"
-                            trailing_trivia:
-                              - start_position:
-                                  bytes: 494
-                                  line: 15
-                                  character: 71
-                                end_position:
-                                  bytes: 495
-                                  line: 15
-                                  character: 72
-                                token_type:
-                                  type: Whitespace
-                                  characters: " "
-                          right:
-                            String:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 495
-                                  line: 15
-                                  character: 72
-                                end_position:
-                                  bytes: 505
-                                  line: 15
-                                  character: 82
-                                token_type:
-                                  type: StringLiteral
-                                  literal: basilisk
-                                  quote_type: Double
-                              trailing_trivia: []
+                          leading: ~
+                          types:
+                            pairs:
+                              - Punctuated:
+                                  - String:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 484
+                                          line: 15
+                                          character: 61
+                                        end_position:
+                                          bytes: 492
+                                          line: 15
+                                          character: 69
+                                        token_type:
+                                          type: StringLiteral
+                                          literal: weasel
+                                          quote_type: Double
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 492
+                                            line: 15
+                                            character: 69
+                                          end_position:
+                                            bytes: 493
+                                            line: 15
+                                            character: 70
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 493
+                                        line: 15
+                                        character: 70
+                                      end_position:
+                                        bytes: 494
+                                        line: 15
+                                        character: 71
+                                      token_type:
+                                        type: Symbol
+                                        symbol: "|"
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 494
+                                          line: 15
+                                          character: 71
+                                        end_position:
+                                          bytes: 495
+                                          line: 15
+                                          character: 72
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                              - End:
+                                  String:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 495
+                                        line: 15
+                                        character: 72
+                                      end_position:
+                                        bytes: 505
+                                        line: 15
+                                        character: 82
+                                      token_type:
+                                        type: StringLiteral
+                                        literal: basilisk
+                                        quote_type: Double
+                                    trailing_trivia: []
     - ~
   - - TypeDeclaration:
         type_token:
@@ -3730,301 +3737,303 @@ stmts:
                 characters: " "
         declare_as:
           Intersection:
-            left:
-              Table:
-                braces:
-                  tokens:
-                    - leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 571
-                          line: 17
-                          character: 21
-                        end_position:
-                          bytes: 572
-                          line: 17
-                          character: 22
-                        token_type:
-                          type: Symbol
-                          symbol: "{"
-                      trailing_trivia:
-                        - start_position:
-                            bytes: 572
-                            line: 17
-                            character: 22
-                          end_position:
-                            bytes: 573
-                            line: 17
-                            character: 23
-                          token_type:
-                            type: Whitespace
-                            characters: " "
-                    - leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 590
-                          line: 17
-                          character: 40
-                        end_position:
-                          bytes: 591
-                          line: 17
-                          character: 41
-                        token_type:
-                          type: Symbol
-                          symbol: "}"
-                      trailing_trivia:
-                        - start_position:
-                            bytes: 591
-                            line: 17
-                            character: 41
-                          end_position:
-                            bytes: 592
-                            line: 17
-                            character: 42
-                          token_type:
-                            type: Whitespace
-                            characters: " "
-                fields:
-                  pairs:
-                    - End:
-                        key:
-                          Name:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 573
-                                line: 17
-                                character: 23
-                              end_position:
-                                bytes: 580
-                                line: 17
-                                character: 30
-                              token_type:
-                                type: Identifier
-                                identifier: message
-                            trailing_trivia: []
-                        colon:
-                          leading_trivia: []
-                          token:
-                            start_position:
-                              bytes: 580
-                              line: 17
-                              character: 30
-                            end_position:
-                              bytes: 581
-                              line: 17
-                              character: 31
-                            token_type:
-                              type: Symbol
-                              symbol: ":"
-                          trailing_trivia:
-                            - start_position:
-                                bytes: 581
-                                line: 17
-                                character: 31
-                              end_position:
-                                bytes: 582
-                                line: 17
-                                character: 32
-                              token_type:
-                                type: Whitespace
-                                characters: " "
-                        value:
-                          Optional:
-                            base:
-                              Basic:
-                                leading_trivia: []
-                                token:
-                                  start_position:
-                                    bytes: 582
-                                    line: 17
-                                    character: 32
-                                  end_position:
-                                    bytes: 588
-                                    line: 17
-                                    character: 38
-                                  token_type:
-                                    type: Identifier
-                                    identifier: string
-                                trailing_trivia: []
-                            question_mark:
-                              leading_trivia: []
+            leading: ~
+            types:
+              pairs:
+                - Punctuated:
+                    - Table:
+                        braces:
+                          tokens:
+                            - leading_trivia: []
                               token:
                                 start_position:
-                                  bytes: 588
+                                  bytes: 571
                                   line: 17
-                                  character: 38
+                                  character: 21
                                 end_position:
-                                  bytes: 589
+                                  bytes: 572
                                   line: 17
-                                  character: 39
+                                  character: 22
                                 token_type:
                                   type: Symbol
-                                  symbol: "?"
+                                  symbol: "{"
                               trailing_trivia:
                                 - start_position:
-                                    bytes: 589
+                                    bytes: 572
                                     line: 17
-                                    character: 39
+                                    character: 22
                                   end_position:
-                                    bytes: 590
+                                    bytes: 573
                                     line: 17
-                                    character: 40
+                                    character: 23
                                   token_type:
                                     type: Whitespace
                                     characters: " "
-            ampersand:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 592
-                  line: 17
-                  character: 42
-                end_position:
-                  bytes: 593
-                  line: 17
-                  character: 43
-                token_type:
-                  type: Symbol
-                  symbol: "&"
-              trailing_trivia:
-                - start_position:
-                    bytes: 593
-                    line: 17
-                    character: 43
-                  end_position:
-                    bytes: 594
-                    line: 17
-                    character: 44
-                  token_type:
-                    type: Whitespace
-                    characters: " "
-            right:
-              Table:
-                braces:
-                  tokens:
+                            - leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 590
+                                  line: 17
+                                  character: 40
+                                end_position:
+                                  bytes: 591
+                                  line: 17
+                                  character: 41
+                                token_type:
+                                  type: Symbol
+                                  symbol: "}"
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 591
+                                    line: 17
+                                    character: 41
+                                  end_position:
+                                    bytes: 592
+                                    line: 17
+                                    character: 42
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                        fields:
+                          pairs:
+                            - End:
+                                key:
+                                  Name:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 573
+                                        line: 17
+                                        character: 23
+                                      end_position:
+                                        bytes: 580
+                                        line: 17
+                                        character: 30
+                                      token_type:
+                                        type: Identifier
+                                        identifier: message
+                                    trailing_trivia: []
+                                colon:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 580
+                                      line: 17
+                                      character: 30
+                                    end_position:
+                                      bytes: 581
+                                      line: 17
+                                      character: 31
+                                    token_type:
+                                      type: Symbol
+                                      symbol: ":"
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 581
+                                        line: 17
+                                        character: 31
+                                      end_position:
+                                        bytes: 582
+                                        line: 17
+                                        character: 32
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                                value:
+                                  Optional:
+                                    base:
+                                      Basic:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 582
+                                            line: 17
+                                            character: 32
+                                          end_position:
+                                            bytes: 588
+                                            line: 17
+                                            character: 38
+                                          token_type:
+                                            type: Identifier
+                                            identifier: string
+                                        trailing_trivia: []
+                                    question_mark:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 588
+                                          line: 17
+                                          character: 38
+                                        end_position:
+                                          bytes: 589
+                                          line: 17
+                                          character: 39
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "?"
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 589
+                                            line: 17
+                                            character: 39
+                                          end_position:
+                                            bytes: 590
+                                            line: 17
+                                            character: 40
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
                     - leading_trivia: []
                       token:
                         start_position:
-                          bytes: 594
+                          bytes: 592
                           line: 17
-                          character: 44
+                          character: 42
                         end_position:
-                          bytes: 595
+                          bytes: 593
                           line: 17
-                          character: 45
+                          character: 43
                         token_type:
                           type: Symbol
-                          symbol: "{"
+                          symbol: "&"
                       trailing_trivia:
                         - start_position:
-                            bytes: 595
+                            bytes: 593
                             line: 17
-                            character: 45
+                            character: 43
                           end_position:
-                            bytes: 596
+                            bytes: 594
                             line: 17
-                            character: 46
+                            character: 44
                           token_type:
                             type: Whitespace
                             characters: " "
-                    - leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 610
-                          line: 17
-                          character: 60
-                        end_position:
-                          bytes: 611
-                          line: 17
-                          character: 61
-                        token_type:
-                          type: Symbol
-                          symbol: "}"
-                      trailing_trivia:
-                        - start_position:
-                            bytes: 611
-                            line: 17
-                            character: 61
-                          end_position:
-                            bytes: 612
-                            line: 17
-                            character: 61
-                          token_type:
-                            type: Whitespace
-                            characters: "\n"
-                fields:
-                  pairs:
-                    - End:
-                        key:
-                          Name:
-                            leading_trivia: []
+                - End:
+                    Table:
+                      braces:
+                        tokens:
+                          - leading_trivia: []
                             token:
                               start_position:
-                                bytes: 596
+                                bytes: 594
                                 line: 17
-                                character: 46
+                                character: 44
                               end_position:
-                                bytes: 603
+                                bytes: 595
                                 line: 17
-                                character: 53
-                              token_type:
-                                type: Identifier
-                                identifier: handled
-                            trailing_trivia: []
-                        colon:
-                          leading_trivia: []
-                          token:
-                            start_position:
-                              bytes: 603
-                              line: 17
-                              character: 53
-                            end_position:
-                              bytes: 604
-                              line: 17
-                              character: 54
-                            token_type:
-                              type: Symbol
-                              symbol: ":"
-                          trailing_trivia:
-                            - start_position:
-                                bytes: 604
-                                line: 17
-                                character: 54
-                              end_position:
-                                bytes: 605
-                                line: 17
-                                character: 55
-                              token_type:
-                                type: Whitespace
-                                characters: " "
-                        value:
-                          Boolean:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 605
-                                line: 17
-                                character: 55
-                              end_position:
-                                bytes: 609
-                                line: 17
-                                character: 59
+                                character: 45
                               token_type:
                                 type: Symbol
-                                symbol: "true"
+                                symbol: "{"
                             trailing_trivia:
                               - start_position:
-                                  bytes: 609
+                                  bytes: 595
                                   line: 17
-                                  character: 59
+                                  character: 45
                                 end_position:
-                                  bytes: 610
+                                  bytes: 596
                                   line: 17
-                                  character: 60
+                                  character: 46
                                 token_type:
                                   type: Whitespace
                                   characters: " "
+                          - leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 610
+                                line: 17
+                                character: 60
+                              end_position:
+                                bytes: 611
+                                line: 17
+                                character: 61
+                              token_type:
+                                type: Symbol
+                                symbol: "}"
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 611
+                                  line: 17
+                                  character: 61
+                                end_position:
+                                  bytes: 612
+                                  line: 17
+                                  character: 61
+                                token_type:
+                                  type: Whitespace
+                                  characters: "\n"
+                      fields:
+                        pairs:
+                          - End:
+                              key:
+                                Name:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 596
+                                      line: 17
+                                      character: 46
+                                    end_position:
+                                      bytes: 603
+                                      line: 17
+                                      character: 53
+                                    token_type:
+                                      type: Identifier
+                                      identifier: handled
+                                  trailing_trivia: []
+                              colon:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 603
+                                    line: 17
+                                    character: 53
+                                  end_position:
+                                    bytes: 604
+                                    line: 17
+                                    character: 54
+                                  token_type:
+                                    type: Symbol
+                                    symbol: ":"
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 604
+                                      line: 17
+                                      character: 54
+                                    end_position:
+                                      bytes: 605
+                                      line: 17
+                                      character: 55
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                              value:
+                                Boolean:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 605
+                                      line: 17
+                                      character: 55
+                                    end_position:
+                                      bytes: 609
+                                      line: 17
+                                      character: 59
+                                    token_type:
+                                      type: Symbol
+                                      symbol: "true"
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 609
+                                        line: 17
+                                        character: 59
+                                      end_position:
+                                        bytes: 610
+                                        line: 17
+                                        character: 60
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
     - ~
   - - TypeDeclaration:
         type_token:
@@ -4956,77 +4965,79 @@ stmts:
                                 characters: " "
                     - End:
                         Union:
-                          left:
-                            String:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 753
-                                  line: 27
-                                  character: 26
-                                end_position:
-                                  bytes: 760
-                                  line: 27
-                                  character: 33
-                                token_type:
-                                  type: StringLiteral
-                                  literal: allow
-                                  quote_type: Double
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 760
-                                    line: 27
-                                    character: 33
-                                  end_position:
-                                    bytes: 761
-                                    line: 27
-                                    character: 34
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                          pipe:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 761
-                                line: 27
-                                character: 34
-                              end_position:
-                                bytes: 762
-                                line: 27
-                                character: 35
-                              token_type:
-                                type: Symbol
-                                symbol: "|"
-                            trailing_trivia:
-                              - start_position:
-                                  bytes: 762
-                                  line: 27
-                                  character: 35
-                                end_position:
-                                  bytes: 763
-                                  line: 27
-                                  character: 36
-                                token_type:
-                                  type: Whitespace
-                                  characters: " "
-                          right:
-                            String:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 763
-                                  line: 27
-                                  character: 36
-                                end_position:
-                                  bytes: 769
-                                  line: 27
-                                  character: 42
-                                token_type:
-                                  type: StringLiteral
-                                  literal: deny
-                                  quote_type: Double
-                              trailing_trivia: []
+                          leading: ~
+                          types:
+                            pairs:
+                              - Punctuated:
+                                  - String:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 753
+                                          line: 27
+                                          character: 26
+                                        end_position:
+                                          bytes: 760
+                                          line: 27
+                                          character: 33
+                                        token_type:
+                                          type: StringLiteral
+                                          literal: allow
+                                          quote_type: Double
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 760
+                                            line: 27
+                                            character: 33
+                                          end_position:
+                                            bytes: 761
+                                            line: 27
+                                            character: 34
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 761
+                                        line: 27
+                                        character: 34
+                                      end_position:
+                                        bytes: 762
+                                        line: 27
+                                        character: 35
+                                      token_type:
+                                        type: Symbol
+                                        symbol: "|"
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 762
+                                          line: 27
+                                          character: 35
+                                        end_position:
+                                          bytes: 763
+                                          line: 27
+                                          character: 36
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                              - End:
+                                  String:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 763
+                                        line: 27
+                                        character: 36
+                                      end_position:
+                                        bytes: 769
+                                        line: 27
+                                        character: 42
+                                      token_type:
+                                        type: StringLiteral
+                                        literal: deny
+                                        quote_type: Double
+                                    trailing_trivia: []
         name_list:
           pairs:
             - End:
@@ -5467,86 +5478,88 @@ stmts:
                     characters: " "
             type_info:
               Union:
-                left:
-                  Basic:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 850
-                        line: 31
-                        character: 15
-                      end_position:
-                        bytes: 856
-                        line: 31
-                        character: 21
-                      token_type:
-                        type: Identifier
-                        identifier: number
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 856
-                          line: 31
-                          character: 21
-                        end_position:
-                          bytes: 857
-                          line: 31
-                          character: 22
-                        token_type:
-                          type: Whitespace
-                          characters: " "
-                pipe:
-                  leading_trivia: []
-                  token:
-                    start_position:
-                      bytes: 857
-                      line: 31
-                      character: 22
-                    end_position:
-                      bytes: 858
-                      line: 31
-                      character: 23
-                    token_type:
-                      type: Symbol
-                      symbol: "|"
-                  trailing_trivia:
-                    - start_position:
-                        bytes: 858
-                        line: 31
-                        character: 23
-                      end_position:
-                        bytes: 859
-                        line: 31
-                        character: 24
-                      token_type:
-                        type: Whitespace
-                        characters: " "
-                right:
-                  Basic:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 859
-                        line: 31
-                        character: 24
-                      end_position:
-                        bytes: 865
-                        line: 31
-                        character: 30
-                      token_type:
-                        type: Identifier
-                        identifier: string
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 865
-                          line: 31
-                          character: 30
-                        end_position:
-                          bytes: 866
-                          line: 31
-                          character: 30
-                        token_type:
-                          type: Whitespace
-                          characters: "\n"
+                leading: ~
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 850
+                                line: 31
+                                character: 15
+                              end_position:
+                                bytes: 856
+                                line: 31
+                                character: 21
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 856
+                                  line: 31
+                                  character: 21
+                                end_position:
+                                  bytes: 857
+                                  line: 31
+                                  character: 22
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 857
+                              line: 31
+                              character: 22
+                            end_position:
+                              bytes: 858
+                              line: 31
+                              character: 23
+                            token_type:
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 858
+                                line: 31
+                                character: 23
+                              end_position:
+                                bytes: 859
+                                line: 31
+                                character: 24
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 859
+                              line: 31
+                              character: 24
+                            end_position:
+                              bytes: 865
+                              line: 31
+                              character: 30
+                            token_type:
+                              type: Identifier
+                              identifier: string
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 865
+                                line: 31
+                                character: 30
+                              end_position:
+                                bytes: 866
+                                line: 31
+                                character: 30
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
         name_list:
           pairs:
             - End:
@@ -5624,141 +5637,140 @@ stmts:
                     characters: " "
             type_info:
               Union:
-                left:
-                  Union:
-                    left:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 885
-                            line: 32
-                            character: 20
-                          end_position:
-                            bytes: 891
-                            line: 32
-                            character: 26
-                          token_type:
-                            type: Identifier
-                            identifier: number
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 891
-                              line: 32
-                              character: 26
-                            end_position:
+                leading: ~
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 885
+                                line: 32
+                                character: 20
+                              end_position:
+                                bytes: 891
+                                line: 32
+                                character: 26
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 891
+                                  line: 32
+                                  character: 26
+                                end_position:
+                                  bytes: 892
+                                  line: 32
+                                  character: 27
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
                               bytes: 892
                               line: 32
                               character: 27
-                            token_type:
-                              type: Whitespace
-                              characters: " "
-                    pipe:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 892
-                          line: 32
-                          character: 27
-                        end_position:
-                          bytes: 893
-                          line: 32
-                          character: 28
-                        token_type:
-                          type: Symbol
-                          symbol: "|"
-                      trailing_trivia:
-                        - start_position:
-                            bytes: 893
-                            line: 32
-                            character: 28
-                          end_position:
-                            bytes: 894
-                            line: 32
-                            character: 29
-                          token_type:
-                            type: Whitespace
-                            characters: " "
-                    right:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 894
-                            line: 32
-                            character: 29
-                          end_position:
-                            bytes: 900
-                            line: 32
-                            character: 35
-                          token_type:
-                            type: Identifier
-                            identifier: string
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 900
-                              line: 32
-                              character: 35
                             end_position:
+                              bytes: 893
+                              line: 32
+                              character: 28
+                            token_type:
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 893
+                                line: 32
+                                character: 28
+                              end_position:
+                                bytes: 894
+                                line: 32
+                                character: 29
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 894
+                                line: 32
+                                character: 29
+                              end_position:
+                                bytes: 900
+                                line: 32
+                                character: 35
+                              token_type:
+                                type: Identifier
+                                identifier: string
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 900
+                                  line: 32
+                                  character: 35
+                                end_position:
+                                  bytes: 901
+                                  line: 32
+                                  character: 36
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
                               bytes: 901
                               line: 32
                               character: 36
+                            end_position:
+                              bytes: 902
+                              line: 32
+                              character: 37
                             token_type:
-                              type: Whitespace
-                              characters: " "
-                pipe:
-                  leading_trivia: []
-                  token:
-                    start_position:
-                      bytes: 901
-                      line: 32
-                      character: 36
-                    end_position:
-                      bytes: 902
-                      line: 32
-                      character: 37
-                    token_type:
-                      type: Symbol
-                      symbol: "|"
-                  trailing_trivia:
-                    - start_position:
-                        bytes: 902
-                        line: 32
-                        character: 37
-                      end_position:
-                        bytes: 903
-                        line: 32
-                        character: 38
-                      token_type:
-                        type: Whitespace
-                        characters: " "
-                right:
-                  Basic:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 903
-                        line: 32
-                        character: 38
-                      end_position:
-                        bytes: 906
-                        line: 32
-                        character: 41
-                      token_type:
-                        type: Symbol
-                        symbol: nil
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 906
-                          line: 32
-                          character: 41
-                        end_position:
-                          bytes: 907
-                          line: 32
-                          character: 41
-                        token_type:
-                          type: Whitespace
-                          characters: "\n"
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 902
+                                line: 32
+                                character: 37
+                              end_position:
+                                bytes: 903
+                                line: 32
+                                character: 38
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 903
+                              line: 32
+                              character: 38
+                            end_position:
+                              bytes: 906
+                              line: 32
+                              character: 41
+                            token_type:
+                              type: Symbol
+                              symbol: nil
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 906
+                                line: 32
+                                character: 41
+                              end_position:
+                                bytes: 907
+                                line: 32
+                                character: 41
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
         name_list:
           pairs:
             - End:
@@ -5782,38 +5794,27 @@ stmts:
     - ~
   - - LocalAssignment:
         local_token:
-          leading_trivia:
-            - start_position:
-                bytes: 907
-                line: 33
-                character: 1
-              end_position:
-                bytes: 908
-                line: 33
-                character: 1
-              token_type:
-                type: Whitespace
-                characters: "\n"
+          leading_trivia: []
           token:
             start_position:
-              bytes: 908
-              line: 34
+              bytes: 907
+              line: 33
               character: 1
             end_position:
-              bytes: 913
-              line: 34
+              bytes: 912
+              line: 33
               character: 6
             token_type:
               type: Symbol
               symbol: local
           trailing_trivia:
             - start_position:
-                bytes: 913
-                line: 34
+                bytes: 912
+                line: 33
                 character: 6
               end_position:
-                bytes: 914
-                line: 34
+                bytes: 913
+                line: 33
                 character: 7
               token_type:
                 type: Whitespace
@@ -5823,122 +5824,371 @@ stmts:
               leading_trivia: []
               token:
                 start_position:
-                  bytes: 927
-                  line: 34
+                  bytes: 926
+                  line: 33
                   character: 20
                 end_position:
-                  bytes: 928
-                  line: 34
+                  bytes: 927
+                  line: 33
                   character: 21
                 token_type:
                   type: Symbol
                   symbol: ":"
               trailing_trivia:
                 - start_position:
-                    bytes: 928
-                    line: 34
+                    bytes: 927
+                    line: 33
                     character: 21
                   end_position:
-                    bytes: 929
-                    line: 34
+                    bytes: 928
+                    line: 33
                     character: 22
                   token_type:
                     type: Whitespace
                     characters: " "
             type_info:
-              Intersection:
-                left:
-                  Basic:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 929
-                        line: 34
-                        character: 22
-                      end_position:
-                        bytes: 935
-                        line: 34
-                        character: 28
-                      token_type:
-                        type: Identifier
-                        identifier: number
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 935
-                          line: 34
-                          character: 28
-                        end_position:
-                          bytes: 936
-                          line: 34
-                          character: 29
-                        token_type:
-                          type: Whitespace
-                          characters: " "
-                ampersand:
+              Union:
+                leading:
                   leading_trivia: []
                   token:
                     start_position:
-                      bytes: 936
-                      line: 34
-                      character: 29
+                      bytes: 928
+                      line: 33
+                      character: 22
                     end_position:
-                      bytes: 937
-                      line: 34
-                      character: 30
+                      bytes: 929
+                      line: 33
+                      character: 23
                     token_type:
                       type: Symbol
-                      symbol: "&"
+                      symbol: "|"
                   trailing_trivia:
                     - start_position:
-                        bytes: 937
-                        line: 34
-                        character: 30
+                        bytes: 929
+                        line: 33
+                        character: 23
                       end_position:
-                        bytes: 938
-                        line: 34
-                        character: 31
+                        bytes: 930
+                        line: 33
+                        character: 24
                       token_type:
                         type: Whitespace
                         characters: " "
-                right:
-                  Basic:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 938
-                        line: 34
-                        character: 31
-                      end_position:
-                        bytes: 944
-                        line: 34
-                        character: 37
-                      token_type:
-                        type: Identifier
-                        identifier: string
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 944
-                          line: 34
-                          character: 37
-                        end_position:
-                          bytes: 945
-                          line: 34
-                          character: 37
-                        token_type:
-                          type: Whitespace
-                          characters: "\n"
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 930
+                                line: 33
+                                character: 24
+                              end_position:
+                                bytes: 936
+                                line: 33
+                                character: 30
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 936
+                                  line: 33
+                                  character: 30
+                                end_position:
+                                  bytes: 937
+                                  line: 33
+                                  character: 31
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 937
+                              line: 33
+                              character: 31
+                            end_position:
+                              bytes: 938
+                              line: 33
+                              character: 32
+                            token_type:
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 938
+                                line: 33
+                                character: 32
+                              end_position:
+                                bytes: 939
+                                line: 33
+                                character: 33
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 939
+                                line: 33
+                                character: 33
+                              end_position:
+                                bytes: 945
+                                line: 33
+                                character: 39
+                              token_type:
+                                type: Identifier
+                                identifier: string
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 945
+                                  line: 33
+                                  character: 39
+                                end_position:
+                                  bytes: 946
+                                  line: 33
+                                  character: 40
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 946
+                              line: 33
+                              character: 40
+                            end_position:
+                              bytes: 947
+                              line: 33
+                              character: 41
+                            token_type:
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 947
+                                line: 33
+                                character: 41
+                              end_position:
+                                bytes: 948
+                                line: 33
+                                character: 42
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 948
+                              line: 33
+                              character: 42
+                            end_position:
+                              bytes: 951
+                              line: 33
+                              character: 45
+                            token_type:
+                              type: Symbol
+                              symbol: nil
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 951
+                                line: 33
+                                character: 45
+                              end_position:
+                                bytes: 952
+                                line: 33
+                                character: 45
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
         name_list:
           pairs:
             - End:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 914
-                    line: 34
+                    bytes: 913
+                    line: 33
                     character: 7
                   end_position:
-                    bytes: 927
-                    line: 34
+                    bytes: 926
+                    line: 33
+                    character: 20
+                  token_type:
+                    type: Identifier
+                    identifier: _leadingUnion
+                trailing_trivia: []
+        equal_token: ~
+        expr_list:
+          pairs: []
+    - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia:
+            - start_position:
+                bytes: 952
+                line: 34
+                character: 1
+              end_position:
+                bytes: 953
+                line: 34
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 953
+              line: 35
+              character: 1
+            end_position:
+              bytes: 958
+              line: 35
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 958
+                line: 35
+                character: 6
+              end_position:
+                bytes: 959
+                line: 35
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        type_specifiers:
+          - punctuation:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 972
+                  line: 35
+                  character: 20
+                end_position:
+                  bytes: 973
+                  line: 35
+                  character: 21
+                token_type:
+                  type: Symbol
+                  symbol: ":"
+              trailing_trivia:
+                - start_position:
+                    bytes: 973
+                    line: 35
+                    character: 21
+                  end_position:
+                    bytes: 974
+                    line: 35
+                    character: 22
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            type_info:
+              Intersection:
+                leading: ~
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 974
+                                line: 35
+                                character: 22
+                              end_position:
+                                bytes: 980
+                                line: 35
+                                character: 28
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 980
+                                  line: 35
+                                  character: 28
+                                end_position:
+                                  bytes: 981
+                                  line: 35
+                                  character: 29
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 981
+                              line: 35
+                              character: 29
+                            end_position:
+                              bytes: 982
+                              line: 35
+                              character: 30
+                            token_type:
+                              type: Symbol
+                              symbol: "&"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 982
+                                line: 35
+                                character: 30
+                              end_position:
+                                bytes: 983
+                                line: 35
+                                character: 31
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 983
+                              line: 35
+                              character: 31
+                            end_position:
+                              bytes: 989
+                              line: 35
+                              character: 37
+                            token_type:
+                              type: Identifier
+                              identifier: string
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 989
+                                line: 35
+                                character: 37
+                              end_position:
+                                bytes: 990
+                                line: 35
+                                character: 37
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 959
+                    line: 35
+                    character: 7
+                  end_position:
+                    bytes: 972
+                    line: 35
                     character: 20
                   token_type:
                     type: Identifier
@@ -5953,24 +6203,24 @@ stmts:
           leading_trivia: []
           token:
             start_position:
-              bytes: 945
-              line: 35
+              bytes: 990
+              line: 36
               character: 1
             end_position:
-              bytes: 950
-              line: 35
+              bytes: 995
+              line: 36
               character: 6
             token_type:
               type: Symbol
               symbol: local
           trailing_trivia:
             - start_position:
-                bytes: 950
-                line: 35
+                bytes: 995
+                line: 36
                 character: 6
               end_position:
-                bytes: 951
-                line: 35
+                bytes: 996
+                line: 36
                 character: 7
               token_type:
                 type: Whitespace
@@ -5980,177 +6230,176 @@ stmts:
               leading_trivia: []
               token:
                 start_position:
-                  bytes: 969
-                  line: 35
+                  bytes: 1014
+                  line: 36
                   character: 25
                 end_position:
-                  bytes: 970
-                  line: 35
+                  bytes: 1015
+                  line: 36
                   character: 26
                 token_type:
                   type: Symbol
                   symbol: ":"
               trailing_trivia:
                 - start_position:
-                    bytes: 970
-                    line: 35
+                    bytes: 1015
+                    line: 36
                     character: 26
                   end_position:
-                    bytes: 971
-                    line: 35
+                    bytes: 1016
+                    line: 36
                     character: 27
                   token_type:
                     type: Whitespace
                     characters: " "
             type_info:
               Intersection:
-                left:
-                  Intersection:
-                    left:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 971
-                            line: 35
-                            character: 27
-                          end_position:
-                            bytes: 977
-                            line: 35
-                            character: 33
-                          token_type:
-                            type: Identifier
-                            identifier: number
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 977
-                              line: 35
-                              character: 33
-                            end_position:
-                              bytes: 978
-                              line: 35
+                leading: ~
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 1016
+                                line: 36
+                                character: 27
+                              end_position:
+                                bytes: 1022
+                                line: 36
+                                character: 33
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 1022
+                                  line: 36
+                                  character: 33
+                                end_position:
+                                  bytes: 1023
+                                  line: 36
+                                  character: 34
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 1023
+                              line: 36
                               character: 34
-                            token_type:
-                              type: Whitespace
-                              characters: " "
-                    ampersand:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 978
-                          line: 35
-                          character: 34
-                        end_position:
-                          bytes: 979
-                          line: 35
-                          character: 35
-                        token_type:
-                          type: Symbol
-                          symbol: "&"
-                      trailing_trivia:
-                        - start_position:
-                            bytes: 979
-                            line: 35
-                            character: 35
-                          end_position:
-                            bytes: 980
-                            line: 35
-                            character: 36
-                          token_type:
-                            type: Whitespace
-                            characters: " "
-                    right:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 980
-                            line: 35
-                            character: 36
-                          end_position:
-                            bytes: 986
-                            line: 35
-                            character: 42
-                          token_type:
-                            type: Identifier
-                            identifier: string
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 986
-                              line: 35
-                              character: 42
                             end_position:
-                              bytes: 987
-                              line: 35
-                              character: 43
+                              bytes: 1024
+                              line: 36
+                              character: 35
                             token_type:
-                              type: Whitespace
-                              characters: " "
-                ampersand:
-                  leading_trivia: []
-                  token:
-                    start_position:
-                      bytes: 987
-                      line: 35
-                      character: 43
-                    end_position:
-                      bytes: 988
-                      line: 35
-                      character: 44
-                    token_type:
-                      type: Symbol
-                      symbol: "&"
-                  trailing_trivia:
-                    - start_position:
-                        bytes: 988
-                        line: 35
-                        character: 44
-                      end_position:
-                        bytes: 989
-                        line: 35
-                        character: 45
-                      token_type:
-                        type: Whitespace
-                        characters: " "
-                right:
-                  Basic:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 989
-                        line: 35
-                        character: 45
-                      end_position:
-                        bytes: 992
-                        line: 35
-                        character: 48
-                      token_type:
-                        type: Symbol
-                        symbol: nil
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 992
-                          line: 35
-                          character: 48
-                        end_position:
-                          bytes: 993
-                          line: 35
-                          character: 48
-                        token_type:
-                          type: Whitespace
-                          characters: "\n"
+                              type: Symbol
+                              symbol: "&"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 1024
+                                line: 36
+                                character: 35
+                              end_position:
+                                bytes: 1025
+                                line: 36
+                                character: 36
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 1025
+                                line: 36
+                                character: 36
+                              end_position:
+                                bytes: 1031
+                                line: 36
+                                character: 42
+                              token_type:
+                                type: Identifier
+                                identifier: string
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 1031
+                                  line: 36
+                                  character: 42
+                                end_position:
+                                  bytes: 1032
+                                  line: 36
+                                  character: 43
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 1032
+                              line: 36
+                              character: 43
+                            end_position:
+                              bytes: 1033
+                              line: 36
+                              character: 44
+                            token_type:
+                              type: Symbol
+                              symbol: "&"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 1033
+                                line: 36
+                                character: 44
+                              end_position:
+                                bytes: 1034
+                                line: 36
+                                character: 45
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 1034
+                              line: 36
+                              character: 45
+                            end_position:
+                              bytes: 1037
+                              line: 36
+                              character: 48
+                            token_type:
+                              type: Symbol
+                              symbol: nil
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 1037
+                                line: 36
+                                character: 48
+                              end_position:
+                                bytes: 1038
+                                line: 36
+                                character: 48
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
         name_list:
           pairs:
             - End:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 951
-                    line: 35
+                    bytes: 996
+                    line: 36
                     character: 7
                   end_position:
-                    bytes: 969
-                    line: 35
+                    bytes: 1014
+                    line: 36
                     character: 25
                   token_type:
                     type: Identifier
@@ -6160,40 +6409,276 @@ stmts:
         expr_list:
           pairs: []
     - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 1038
+              line: 37
+              character: 1
+            end_position:
+              bytes: 1043
+              line: 37
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 1043
+                line: 37
+                character: 6
+              end_position:
+                bytes: 1044
+                line: 37
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        type_specifiers:
+          - punctuation:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 1064
+                  line: 37
+                  character: 27
+                end_position:
+                  bytes: 1065
+                  line: 37
+                  character: 28
+                token_type:
+                  type: Symbol
+                  symbol: ":"
+              trailing_trivia:
+                - start_position:
+                    bytes: 1065
+                    line: 37
+                    character: 28
+                  end_position:
+                    bytes: 1066
+                    line: 37
+                    character: 29
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            type_info:
+              Intersection:
+                leading:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 1066
+                      line: 37
+                      character: 29
+                    end_position:
+                      bytes: 1067
+                      line: 37
+                      character: 30
+                    token_type:
+                      type: Symbol
+                      symbol: "&"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 1067
+                        line: 37
+                        character: 30
+                      end_position:
+                        bytes: 1068
+                        line: 37
+                        character: 31
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 1068
+                                line: 37
+                                character: 31
+                              end_position:
+                                bytes: 1074
+                                line: 37
+                                character: 37
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 1074
+                                  line: 37
+                                  character: 37
+                                end_position:
+                                  bytes: 1075
+                                  line: 37
+                                  character: 38
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 1075
+                              line: 37
+                              character: 38
+                            end_position:
+                              bytes: 1076
+                              line: 37
+                              character: 39
+                            token_type:
+                              type: Symbol
+                              symbol: "&"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 1076
+                                line: 37
+                                character: 39
+                              end_position:
+                                bytes: 1077
+                                line: 37
+                                character: 40
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 1077
+                                line: 37
+                                character: 40
+                              end_position:
+                                bytes: 1083
+                                line: 37
+                                character: 46
+                              token_type:
+                                type: Identifier
+                                identifier: string
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 1083
+                                  line: 37
+                                  character: 46
+                                end_position:
+                                  bytes: 1084
+                                  line: 37
+                                  character: 47
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 1084
+                              line: 37
+                              character: 47
+                            end_position:
+                              bytes: 1085
+                              line: 37
+                              character: 48
+                            token_type:
+                              type: Symbol
+                              symbol: "&"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 1085
+                                line: 37
+                                character: 48
+                              end_position:
+                                bytes: 1086
+                                line: 37
+                                character: 49
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 1086
+                              line: 37
+                              character: 49
+                            end_position:
+                              bytes: 1089
+                              line: 37
+                              character: 52
+                            token_type:
+                              type: Symbol
+                              symbol: nil
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 1089
+                                line: 37
+                                character: 52
+                              end_position:
+                                bytes: 1090
+                                line: 37
+                                character: 52
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 1044
+                    line: 37
+                    character: 7
+                  end_position:
+                    bytes: 1064
+                    line: 37
+                    character: 27
+                  token_type:
+                    type: Identifier
+                    identifier: _leadingIntersection
+                trailing_trivia: []
+        equal_token: ~
+        expr_list:
+          pairs: []
+    - ~
   - - FunctionDeclaration:
         function_token:
           leading_trivia:
             - start_position:
-                bytes: 993
-                line: 36
+                bytes: 1090
+                line: 38
                 character: 1
               end_position:
-                bytes: 994
-                line: 36
+                bytes: 1091
+                line: 38
                 character: 1
               token_type:
                 type: Whitespace
                 characters: "\n"
           token:
             start_position:
-              bytes: 994
-              line: 37
+              bytes: 1091
+              line: 39
               character: 1
             end_position:
-              bytes: 1002
-              line: 37
+              bytes: 1099
+              line: 39
               character: 9
             token_type:
               type: Symbol
               symbol: function
           trailing_trivia:
             - start_position:
-                bytes: 1002
-                line: 37
+                bytes: 1099
+                line: 39
                 character: 9
               end_position:
-                bytes: 1003
-                line: 37
+                bytes: 1100
+                line: 39
                 character: 10
               token_type:
                 type: Whitespace
@@ -6205,12 +6690,12 @@ stmts:
                   leading_trivia: []
                   token:
                     start_position:
-                      bytes: 1003
-                      line: 37
+                      bytes: 1100
+                      line: 39
                       character: 10
                     end_position:
-                      bytes: 1007
-                      line: 37
+                      bytes: 1104
+                      line: 39
                       character: 14
                     token_type:
                       type: Identifier
@@ -6224,12 +6709,12 @@ stmts:
               - leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1007
-                    line: 37
+                    bytes: 1104
+                    line: 39
                     character: 14
                   end_position:
-                    bytes: 1008
-                    line: 37
+                    bytes: 1105
+                    line: 39
                     character: 15
                   token_type:
                     type: Symbol
@@ -6238,12 +6723,12 @@ stmts:
               - leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1021
-                    line: 37
+                    bytes: 1118
+                    line: 39
                     character: 28
                   end_position:
-                    bytes: 1022
-                    line: 37
+                    bytes: 1119
+                    line: 39
                     character: 29
                   token_type:
                     type: Symbol
@@ -6256,12 +6741,12 @@ stmts:
                     leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1008
-                        line: 37
+                        bytes: 1105
+                        line: 39
                         character: 15
                       end_position:
-                        bytes: 1013
-                        line: 37
+                        bytes: 1110
+                        line: 39
                         character: 20
                       token_type:
                         type: Identifier
@@ -6272,24 +6757,24 @@ stmts:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1013
-                    line: 37
+                    bytes: 1110
+                    line: 39
                     character: 20
                   end_position:
-                    bytes: 1014
-                    line: 37
+                    bytes: 1111
+                    line: 39
                     character: 21
                   token_type:
                     type: Symbol
                     symbol: ":"
                 trailing_trivia:
                   - start_position:
-                      bytes: 1014
-                      line: 37
+                      bytes: 1111
+                      line: 39
                       character: 21
                     end_position:
-                      bytes: 1015
-                      line: 37
+                      bytes: 1112
+                      line: 39
                       character: 22
                     token_type:
                       type: Whitespace
@@ -6299,12 +6784,12 @@ stmts:
                   leading_trivia: []
                   token:
                     start_position:
-                      bytes: 1015
-                      line: 37
+                      bytes: 1112
+                      line: 39
                       character: 22
                     end_position:
-                      bytes: 1021
-                      line: 37
+                      bytes: 1118
+                      line: 39
                       character: 28
                     token_type:
                       type: Identifier
@@ -6315,24 +6800,24 @@ stmts:
               leading_trivia: []
               token:
                 start_position:
-                  bytes: 1022
-                  line: 37
+                  bytes: 1119
+                  line: 39
                   character: 29
                 end_position:
-                  bytes: 1023
-                  line: 37
+                  bytes: 1120
+                  line: 39
                   character: 30
                 token_type:
                   type: Symbol
                   symbol: ":"
               trailing_trivia:
                 - start_position:
-                    bytes: 1023
-                    line: 37
+                    bytes: 1120
+                    line: 39
                     character: 30
                   end_position:
-                    bytes: 1024
-                    line: 37
+                    bytes: 1121
+                    line: 39
                     character: 31
                   token_type:
                     type: Whitespace
@@ -6342,24 +6827,24 @@ stmts:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1024
-                    line: 37
+                    bytes: 1121
+                    line: 39
                     character: 31
                   end_position:
-                    bytes: 1030
-                    line: 37
+                    bytes: 1127
+                    line: 39
                     character: 37
                   token_type:
                     type: Identifier
                     identifier: string
                 trailing_trivia:
                   - start_position:
-                      bytes: 1030
-                      line: 37
+                      bytes: 1127
+                      line: 39
                       character: 37
                     end_position:
-                      bytes: 1031
-                      line: 37
+                      bytes: 1128
+                      line: 39
                       character: 37
                     token_type:
                       type: Whitespace
@@ -6371,36 +6856,36 @@ stmts:
                   token:
                     leading_trivia:
                       - start_position:
-                          bytes: 1031
-                          line: 38
+                          bytes: 1128
+                          line: 40
                           character: 1
                         end_position:
-                          bytes: 1032
-                          line: 38
+                          bytes: 1129
+                          line: 40
                           character: 2
                         token_type:
                           type: Whitespace
                           characters: "\t"
                     token:
                       start_position:
-                        bytes: 1032
-                        line: 38
+                        bytes: 1129
+                        line: 40
                         character: 2
                       end_position:
-                        bytes: 1038
-                        line: 38
+                        bytes: 1135
+                        line: 40
                         character: 8
                       token_type:
                         type: Symbol
                         symbol: return
                     trailing_trivia:
                       - start_position:
-                          bytes: 1038
-                          line: 38
+                          bytes: 1135
+                          line: 40
                           character: 8
                         end_position:
-                          bytes: 1039
-                          line: 38
+                          bytes: 1136
+                          line: 40
                           character: 9
                         token_type:
                           type: Whitespace
@@ -6413,24 +6898,24 @@ stmts:
                               leading_trivia: []
                               token:
                                 start_position:
-                                  bytes: 1039
-                                  line: 38
+                                  bytes: 1136
+                                  line: 40
                                   character: 9
                                 end_position:
-                                  bytes: 1044
-                                  line: 38
+                                  bytes: 1141
+                                  line: 40
                                   character: 14
                                 token_type:
                                   type: Identifier
                                   identifier: param
                               trailing_trivia:
                                 - start_position:
-                                    bytes: 1044
-                                    line: 38
+                                    bytes: 1141
+                                    line: 40
                                     character: 14
                                   end_position:
-                                    bytes: 1045
-                                    line: 38
+                                    bytes: 1142
+                                    line: 40
                                     character: 14
                                   token_type:
                                     type: Whitespace
@@ -6440,24 +6925,24 @@ stmts:
             leading_trivia: []
             token:
               start_position:
-                bytes: 1045
-                line: 39
+                bytes: 1142
+                line: 41
                 character: 1
               end_position:
-                bytes: 1048
-                line: 39
+                bytes: 1145
+                line: 41
                 character: 4
               token_type:
                 type: Symbol
                 symbol: end
             trailing_trivia:
               - start_position:
-                  bytes: 1048
-                  line: 39
+                  bytes: 1145
+                  line: 41
                   character: 4
                 end_position:
-                  bytes: 1049
-                  line: 39
+                  bytes: 1146
+                  line: 41
                   character: 4
                 token_type:
                   type: Whitespace
@@ -6467,36 +6952,36 @@ stmts:
         function_token:
           leading_trivia:
             - start_position:
-                bytes: 1049
-                line: 40
+                bytes: 1146
+                line: 42
                 character: 1
               end_position:
-                bytes: 1050
-                line: 40
+                bytes: 1147
+                line: 42
                 character: 1
               token_type:
                 type: Whitespace
                 characters: "\n"
           token:
             start_position:
-              bytes: 1050
-              line: 41
+              bytes: 1147
+              line: 43
               character: 1
             end_position:
-              bytes: 1058
-              line: 41
+              bytes: 1155
+              line: 43
               character: 9
             token_type:
               type: Symbol
               symbol: function
           trailing_trivia:
             - start_position:
-                bytes: 1058
-                line: 41
+                bytes: 1155
+                line: 43
                 character: 9
               end_position:
-                bytes: 1059
-                line: 41
+                bytes: 1156
+                line: 43
                 character: 10
               token_type:
                 type: Whitespace
@@ -6508,12 +6993,12 @@ stmts:
                   leading_trivia: []
                   token:
                     start_position:
-                      bytes: 1059
-                      line: 41
+                      bytes: 1156
+                      line: 43
                       character: 10
                     end_position:
-                      bytes: 1063
-                      line: 41
+                      bytes: 1160
+                      line: 43
                       character: 14
                     token_type:
                       type: Identifier
@@ -6527,12 +7012,12 @@ stmts:
               - leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1063
-                    line: 41
+                    bytes: 1160
+                    line: 43
                     character: 14
                   end_position:
-                    bytes: 1064
-                    line: 41
+                    bytes: 1161
+                    line: 43
                     character: 15
                   token_type:
                     type: Symbol
@@ -6541,24 +7026,24 @@ stmts:
               - leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1089
-                    line: 41
+                    bytes: 1186
+                    line: 43
                     character: 40
                   end_position:
-                    bytes: 1090
-                    line: 41
+                    bytes: 1187
+                    line: 43
                     character: 41
                   token_type:
                     type: Symbol
                     symbol: )
                 trailing_trivia:
                   - start_position:
-                      bytes: 1090
-                      line: 41
+                      bytes: 1187
+                      line: 43
                       character: 41
                     end_position:
-                      bytes: 1091
-                      line: 41
+                      bytes: 1188
+                      line: 43
                       character: 42
                     token_type:
                       type: Whitespace
@@ -6570,12 +7055,12 @@ stmts:
                       leading_trivia: []
                       token:
                         start_position:
-                          bytes: 1064
-                          line: 41
+                          bytes: 1161
+                          line: 43
                           character: 15
                         end_position:
-                          bytes: 1065
-                          line: 41
+                          bytes: 1162
+                          line: 43
                           character: 16
                         token_type:
                           type: Identifier
@@ -6584,24 +7069,24 @@ stmts:
                   - leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1073
-                        line: 41
+                        bytes: 1170
+                        line: 43
                         character: 24
                       end_position:
-                        bytes: 1074
-                        line: 41
+                        bytes: 1171
+                        line: 43
                         character: 25
                       token_type:
                         type: Symbol
                         symbol: ","
                     trailing_trivia:
                       - start_position:
-                          bytes: 1074
-                          line: 41
+                          bytes: 1171
+                          line: 43
                           character: 25
                         end_position:
-                          bytes: 1075
-                          line: 41
+                          bytes: 1172
+                          line: 43
                           character: 26
                         token_type:
                           type: Whitespace
@@ -6611,12 +7096,12 @@ stmts:
                       leading_trivia: []
                       token:
                         start_position:
-                          bytes: 1075
-                          line: 41
+                          bytes: 1172
+                          line: 43
                           character: 26
                         end_position:
-                          bytes: 1076
-                          line: 41
+                          bytes: 1173
+                          line: 43
                           character: 27
                         token_type:
                           type: Identifier
@@ -6625,24 +7110,24 @@ stmts:
                   - leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1084
-                        line: 41
+                        bytes: 1181
+                        line: 43
                         character: 35
                       end_position:
-                        bytes: 1085
-                        line: 41
+                        bytes: 1182
+                        line: 43
                         character: 36
                       token_type:
                         type: Symbol
                         symbol: ","
                     trailing_trivia:
                       - start_position:
-                          bytes: 1085
-                          line: 41
+                          bytes: 1182
+                          line: 43
                           character: 36
                         end_position:
-                          bytes: 1086
-                          line: 41
+                          bytes: 1183
+                          line: 43
                           character: 37
                         token_type:
                           type: Whitespace
@@ -6652,12 +7137,12 @@ stmts:
                     leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1086
-                        line: 41
+                        bytes: 1183
+                        line: 43
                         character: 37
                       end_position:
-                        bytes: 1089
-                        line: 41
+                        bytes: 1186
+                        line: 43
                         character: 40
                       token_type:
                         type: Symbol
@@ -6668,24 +7153,24 @@ stmts:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1065
-                    line: 41
+                    bytes: 1162
+                    line: 43
                     character: 16
                   end_position:
-                    bytes: 1066
-                    line: 41
+                    bytes: 1163
+                    line: 43
                     character: 17
                   token_type:
                     type: Symbol
                     symbol: ":"
                 trailing_trivia:
                   - start_position:
-                      bytes: 1066
-                      line: 41
+                      bytes: 1163
+                      line: 43
                       character: 17
                     end_position:
-                      bytes: 1067
-                      line: 41
+                      bytes: 1164
+                      line: 43
                       character: 18
                     token_type:
                       type: Whitespace
@@ -6695,12 +7180,12 @@ stmts:
                   leading_trivia: []
                   token:
                     start_position:
-                      bytes: 1067
-                      line: 41
+                      bytes: 1164
+                      line: 43
                       character: 18
                     end_position:
-                      bytes: 1073
-                      line: 41
+                      bytes: 1170
+                      line: 43
                       character: 24
                     token_type:
                       type: Identifier
@@ -6710,24 +7195,24 @@ stmts:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1076
-                    line: 41
+                    bytes: 1173
+                    line: 43
                     character: 27
                   end_position:
-                    bytes: 1077
-                    line: 41
+                    bytes: 1174
+                    line: 43
                     character: 28
                   token_type:
                     type: Symbol
                     symbol: ":"
                 trailing_trivia:
                   - start_position:
-                      bytes: 1077
-                      line: 41
+                      bytes: 1174
+                      line: 43
                       character: 28
                     end_position:
-                      bytes: 1078
-                      line: 41
+                      bytes: 1175
+                      line: 43
                       character: 29
                     token_type:
                       type: Whitespace
@@ -6737,12 +7222,12 @@ stmts:
                   leading_trivia: []
                   token:
                     start_position:
-                      bytes: 1078
-                      line: 41
+                      bytes: 1175
+                      line: 43
                       character: 29
                     end_position:
-                      bytes: 1084
-                      line: 41
+                      bytes: 1181
+                      line: 43
                       character: 35
                     token_type:
                       type: Identifier
@@ -6755,24 +7240,24 @@ stmts:
             leading_trivia: []
             token:
               start_position:
-                bytes: 1091
-                line: 41
+                bytes: 1188
+                line: 43
                 character: 42
               end_position:
-                bytes: 1094
-                line: 41
+                bytes: 1191
+                line: 43
                 character: 45
               token_type:
                 type: Symbol
                 symbol: end
             trailing_trivia:
               - start_position:
-                  bytes: 1094
-                  line: 41
+                  bytes: 1191
+                  line: 43
                   character: 45
                 end_position:
-                  bytes: 1095
-                  line: 41
+                  bytes: 1192
+                  line: 43
                   character: 45
                 token_type:
                   type: Whitespace
@@ -6782,36 +7267,36 @@ stmts:
         local_token:
           leading_trivia:
             - start_position:
-                bytes: 1095
-                line: 42
+                bytes: 1192
+                line: 44
                 character: 1
               end_position:
-                bytes: 1096
-                line: 42
+                bytes: 1193
+                line: 44
                 character: 1
               token_type:
                 type: Whitespace
                 characters: "\n"
           token:
             start_position:
-              bytes: 1096
-              line: 43
+              bytes: 1193
+              line: 45
               character: 1
             end_position:
-              bytes: 1101
-              line: 43
+              bytes: 1198
+              line: 45
               character: 6
             token_type:
               type: Symbol
               symbol: local
           trailing_trivia:
             - start_position:
-                bytes: 1101
-                line: 43
+                bytes: 1198
+                line: 45
                 character: 6
               end_position:
-                bytes: 1102
-                line: 43
+                bytes: 1199
+                line: 45
                 character: 7
               token_type:
                 type: Whitespace
@@ -6822,24 +7307,24 @@ stmts:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1102
-                    line: 43
+                    bytes: 1199
+                    line: 45
                     character: 7
                   end_position:
-                    bytes: 1106
-                    line: 43
+                    bytes: 1203
+                    line: 45
                     character: 11
                   token_type:
                     type: Identifier
                     identifier: _fn3
                 trailing_trivia:
                   - start_position:
-                      bytes: 1106
-                      line: 43
+                      bytes: 1203
+                      line: 45
                       character: 11
                     end_position:
-                      bytes: 1107
-                      line: 43
+                      bytes: 1204
+                      line: 45
                       character: 12
                     token_type:
                       type: Whitespace
@@ -6848,24 +7333,24 @@ stmts:
           leading_trivia: []
           token:
             start_position:
-              bytes: 1107
-              line: 43
+              bytes: 1204
+              line: 45
               character: 12
             end_position:
-              bytes: 1108
-              line: 43
+              bytes: 1205
+              line: 45
               character: 13
             token_type:
               type: Symbol
               symbol: "="
           trailing_trivia:
             - start_position:
-                bytes: 1108
-                line: 43
+                bytes: 1205
+                line: 45
                 character: 13
               end_position:
-                bytes: 1109
-                line: 43
+                bytes: 1206
+                line: 45
                 character: 14
               token_type:
                 type: Whitespace
@@ -6877,12 +7362,12 @@ stmts:
                   - leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1109
-                        line: 43
+                        bytes: 1206
+                        line: 45
                         character: 14
                       end_position:
-                        bytes: 1117
-                        line: 43
+                        bytes: 1214
+                        line: 45
                         character: 22
                       token_type:
                         type: Symbol
@@ -6894,12 +7379,12 @@ stmts:
                         - leading_trivia: []
                           token:
                             start_position:
-                              bytes: 1117
-                              line: 43
+                              bytes: 1214
+                              line: 45
                               character: 22
                             end_position:
-                              bytes: 1118
-                              line: 43
+                              bytes: 1215
+                              line: 45
                               character: 23
                             token_type:
                               type: Symbol
@@ -6908,12 +7393,12 @@ stmts:
                         - leading_trivia: []
                           token:
                             start_position:
-                              bytes: 1118
-                              line: 43
+                              bytes: 1215
+                              line: 45
                               character: 23
                             end_position:
-                              bytes: 1119
-                              line: 43
+                              bytes: 1216
+                              line: 45
                               character: 24
                             token_type:
                               type: Symbol
@@ -6927,110 +7412,112 @@ stmts:
                         leading_trivia: []
                         token:
                           start_position:
-                            bytes: 1119
-                            line: 43
+                            bytes: 1216
+                            line: 45
                             character: 24
                           end_position:
-                            bytes: 1120
-                            line: 43
+                            bytes: 1217
+                            line: 45
                             character: 25
                           token_type:
                             type: Symbol
                             symbol: ":"
                         trailing_trivia:
                           - start_position:
-                              bytes: 1120
-                              line: 43
+                              bytes: 1217
+                              line: 45
                               character: 25
                             end_position:
-                              bytes: 1121
-                              line: 43
+                              bytes: 1218
+                              line: 45
                               character: 26
                             token_type:
                               type: Whitespace
                               characters: " "
                       type_info:
                         Union:
-                          left:
-                            Basic:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 1121
-                                  line: 43
-                                  character: 26
-                                end_position:
-                                  bytes: 1127
-                                  line: 43
-                                  character: 32
-                                token_type:
-                                  type: Identifier
-                                  identifier: number
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 1127
-                                    line: 43
-                                    character: 32
-                                  end_position:
-                                    bytes: 1128
-                                    line: 43
-                                    character: 33
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                          pipe:
-                            leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 1128
-                                line: 43
-                                character: 33
-                              end_position:
-                                bytes: 1129
-                                line: 43
-                                character: 34
-                              token_type:
-                                type: Symbol
-                                symbol: "|"
-                            trailing_trivia:
-                              - start_position:
-                                  bytes: 1129
-                                  line: 43
-                                  character: 34
-                                end_position:
-                                  bytes: 1130
-                                  line: 43
-                                  character: 35
-                                token_type:
-                                  type: Whitespace
-                                  characters: " "
-                          right:
-                            Basic:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 1130
-                                  line: 43
-                                  character: 35
-                                end_position:
-                                  bytes: 1133
-                                  line: 43
-                                  character: 38
-                                token_type:
-                                  type: Symbol
-                                  symbol: nil
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 1133
-                                    line: 43
-                                    character: 38
-                                  end_position:
-                                    bytes: 1134
-                                    line: 43
-                                    character: 38
-                                  token_type:
-                                    type: Whitespace
-                                    characters: "\n"
+                          leading: ~
+                          types:
+                            pairs:
+                              - Punctuated:
+                                  - Basic:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 1218
+                                          line: 45
+                                          character: 26
+                                        end_position:
+                                          bytes: 1224
+                                          line: 45
+                                          character: 32
+                                        token_type:
+                                          type: Identifier
+                                          identifier: number
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 1224
+                                            line: 45
+                                            character: 32
+                                          end_position:
+                                            bytes: 1225
+                                            line: 45
+                                            character: 33
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 1225
+                                        line: 45
+                                        character: 33
+                                      end_position:
+                                        bytes: 1226
+                                        line: 45
+                                        character: 34
+                                      token_type:
+                                        type: Symbol
+                                        symbol: "|"
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 1226
+                                          line: 45
+                                          character: 34
+                                        end_position:
+                                          bytes: 1227
+                                          line: 45
+                                          character: 35
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                              - End:
+                                  Basic:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 1227
+                                        line: 45
+                                        character: 35
+                                      end_position:
+                                        bytes: 1230
+                                        line: 45
+                                        character: 38
+                                      token_type:
+                                        type: Symbol
+                                        symbol: nil
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 1230
+                                          line: 45
+                                          character: 38
+                                        end_position:
+                                          bytes: 1231
+                                          line: 45
+                                          character: 38
+                                        token_type:
+                                          type: Whitespace
+                                          characters: "\n"
                     block:
                       stmts: []
                       last_stmt:
@@ -7038,36 +7525,36 @@ stmts:
                             token:
                               leading_trivia:
                                 - start_position:
-                                    bytes: 1134
-                                    line: 44
+                                    bytes: 1231
+                                    line: 46
                                     character: 1
                                   end_position:
-                                    bytes: 1135
-                                    line: 44
+                                    bytes: 1232
+                                    line: 46
                                     character: 2
                                   token_type:
                                     type: Whitespace
                                     characters: "\t"
                               token:
                                 start_position:
-                                  bytes: 1135
-                                  line: 44
+                                  bytes: 1232
+                                  line: 46
                                   character: 2
                                 end_position:
-                                  bytes: 1141
-                                  line: 44
+                                  bytes: 1238
+                                  line: 46
                                   character: 8
                                 token_type:
                                   type: Symbol
                                   symbol: return
                               trailing_trivia:
                                 - start_position:
-                                    bytes: 1141
-                                    line: 44
+                                    bytes: 1238
+                                    line: 46
                                     character: 8
                                   end_position:
-                                    bytes: 1142
-                                    line: 44
+                                    bytes: 1239
+                                    line: 46
                                     character: 9
                                   token_type:
                                     type: Whitespace
@@ -7079,24 +7566,24 @@ stmts:
                                       leading_trivia: []
                                       token:
                                         start_position:
-                                          bytes: 1142
-                                          line: 44
+                                          bytes: 1239
+                                          line: 46
                                           character: 9
                                         end_position:
-                                          bytes: 1143
-                                          line: 44
+                                          bytes: 1240
+                                          line: 46
                                           character: 10
                                         token_type:
                                           type: Number
                                           text: "3"
                                       trailing_trivia:
                                         - start_position:
-                                            bytes: 1143
-                                            line: 44
+                                            bytes: 1240
+                                            line: 46
                                             character: 10
                                           end_position:
-                                            bytes: 1144
-                                            line: 44
+                                            bytes: 1241
+                                            line: 46
                                             character: 10
                                           token_type:
                                             type: Whitespace
@@ -7106,24 +7593,24 @@ stmts:
                       leading_trivia: []
                       token:
                         start_position:
-                          bytes: 1144
-                          line: 45
+                          bytes: 1241
+                          line: 47
                           character: 1
                         end_position:
-                          bytes: 1147
-                          line: 45
+                          bytes: 1244
+                          line: 47
                           character: 4
                         token_type:
                           type: Symbol
                           symbol: end
                       trailing_trivia:
                         - start_position:
-                            bytes: 1147
-                            line: 45
+                            bytes: 1244
+                            line: 47
                             character: 4
                           end_position:
-                            bytes: 1148
-                            line: 45
+                            bytes: 1245
+                            line: 47
                             character: 4
                           token_type:
                             type: Whitespace
@@ -7133,36 +7620,36 @@ stmts:
         local_token:
           leading_trivia:
             - start_position:
-                bytes: 1148
-                line: 46
+                bytes: 1245
+                line: 48
                 character: 1
               end_position:
-                bytes: 1149
-                line: 46
+                bytes: 1246
+                line: 48
                 character: 1
               token_type:
                 type: Whitespace
                 characters: "\n"
           token:
             start_position:
-              bytes: 1149
-              line: 47
+              bytes: 1246
+              line: 49
               character: 1
             end_position:
-              bytes: 1154
-              line: 47
+              bytes: 1251
+              line: 49
               character: 6
             token_type:
               type: Symbol
               symbol: local
           trailing_trivia:
             - start_position:
-                bytes: 1154
-                line: 47
+                bytes: 1251
+                line: 49
                 character: 6
               end_position:
-                bytes: 1155
-                line: 47
+                bytes: 1252
+                line: 49
                 character: 7
               token_type:
                 type: Whitespace
@@ -7171,24 +7658,24 @@ stmts:
           leading_trivia: []
           token:
             start_position:
-              bytes: 1155
-              line: 47
+              bytes: 1252
+              line: 49
               character: 7
             end_position:
-              bytes: 1163
-              line: 47
+              bytes: 1260
+              line: 49
               character: 15
             token_type:
               type: Symbol
               symbol: function
           trailing_trivia:
             - start_position:
-                bytes: 1163
-                line: 47
+                bytes: 1260
+                line: 49
                 character: 15
               end_position:
-                bytes: 1164
-                line: 47
+                bytes: 1261
+                line: 49
                 character: 16
               token_type:
                 type: Whitespace
@@ -7197,12 +7684,12 @@ stmts:
           leading_trivia: []
           token:
             start_position:
-              bytes: 1164
-              line: 47
+              bytes: 1261
+              line: 49
               character: 16
             end_position:
-              bytes: 1171
-              line: 47
+              bytes: 1268
+              line: 49
               character: 23
             token_type:
               type: Identifier
@@ -7215,12 +7702,12 @@ stmts:
                 - leading_trivia: []
                   token:
                     start_position:
-                      bytes: 1171
-                      line: 47
+                      bytes: 1268
+                      line: 49
                       character: 23
                     end_position:
-                      bytes: 1172
-                      line: 47
+                      bytes: 1269
+                      line: 49
                       character: 24
                     token_type:
                       type: Symbol
@@ -7229,12 +7716,12 @@ stmts:
                 - leading_trivia: []
                   token:
                     start_position:
-                      bytes: 1176
-                      line: 47
+                      bytes: 1273
+                      line: 49
                       character: 28
                     end_position:
-                      bytes: 1177
-                      line: 47
+                      bytes: 1274
+                      line: 49
                       character: 29
                     token_type:
                       type: Symbol
@@ -7248,12 +7735,12 @@ stmts:
                           leading_trivia: []
                           token:
                             start_position:
-                              bytes: 1172
-                              line: 47
+                              bytes: 1269
+                              line: 49
                               character: 24
                             end_position:
-                              bytes: 1173
-                              line: 47
+                              bytes: 1270
+                              line: 49
                               character: 25
                             token_type:
                               type: Identifier
@@ -7263,24 +7750,24 @@ stmts:
                     - leading_trivia: []
                       token:
                         start_position:
-                          bytes: 1173
-                          line: 47
+                          bytes: 1270
+                          line: 49
                           character: 25
                         end_position:
-                          bytes: 1174
-                          line: 47
+                          bytes: 1271
+                          line: 49
                           character: 26
                         token_type:
                           type: Symbol
                           symbol: ","
                       trailing_trivia:
                         - start_position:
-                            bytes: 1174
-                            line: 47
+                            bytes: 1271
+                            line: 49
                             character: 26
                           end_position:
-                            bytes: 1175
-                            line: 47
+                            bytes: 1272
+                            line: 49
                             character: 27
                           token_type:
                             type: Whitespace
@@ -7291,12 +7778,12 @@ stmts:
                         leading_trivia: []
                         token:
                           start_position:
-                            bytes: 1175
-                            line: 47
+                            bytes: 1272
+                            line: 49
                             character: 27
                           end_position:
-                            bytes: 1176
-                            line: 47
+                            bytes: 1273
+                            line: 49
                             character: 28
                           token_type:
                             type: Identifier
@@ -7308,12 +7795,12 @@ stmts:
               - leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1177
-                    line: 47
+                    bytes: 1274
+                    line: 49
                     character: 29
                   end_position:
-                    bytes: 1178
-                    line: 47
+                    bytes: 1275
+                    line: 49
                     character: 30
                   token_type:
                     type: Symbol
@@ -7322,12 +7809,12 @@ stmts:
               - leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1213
-                    line: 47
+                    bytes: 1310
+                    line: 49
                     character: 65
                   end_position:
-                    bytes: 1214
-                    line: 47
+                    bytes: 1311
+                    line: 49
                     character: 66
                   token_type:
                     type: Symbol
@@ -7340,12 +7827,12 @@ stmts:
                       leading_trivia: []
                       token:
                         start_position:
-                          bytes: 1178
-                          line: 47
+                          bytes: 1275
+                          line: 49
                           character: 30
                         end_position:
-                          bytes: 1184
-                          line: 47
+                          bytes: 1281
+                          line: 49
                           character: 36
                         token_type:
                           type: Identifier
@@ -7354,24 +7841,24 @@ stmts:
                   - leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1194
-                        line: 47
+                        bytes: 1291
+                        line: 49
                         character: 46
                       end_position:
-                        bytes: 1195
-                        line: 47
+                        bytes: 1292
+                        line: 49
                         character: 47
                       token_type:
                         type: Symbol
                         symbol: ","
                     trailing_trivia:
                       - start_position:
-                          bytes: 1195
-                          line: 47
+                          bytes: 1292
+                          line: 49
                           character: 47
                         end_position:
-                          bytes: 1196
-                          line: 47
+                          bytes: 1293
+                          line: 49
                           character: 48
                         token_type:
                           type: Whitespace
@@ -7381,12 +7868,12 @@ stmts:
                     leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1196
-                        line: 47
+                        bytes: 1293
+                        line: 49
                         character: 48
                       end_position:
-                        bytes: 1199
-                        line: 47
+                        bytes: 1296
+                        line: 49
                         character: 51
                       token_type:
                         type: Symbol
@@ -7397,24 +7884,24 @@ stmts:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1184
-                    line: 47
+                    bytes: 1281
+                    line: 49
                     character: 36
                   end_position:
-                    bytes: 1185
-                    line: 47
+                    bytes: 1282
+                    line: 49
                     character: 37
                   token_type:
                     type: Symbol
                     symbol: ":"
                 trailing_trivia:
                   - start_position:
-                      bytes: 1185
-                      line: 47
+                      bytes: 1282
+                      line: 49
                       character: 37
                     end_position:
-                      bytes: 1186
-                      line: 47
+                      bytes: 1283
+                      line: 49
                       character: 38
                     token_type:
                       type: Whitespace
@@ -7425,12 +7912,12 @@ stmts:
                     leading_trivia: []
                     token:
                       start_position:
-                        bytes: 1186
-                        line: 47
+                        bytes: 1283
+                        line: 49
                         character: 38
                       end_position:
-                        bytes: 1191
-                        line: 47
+                        bytes: 1288
+                        line: 49
                         character: 43
                       token_type:
                         type: Identifier
@@ -7441,12 +7928,12 @@ stmts:
                       - leading_trivia: []
                         token:
                           start_position:
-                            bytes: 1191
-                            line: 47
+                            bytes: 1288
+                            line: 49
                             character: 43
                           end_position:
-                            bytes: 1192
-                            line: 47
+                            bytes: 1289
+                            line: 49
                             character: 44
                           token_type:
                             type: Symbol
@@ -7455,12 +7942,12 @@ stmts:
                       - leading_trivia: []
                         token:
                           start_position:
-                            bytes: 1193
-                            line: 47
+                            bytes: 1290
+                            line: 49
                             character: 45
                           end_position:
-                            bytes: 1194
-                            line: 47
+                            bytes: 1291
+                            line: 49
                             character: 46
                           token_type:
                             type: Symbol
@@ -7473,12 +7960,12 @@ stmts:
                             leading_trivia: []
                             token:
                               start_position:
-                                bytes: 1192
-                                line: 47
+                                bytes: 1289
+                                line: 49
                                 character: 44
                               end_position:
-                                bytes: 1193
-                                line: 47
+                                bytes: 1290
+                                line: 49
                                 character: 45
                               token_type:
                                 type: Identifier
@@ -7488,355 +7975,359 @@ stmts:
                 leading_trivia: []
                 token:
                   start_position:
-                    bytes: 1199
-                    line: 47
+                    bytes: 1296
+                    line: 49
                     character: 51
                   end_position:
-                    bytes: 1200
-                    line: 47
+                    bytes: 1297
+                    line: 49
                     character: 52
                   token_type:
                     type: Symbol
                     symbol: ":"
                 trailing_trivia:
                   - start_position:
-                      bytes: 1200
-                      line: 47
+                      bytes: 1297
+                      line: 49
                       character: 52
                     end_position:
-                      bytes: 1201
-                      line: 47
+                      bytes: 1298
+                      line: 49
                       character: 53
                     token_type:
                       type: Whitespace
                       characters: " "
               type_info:
                 Union:
-                  left:
-                    Generic:
-                      base:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 1201
-                            line: 47
-                            character: 53
-                          end_position:
-                            bytes: 1206
-                            line: 47
-                            character: 58
-                          token_type:
-                            type: Identifier
-                            identifier: Array
-                        trailing_trivia: []
-                      arrows:
-                        tokens:
-                          - leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 1206
-                                line: 47
-                                character: 58
-                              end_position:
-                                bytes: 1207
-                                line: 47
-                                character: 59
-                              token_type:
-                                type: Symbol
-                                symbol: "<"
-                            trailing_trivia: []
-                          - leading_trivia: []
-                            token:
-                              start_position:
-                                bytes: 1208
-                                line: 47
-                                character: 60
-                              end_position:
-                                bytes: 1209
-                                line: 47
-                                character: 61
-                              token_type:
-                                type: Symbol
-                                symbol: ">"
-                            trailing_trivia:
-                              - start_position:
-                                  bytes: 1209
-                                  line: 47
-                                  character: 61
-                                end_position:
-                                  bytes: 1210
-                                  line: 47
-                                  character: 62
-                                token_type:
-                                  type: Whitespace
-                                  characters: " "
-                      generics:
-                        pairs:
-                          - End:
-                              Basic:
+                  leading: ~
+                  types:
+                    pairs:
+                      - Punctuated:
+                          - Generic:
+                              base:
                                 leading_trivia: []
                                 token:
                                   start_position:
-                                    bytes: 1207
-                                    line: 47
-                                    character: 59
+                                    bytes: 1298
+                                    line: 49
+                                    character: 53
                                   end_position:
-                                    bytes: 1208
-                                    line: 47
-                                    character: 60
+                                    bytes: 1303
+                                    line: 49
+                                    character: 58
                                   token_type:
                                     type: Identifier
-                                    identifier: S
+                                    identifier: Array
                                 trailing_trivia: []
-                  pipe:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 1210
-                        line: 47
-                        character: 62
-                      end_position:
-                        bytes: 1211
-                        line: 47
-                        character: 63
-                      token_type:
-                        type: Symbol
-                        symbol: "|"
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 1211
-                          line: 47
-                          character: 63
-                        end_position:
-                          bytes: 1212
-                          line: 47
-                          character: 64
-                        token_type:
-                          type: Whitespace
-                          characters: " "
-                  right:
-                    Basic:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 1212
-                          line: 47
-                          character: 64
-                        end_position:
-                          bytes: 1213
-                          line: 47
-                          character: 65
-                        token_type:
-                          type: Identifier
-                          identifier: S
-                      trailing_trivia: []
+                              arrows:
+                                tokens:
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 1303
+                                        line: 49
+                                        character: 58
+                                      end_position:
+                                        bytes: 1304
+                                        line: 49
+                                        character: 59
+                                      token_type:
+                                        type: Symbol
+                                        symbol: "<"
+                                    trailing_trivia: []
+                                  - leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 1305
+                                        line: 49
+                                        character: 60
+                                      end_position:
+                                        bytes: 1306
+                                        line: 49
+                                        character: 61
+                                      token_type:
+                                        type: Symbol
+                                        symbol: ">"
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 1306
+                                          line: 49
+                                          character: 61
+                                        end_position:
+                                          bytes: 1307
+                                          line: 49
+                                          character: 62
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                              generics:
+                                pairs:
+                                  - End:
+                                      Basic:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 1304
+                                            line: 49
+                                            character: 59
+                                          end_position:
+                                            bytes: 1305
+                                            line: 49
+                                            character: 60
+                                          token_type:
+                                            type: Identifier
+                                            identifier: S
+                                        trailing_trivia: []
+                          - leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 1307
+                                line: 49
+                                character: 62
+                              end_position:
+                                bytes: 1308
+                                line: 49
+                                character: 63
+                              token_type:
+                                type: Symbol
+                                symbol: "|"
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 1308
+                                  line: 49
+                                  character: 63
+                                end_position:
+                                  bytes: 1309
+                                  line: 49
+                                  character: 64
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                      - End:
+                          Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 1309
+                                line: 49
+                                character: 64
+                              end_position:
+                                bytes: 1310
+                                line: 49
+                                character: 65
+                              token_type:
+                                type: Identifier
+                                identifier: S
+                            trailing_trivia: []
           return_type:
             punctuation:
               leading_trivia: []
               token:
                 start_position:
-                  bytes: 1214
-                  line: 47
+                  bytes: 1311
+                  line: 49
                   character: 66
                 end_position:
-                  bytes: 1215
-                  line: 47
+                  bytes: 1312
+                  line: 49
                   character: 67
                 token_type:
                   type: Symbol
                   symbol: ":"
               trailing_trivia:
                 - start_position:
-                    bytes: 1215
-                    line: 47
+                    bytes: 1312
+                    line: 49
                     character: 67
                   end_position:
-                    bytes: 1216
-                    line: 47
+                    bytes: 1313
+                    line: 49
                     character: 68
                   token_type:
                     type: Whitespace
                     characters: " "
             type_info:
               Intersection:
-                left:
-                  Generic:
-                    base:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 1216
-                          line: 47
-                          character: 68
-                        end_position:
-                          bytes: 1221
-                          line: 47
-                          character: 73
-                        token_type:
-                          type: Identifier
-                          identifier: Array
-                      trailing_trivia: []
-                    arrows:
-                      tokens:
+                leading: ~
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Generic:
+                            base:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 1313
+                                  line: 49
+                                  character: 68
+                                end_position:
+                                  bytes: 1318
+                                  line: 49
+                                  character: 73
+                                token_type:
+                                  type: Identifier
+                                  identifier: Array
+                              trailing_trivia: []
+                            arrows:
+                              tokens:
+                                - leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 1318
+                                      line: 49
+                                      character: 73
+                                    end_position:
+                                      bytes: 1319
+                                      line: 49
+                                      character: 74
+                                    token_type:
+                                      type: Symbol
+                                      symbol: "<"
+                                  trailing_trivia: []
+                                - leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 1320
+                                      line: 49
+                                      character: 75
+                                    end_position:
+                                      bytes: 1321
+                                      line: 49
+                                      character: 76
+                                    token_type:
+                                      type: Symbol
+                                      symbol: ">"
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 1321
+                                        line: 49
+                                        character: 76
+                                      end_position:
+                                        bytes: 1322
+                                        line: 49
+                                        character: 77
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                            generics:
+                              pairs:
+                                - End:
+                                    Basic:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 1319
+                                          line: 49
+                                          character: 74
+                                        end_position:
+                                          bytes: 1320
+                                          line: 49
+                                          character: 75
+                                        token_type:
+                                          type: Identifier
+                                          identifier: T
+                                      trailing_trivia: []
                         - leading_trivia: []
                           token:
                             start_position:
-                              bytes: 1221
-                              line: 47
-                              character: 73
+                              bytes: 1322
+                              line: 49
+                              character: 77
                             end_position:
-                              bytes: 1222
-                              line: 47
-                              character: 74
+                              bytes: 1323
+                              line: 49
+                              character: 78
                             token_type:
                               type: Symbol
-                              symbol: "<"
-                          trailing_trivia: []
-                        - leading_trivia: []
-                          token:
-                            start_position:
-                              bytes: 1223
-                              line: 47
-                              character: 75
-                            end_position:
-                              bytes: 1224
-                              line: 47
-                              character: 76
-                            token_type:
-                              type: Symbol
-                              symbol: ">"
+                              symbol: "&"
                           trailing_trivia:
                             - start_position:
-                                bytes: 1224
-                                line: 47
-                                character: 76
+                                bytes: 1323
+                                line: 49
+                                character: 78
                               end_position:
-                                bytes: 1225
-                                line: 47
-                                character: 77
+                                bytes: 1324
+                                line: 49
+                                character: 79
                               token_type:
                                 type: Whitespace
                                 characters: " "
-                    generics:
-                      pairs:
-                        - End:
-                            Basic:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 1222
-                                  line: 47
-                                  character: 74
-                                end_position:
-                                  bytes: 1223
-                                  line: 47
-                                  character: 75
-                                token_type:
-                                  type: Identifier
-                                  identifier: T
-                              trailing_trivia: []
-                ampersand:
-                  leading_trivia: []
-                  token:
-                    start_position:
-                      bytes: 1225
-                      line: 47
-                      character: 77
-                    end_position:
-                      bytes: 1226
-                      line: 47
-                      character: 78
-                    token_type:
-                      type: Symbol
-                      symbol: "&"
-                  trailing_trivia:
-                    - start_position:
-                        bytes: 1226
-                        line: 47
-                        character: 78
-                      end_position:
-                        bytes: 1227
-                        line: 47
-                        character: 79
-                      token_type:
-                        type: Whitespace
-                        characters: " "
-                right:
-                  Generic:
-                    base:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 1227
-                          line: 47
-                          character: 79
-                        end_position:
-                          bytes: 1232
-                          line: 47
-                          character: 84
-                        token_type:
-                          type: Identifier
-                          identifier: Array
-                      trailing_trivia: []
-                    arrows:
-                      tokens:
-                        - leading_trivia: []
-                          token:
-                            start_position:
-                              bytes: 1232
-                              line: 47
-                              character: 84
-                            end_position:
-                              bytes: 1233
-                              line: 47
-                              character: 85
-                            token_type:
-                              type: Symbol
-                              symbol: "<"
-                          trailing_trivia: []
-                        - leading_trivia: []
-                          token:
-                            start_position:
-                              bytes: 1234
-                              line: 47
-                              character: 86
-                            end_position:
-                              bytes: 1235
-                              line: 47
-                              character: 87
-                            token_type:
-                              type: Symbol
-                              symbol: ">"
-                          trailing_trivia:
-                            - start_position:
-                                bytes: 1235
-                                line: 47
-                                character: 87
+                    - End:
+                        Generic:
+                          base:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 1324
+                                line: 49
+                                character: 79
                               end_position:
-                                bytes: 1236
-                                line: 47
-                                character: 87
+                                bytes: 1329
+                                line: 49
+                                character: 84
                               token_type:
-                                type: Whitespace
-                                characters: "\n"
-                    generics:
-                      pairs:
-                        - End:
-                            Basic:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 1233
-                                  line: 47
-                                  character: 85
-                                end_position:
-                                  bytes: 1234
-                                  line: 47
-                                  character: 86
-                                token_type:
-                                  type: Identifier
-                                  identifier: S
-                              trailing_trivia: []
+                                type: Identifier
+                                identifier: Array
+                            trailing_trivia: []
+                          arrows:
+                            tokens:
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 1329
+                                    line: 49
+                                    character: 84
+                                  end_position:
+                                    bytes: 1330
+                                    line: 49
+                                    character: 85
+                                  token_type:
+                                    type: Symbol
+                                    symbol: "<"
+                                trailing_trivia: []
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 1331
+                                    line: 49
+                                    character: 86
+                                  end_position:
+                                    bytes: 1332
+                                    line: 49
+                                    character: 87
+                                  token_type:
+                                    type: Symbol
+                                    symbol: ">"
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 1332
+                                      line: 49
+                                      character: 87
+                                    end_position:
+                                      bytes: 1333
+                                      line: 49
+                                      character: 87
+                                    token_type:
+                                      type: Whitespace
+                                      characters: "\n"
+                          generics:
+                            pairs:
+                              - End:
+                                  Basic:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 1330
+                                        line: 49
+                                        character: 85
+                                      end_position:
+                                        bytes: 1331
+                                        line: 49
+                                        character: 86
+                                      token_type:
+                                        type: Identifier
+                                        identifier: S
+                                    trailing_trivia: []
           block:
             stmts: []
             last_stmt:
@@ -7844,36 +8335,36 @@ stmts:
                   token:
                     leading_trivia:
                       - start_position:
-                          bytes: 1236
-                          line: 48
+                          bytes: 1333
+                          line: 50
                           character: 1
                         end_position:
-                          bytes: 1240
-                          line: 48
+                          bytes: 1337
+                          line: 50
                           character: 5
                         token_type:
                           type: Whitespace
                           characters: "    "
                     token:
                       start_position:
-                        bytes: 1240
-                        line: 48
+                        bytes: 1337
+                        line: 50
                         character: 5
                       end_position:
-                        bytes: 1246
-                        line: 48
+                        bytes: 1343
+                        line: 50
                         character: 11
                       token_type:
                         type: Symbol
                         symbol: return
                     trailing_trivia:
                       - start_position:
-                          bytes: 1246
-                          line: 48
+                          bytes: 1343
+                          line: 50
                           character: 11
                         end_position:
-                          bytes: 1247
-                          line: 48
+                          bytes: 1344
+                          line: 50
                           character: 12
                         token_type:
                           type: Whitespace
@@ -7889,12 +8380,12 @@ stmts:
                                     - leading_trivia: []
                                       token:
                                         start_position:
-                                          bytes: 1247
-                                          line: 48
+                                          bytes: 1344
+                                          line: 50
                                           character: 12
                                         end_position:
-                                          bytes: 1248
-                                          line: 48
+                                          bytes: 1345
+                                          line: 50
                                           character: 13
                                         token_type:
                                           type: Symbol
@@ -7903,24 +8394,24 @@ stmts:
                                     - leading_trivia: []
                                       token:
                                         start_position:
-                                          bytes: 1261
-                                          line: 48
+                                          bytes: 1358
+                                          line: 50
                                           character: 26
                                         end_position:
-                                          bytes: 1262
-                                          line: 48
+                                          bytes: 1359
+                                          line: 50
                                           character: 27
                                         token_type:
                                           type: Symbol
                                           symbol: )
                                       trailing_trivia:
                                         - start_position:
-                                            bytes: 1262
-                                            line: 48
+                                            bytes: 1359
+                                            line: 50
                                             character: 27
                                           end_position:
-                                            bytes: 1263
-                                            line: 48
+                                            bytes: 1360
+                                            line: 50
                                             character: 28
                                           token_type:
                                             type: Whitespace
@@ -7933,24 +8424,24 @@ stmts:
                                           leading_trivia: []
                                           token:
                                             start_position:
-                                              bytes: 1248
-                                              line: 48
+                                              bytes: 1345
+                                              line: 50
                                               character: 13
                                             end_position:
-                                              bytes: 1254
-                                              line: 48
+                                              bytes: 1351
+                                              line: 50
                                               character: 19
                                             token_type:
                                               type: Identifier
                                               identifier: source
                                           trailing_trivia:
                                             - start_position:
-                                                bytes: 1254
-                                                line: 48
+                                                bytes: 1351
+                                                line: 50
                                                 character: 19
                                               end_position:
-                                                bytes: 1255
-                                                line: 48
+                                                bytes: 1352
+                                                line: 50
                                                 character: 20
                                               token_type:
                                                 type: Whitespace
@@ -7960,24 +8451,24 @@ stmts:
                                         leading_trivia: []
                                         token:
                                           start_position:
-                                            bytes: 1255
-                                            line: 48
+                                            bytes: 1352
+                                            line: 50
                                             character: 20
                                           end_position:
-                                            bytes: 1257
-                                            line: 48
+                                            bytes: 1354
+                                            line: 50
                                             character: 22
                                           token_type:
                                             type: Symbol
                                             symbol: "::"
                                         trailing_trivia:
                                           - start_position:
-                                              bytes: 1257
-                                              line: 48
+                                              bytes: 1354
+                                              line: 50
                                               character: 22
                                             end_position:
-                                              bytes: 1258
-                                              line: 48
+                                              bytes: 1355
+                                              line: 50
                                               character: 23
                                             token_type:
                                               type: Whitespace
@@ -7987,12 +8478,12 @@ stmts:
                                           leading_trivia: []
                                           token:
                                             start_position:
-                                              bytes: 1258
-                                              line: 48
+                                              bytes: 1355
+                                              line: 50
                                               character: 23
                                             end_position:
-                                              bytes: 1261
-                                              line: 48
+                                              bytes: 1358
+                                              line: 50
                                               character: 26
                                             token_type:
                                               type: Identifier
@@ -8003,223 +8494,224 @@ stmts:
                                 leading_trivia: []
                                 token:
                                   start_position:
-                                    bytes: 1263
-                                    line: 48
+                                    bytes: 1360
+                                    line: 50
                                     character: 28
                                   end_position:
-                                    bytes: 1265
-                                    line: 48
+                                    bytes: 1362
+                                    line: 50
                                     character: 30
                                   token_type:
                                     type: Symbol
                                     symbol: "::"
                                 trailing_trivia:
                                   - start_position:
-                                      bytes: 1265
-                                      line: 48
+                                      bytes: 1362
+                                      line: 50
                                       character: 30
                                     end_position:
-                                      bytes: 1266
-                                      line: 48
+                                      bytes: 1363
+                                      line: 50
                                       character: 31
                                     token_type:
                                       type: Whitespace
                                       characters: " "
                               cast_to:
                                 Intersection:
-                                  left:
-                                    Generic:
-                                      base:
-                                        leading_trivia: []
-                                        token:
-                                          start_position:
-                                            bytes: 1266
-                                            line: 48
-                                            character: 31
-                                          end_position:
-                                            bytes: 1271
-                                            line: 48
-                                            character: 36
-                                          token_type:
-                                            type: Identifier
-                                            identifier: Array
-                                        trailing_trivia: []
-                                      arrows:
-                                        tokens:
+                                  leading: ~
+                                  types:
+                                    pairs:
+                                      - Punctuated:
+                                          - Generic:
+                                              base:
+                                                leading_trivia: []
+                                                token:
+                                                  start_position:
+                                                    bytes: 1363
+                                                    line: 50
+                                                    character: 31
+                                                  end_position:
+                                                    bytes: 1368
+                                                    line: 50
+                                                    character: 36
+                                                  token_type:
+                                                    type: Identifier
+                                                    identifier: Array
+                                                trailing_trivia: []
+                                              arrows:
+                                                tokens:
+                                                  - leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 1368
+                                                        line: 50
+                                                        character: 36
+                                                      end_position:
+                                                        bytes: 1369
+                                                        line: 50
+                                                        character: 37
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: "<"
+                                                    trailing_trivia: []
+                                                  - leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 1370
+                                                        line: 50
+                                                        character: 38
+                                                      end_position:
+                                                        bytes: 1371
+                                                        line: 50
+                                                        character: 39
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: ">"
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 1371
+                                                          line: 50
+                                                          character: 39
+                                                        end_position:
+                                                          bytes: 1372
+                                                          line: 50
+                                                          character: 40
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                              generics:
+                                                pairs:
+                                                  - End:
+                                                      Basic:
+                                                        leading_trivia: []
+                                                        token:
+                                                          start_position:
+                                                            bytes: 1369
+                                                            line: 50
+                                                            character: 37
+                                                          end_position:
+                                                            bytes: 1370
+                                                            line: 50
+                                                            character: 38
+                                                          token_type:
+                                                            type: Identifier
+                                                            identifier: S
+                                                        trailing_trivia: []
                                           - leading_trivia: []
                                             token:
                                               start_position:
-                                                bytes: 1271
-                                                line: 48
-                                                character: 36
+                                                bytes: 1372
+                                                line: 50
+                                                character: 40
                                               end_position:
-                                                bytes: 1272
-                                                line: 48
-                                                character: 37
+                                                bytes: 1373
+                                                line: 50
+                                                character: 41
                                               token_type:
                                                 type: Symbol
-                                                symbol: "<"
-                                            trailing_trivia: []
-                                          - leading_trivia: []
-                                            token:
-                                              start_position:
-                                                bytes: 1273
-                                                line: 48
-                                                character: 38
-                                              end_position:
-                                                bytes: 1274
-                                                line: 48
-                                                character: 39
-                                              token_type:
-                                                type: Symbol
-                                                symbol: ">"
+                                                symbol: "&"
                                             trailing_trivia:
                                               - start_position:
-                                                  bytes: 1274
-                                                  line: 48
-                                                  character: 39
+                                                  bytes: 1373
+                                                  line: 50
+                                                  character: 41
                                                 end_position:
-                                                  bytes: 1275
-                                                  line: 48
-                                                  character: 40
+                                                  bytes: 1374
+                                                  line: 50
+                                                  character: 42
                                                 token_type:
                                                   type: Whitespace
                                                   characters: " "
-                                      generics:
-                                        pairs:
-                                          - End:
-                                              Basic:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 1272
-                                                    line: 48
-                                                    character: 37
-                                                  end_position:
-                                                    bytes: 1273
-                                                    line: 48
-                                                    character: 38
-                                                  token_type:
-                                                    type: Identifier
-                                                    identifier: S
-                                                trailing_trivia: []
-                                  ampersand:
-                                    leading_trivia: []
-                                    token:
-                                      start_position:
-                                        bytes: 1275
-                                        line: 48
-                                        character: 40
-                                      end_position:
-                                        bytes: 1276
-                                        line: 48
-                                        character: 41
-                                      token_type:
-                                        type: Symbol
-                                        symbol: "&"
-                                    trailing_trivia:
-                                      - start_position:
-                                          bytes: 1276
-                                          line: 48
-                                          character: 41
-                                        end_position:
-                                          bytes: 1277
-                                          line: 48
-                                          character: 42
-                                        token_type:
-                                          type: Whitespace
-                                          characters: " "
-                                  right:
-                                    Generic:
-                                      base:
-                                        leading_trivia: []
-                                        token:
-                                          start_position:
-                                            bytes: 1277
-                                            line: 48
-                                            character: 42
-                                          end_position:
-                                            bytes: 1282
-                                            line: 48
-                                            character: 47
-                                          token_type:
-                                            type: Identifier
-                                            identifier: Array
-                                        trailing_trivia: []
-                                      arrows:
-                                        tokens:
-                                          - leading_trivia: []
-                                            token:
-                                              start_position:
-                                                bytes: 1282
-                                                line: 48
-                                                character: 47
-                                              end_position:
-                                                bytes: 1283
-                                                line: 48
-                                                character: 48
-                                              token_type:
-                                                type: Symbol
-                                                symbol: "<"
-                                            trailing_trivia: []
-                                          - leading_trivia: []
-                                            token:
-                                              start_position:
-                                                bytes: 1284
-                                                line: 48
-                                                character: 49
-                                              end_position:
-                                                bytes: 1285
-                                                line: 48
-                                                character: 50
-                                              token_type:
-                                                type: Symbol
-                                                symbol: ">"
-                                            trailing_trivia:
-                                              - start_position:
-                                                  bytes: 1285
-                                                  line: 48
-                                                  character: 50
+                                      - End:
+                                          Generic:
+                                            base:
+                                              leading_trivia: []
+                                              token:
+                                                start_position:
+                                                  bytes: 1374
+                                                  line: 50
+                                                  character: 42
                                                 end_position:
-                                                  bytes: 1286
-                                                  line: 48
-                                                  character: 50
+                                                  bytes: 1379
+                                                  line: 50
+                                                  character: 47
                                                 token_type:
-                                                  type: Whitespace
-                                                  characters: "\n"
-                                      generics:
-                                        pairs:
-                                          - End:
-                                              Basic:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 1283
-                                                    line: 48
-                                                    character: 48
-                                                  end_position:
-                                                    bytes: 1284
-                                                    line: 48
-                                                    character: 49
-                                                  token_type:
-                                                    type: Identifier
-                                                    identifier: T
-                                                trailing_trivia: []
+                                                  type: Identifier
+                                                  identifier: Array
+                                              trailing_trivia: []
+                                            arrows:
+                                              tokens:
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 1379
+                                                      line: 50
+                                                      character: 47
+                                                    end_position:
+                                                      bytes: 1380
+                                                      line: 50
+                                                      character: 48
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: "<"
+                                                  trailing_trivia: []
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 1381
+                                                      line: 50
+                                                      character: 49
+                                                    end_position:
+                                                      bytes: 1382
+                                                      line: 50
+                                                      character: 50
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: ">"
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 1382
+                                                        line: 50
+                                                        character: 50
+                                                      end_position:
+                                                        bytes: 1383
+                                                        line: 50
+                                                        character: 50
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: "\n"
+                                            generics:
+                                              pairs:
+                                                - End:
+                                                    Basic:
+                                                      leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 1380
+                                                          line: 50
+                                                          character: 48
+                                                        end_position:
+                                                          bytes: 1381
+                                                          line: 50
+                                                          character: 49
+                                                        token_type:
+                                                          type: Identifier
+                                                          identifier: T
+                                                      trailing_trivia: []
               - ~
           end_token:
             leading_trivia: []
             token:
               start_position:
-                bytes: 1286
-                line: 49
+                bytes: 1383
+                line: 51
                 character: 1
               end_position:
-                bytes: 1289
-                line: 49
+                bytes: 1386
+                line: 51
                 character: 4
               token_type:
                 type: Symbol
                 symbol: end
             trailing_trivia: []
     - ~
-

--- a/full-moon/tests/roblox_cases/pass/types/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types/source.lua
@@ -30,9 +30,11 @@ local _foo4: string, _bar1: string
 
 local _union: number | string
 local _multiUnion: number | string | nil
+local _leadingUnion: | number | string | nil
 
 local _intersection: number & string
 local _multiIntersection: number & string & nil
+local _leadingIntersection: & number & string & nil
 
 function _fn0(param: string): string
 	return param

--- a/full-moon/tests/roblox_cases/pass/types/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types/tokens.snap
@@ -2,7 +2,6 @@
 source: full-moon/tests/pass_cases.rs
 expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/types
-
 ---
 - start_position:
     bytes: 0
@@ -4484,1868 +4483,2241 @@ input_file: full-moon/tests/roblox_cases/pass/types
     line: 33
     character: 1
   end_position:
-    bytes: 908
+    bytes: 912
     line: 33
-    character: 1
-  token_type:
-    type: Whitespace
-    characters: "\n"
-- start_position:
-    bytes: 908
-    line: 34
-    character: 1
-  end_position:
-    bytes: 913
-    line: 34
     character: 6
   token_type:
     type: Symbol
     symbol: local
 - start_position:
-    bytes: 913
-    line: 34
+    bytes: 912
+    line: 33
     character: 6
   end_position:
-    bytes: 914
-    line: 34
+    bytes: 913
+    line: 33
     character: 7
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 914
-    line: 34
+    bytes: 913
+    line: 33
     character: 7
   end_position:
+    bytes: 926
+    line: 33
+    character: 20
+  token_type:
+    type: Identifier
+    identifier: _leadingUnion
+- start_position:
+    bytes: 926
+    line: 33
+    character: 20
+  end_position:
     bytes: 927
+    line: 33
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 927
+    line: 33
+    character: 21
+  end_position:
+    bytes: 928
+    line: 33
+    character: 22
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 928
+    line: 33
+    character: 22
+  end_position:
+    bytes: 929
+    line: 33
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 929
+    line: 33
+    character: 23
+  end_position:
+    bytes: 930
+    line: 33
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 930
+    line: 33
+    character: 24
+  end_position:
+    bytes: 936
+    line: 33
+    character: 30
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 936
+    line: 33
+    character: 30
+  end_position:
+    bytes: 937
+    line: 33
+    character: 31
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 937
+    line: 33
+    character: 31
+  end_position:
+    bytes: 938
+    line: 33
+    character: 32
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 938
+    line: 33
+    character: 32
+  end_position:
+    bytes: 939
+    line: 33
+    character: 33
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 939
+    line: 33
+    character: 33
+  end_position:
+    bytes: 945
+    line: 33
+    character: 39
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 945
+    line: 33
+    character: 39
+  end_position:
+    bytes: 946
+    line: 33
+    character: 40
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 946
+    line: 33
+    character: 40
+  end_position:
+    bytes: 947
+    line: 33
+    character: 41
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 947
+    line: 33
+    character: 41
+  end_position:
+    bytes: 948
+    line: 33
+    character: 42
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 948
+    line: 33
+    character: 42
+  end_position:
+    bytes: 951
+    line: 33
+    character: 45
+  token_type:
+    type: Symbol
+    symbol: nil
+- start_position:
+    bytes: 951
+    line: 33
+    character: 45
+  end_position:
+    bytes: 952
+    line: 33
+    character: 45
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 952
     line: 34
+    character: 1
+  end_position:
+    bytes: 953
+    line: 34
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 953
+    line: 35
+    character: 1
+  end_position:
+    bytes: 958
+    line: 35
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 958
+    line: 35
+    character: 6
+  end_position:
+    bytes: 959
+    line: 35
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 959
+    line: 35
+    character: 7
+  end_position:
+    bytes: 972
+    line: 35
     character: 20
   token_type:
     type: Identifier
     identifier: _intersection
 - start_position:
-    bytes: 927
-    line: 34
+    bytes: 972
+    line: 35
     character: 20
   end_position:
-    bytes: 928
-    line: 34
+    bytes: 973
+    line: 35
     character: 21
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 928
-    line: 34
+    bytes: 973
+    line: 35
     character: 21
   end_position:
-    bytes: 929
-    line: 34
+    bytes: 974
+    line: 35
     character: 22
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 929
-    line: 34
+    bytes: 974
+    line: 35
     character: 22
   end_position:
-    bytes: 935
-    line: 34
+    bytes: 980
+    line: 35
     character: 28
   token_type:
     type: Identifier
     identifier: number
 - start_position:
-    bytes: 935
-    line: 34
+    bytes: 980
+    line: 35
     character: 28
   end_position:
-    bytes: 936
-    line: 34
+    bytes: 981
+    line: 35
     character: 29
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 936
-    line: 34
+    bytes: 981
+    line: 35
     character: 29
   end_position:
-    bytes: 937
-    line: 34
+    bytes: 982
+    line: 35
     character: 30
   token_type:
     type: Symbol
     symbol: "&"
 - start_position:
-    bytes: 937
-    line: 34
+    bytes: 982
+    line: 35
     character: 30
   end_position:
-    bytes: 938
-    line: 34
+    bytes: 983
+    line: 35
     character: 31
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 938
-    line: 34
+    bytes: 983
+    line: 35
     character: 31
   end_position:
-    bytes: 944
-    line: 34
+    bytes: 989
+    line: 35
     character: 37
   token_type:
     type: Identifier
     identifier: string
 - start_position:
-    bytes: 944
-    line: 34
+    bytes: 989
+    line: 35
     character: 37
   end_position:
-    bytes: 945
-    line: 34
+    bytes: 990
+    line: 35
     character: 37
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 945
-    line: 35
+    bytes: 990
+    line: 36
     character: 1
   end_position:
-    bytes: 950
-    line: 35
+    bytes: 995
+    line: 36
     character: 6
   token_type:
     type: Symbol
     symbol: local
 - start_position:
-    bytes: 950
-    line: 35
+    bytes: 995
+    line: 36
     character: 6
   end_position:
-    bytes: 951
-    line: 35
+    bytes: 996
+    line: 36
     character: 7
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 951
-    line: 35
+    bytes: 996
+    line: 36
     character: 7
   end_position:
-    bytes: 969
-    line: 35
+    bytes: 1014
+    line: 36
     character: 25
   token_type:
     type: Identifier
     identifier: _multiIntersection
 - start_position:
-    bytes: 969
-    line: 35
+    bytes: 1014
+    line: 36
     character: 25
   end_position:
-    bytes: 970
-    line: 35
+    bytes: 1015
+    line: 36
     character: 26
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 970
-    line: 35
+    bytes: 1015
+    line: 36
     character: 26
   end_position:
-    bytes: 971
-    line: 35
+    bytes: 1016
+    line: 36
     character: 27
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 971
-    line: 35
+    bytes: 1016
+    line: 36
     character: 27
   end_position:
-    bytes: 977
-    line: 35
+    bytes: 1022
+    line: 36
     character: 33
   token_type:
     type: Identifier
     identifier: number
 - start_position:
-    bytes: 977
-    line: 35
+    bytes: 1022
+    line: 36
     character: 33
   end_position:
-    bytes: 978
-    line: 35
+    bytes: 1023
+    line: 36
     character: 34
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 978
-    line: 35
+    bytes: 1023
+    line: 36
     character: 34
   end_position:
-    bytes: 979
-    line: 35
+    bytes: 1024
+    line: 36
     character: 35
   token_type:
     type: Symbol
     symbol: "&"
 - start_position:
-    bytes: 979
-    line: 35
+    bytes: 1024
+    line: 36
     character: 35
   end_position:
-    bytes: 980
-    line: 35
+    bytes: 1025
+    line: 36
     character: 36
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 980
-    line: 35
+    bytes: 1025
+    line: 36
     character: 36
   end_position:
-    bytes: 986
-    line: 35
+    bytes: 1031
+    line: 36
     character: 42
   token_type:
     type: Identifier
     identifier: string
 - start_position:
-    bytes: 986
-    line: 35
+    bytes: 1031
+    line: 36
     character: 42
   end_position:
-    bytes: 987
-    line: 35
+    bytes: 1032
+    line: 36
     character: 43
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 987
-    line: 35
+    bytes: 1032
+    line: 36
     character: 43
   end_position:
-    bytes: 988
-    line: 35
+    bytes: 1033
+    line: 36
     character: 44
   token_type:
     type: Symbol
     symbol: "&"
 - start_position:
-    bytes: 988
-    line: 35
+    bytes: 1033
+    line: 36
     character: 44
   end_position:
-    bytes: 989
-    line: 35
+    bytes: 1034
+    line: 36
     character: 45
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 989
-    line: 35
+    bytes: 1034
+    line: 36
     character: 45
   end_position:
-    bytes: 992
-    line: 35
+    bytes: 1037
+    line: 36
     character: 48
   token_type:
     type: Symbol
     symbol: nil
 - start_position:
-    bytes: 992
-    line: 35
+    bytes: 1037
+    line: 36
     character: 48
   end_position:
-    bytes: 993
-    line: 35
+    bytes: 1038
+    line: 36
     character: 48
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 993
-    line: 36
+    bytes: 1038
+    line: 37
     character: 1
   end_position:
-    bytes: 994
-    line: 36
+    bytes: 1043
+    line: 37
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 1043
+    line: 37
+    character: 6
+  end_position:
+    bytes: 1044
+    line: 37
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 1044
+    line: 37
+    character: 7
+  end_position:
+    bytes: 1064
+    line: 37
+    character: 27
+  token_type:
+    type: Identifier
+    identifier: _leadingIntersection
+- start_position:
+    bytes: 1064
+    line: 37
+    character: 27
+  end_position:
+    bytes: 1065
+    line: 37
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 1065
+    line: 37
+    character: 28
+  end_position:
+    bytes: 1066
+    line: 37
+    character: 29
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 1066
+    line: 37
+    character: 29
+  end_position:
+    bytes: 1067
+    line: 37
+    character: 30
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 1067
+    line: 37
+    character: 30
+  end_position:
+    bytes: 1068
+    line: 37
+    character: 31
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 1068
+    line: 37
+    character: 31
+  end_position:
+    bytes: 1074
+    line: 37
+    character: 37
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 1074
+    line: 37
+    character: 37
+  end_position:
+    bytes: 1075
+    line: 37
+    character: 38
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 1075
+    line: 37
+    character: 38
+  end_position:
+    bytes: 1076
+    line: 37
+    character: 39
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 1076
+    line: 37
+    character: 39
+  end_position:
+    bytes: 1077
+    line: 37
+    character: 40
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 1077
+    line: 37
+    character: 40
+  end_position:
+    bytes: 1083
+    line: 37
+    character: 46
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 1083
+    line: 37
+    character: 46
+  end_position:
+    bytes: 1084
+    line: 37
+    character: 47
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 1084
+    line: 37
+    character: 47
+  end_position:
+    bytes: 1085
+    line: 37
+    character: 48
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 1085
+    line: 37
+    character: 48
+  end_position:
+    bytes: 1086
+    line: 37
+    character: 49
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 1086
+    line: 37
+    character: 49
+  end_position:
+    bytes: 1089
+    line: 37
+    character: 52
+  token_type:
+    type: Symbol
+    symbol: nil
+- start_position:
+    bytes: 1089
+    line: 37
+    character: 52
+  end_position:
+    bytes: 1090
+    line: 37
+    character: 52
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 1090
+    line: 38
+    character: 1
+  end_position:
+    bytes: 1091
+    line: 38
     character: 1
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 994
-    line: 37
+    bytes: 1091
+    line: 39
     character: 1
   end_position:
-    bytes: 1002
-    line: 37
+    bytes: 1099
+    line: 39
     character: 9
   token_type:
     type: Symbol
     symbol: function
 - start_position:
-    bytes: 1002
-    line: 37
+    bytes: 1099
+    line: 39
     character: 9
   end_position:
-    bytes: 1003
-    line: 37
+    bytes: 1100
+    line: 39
     character: 10
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1003
-    line: 37
+    bytes: 1100
+    line: 39
     character: 10
   end_position:
-    bytes: 1007
-    line: 37
+    bytes: 1104
+    line: 39
     character: 14
   token_type:
     type: Identifier
     identifier: _fn0
 - start_position:
-    bytes: 1007
-    line: 37
+    bytes: 1104
+    line: 39
     character: 14
   end_position:
-    bytes: 1008
-    line: 37
+    bytes: 1105
+    line: 39
     character: 15
   token_type:
     type: Symbol
     symbol: (
 - start_position:
-    bytes: 1008
-    line: 37
+    bytes: 1105
+    line: 39
     character: 15
   end_position:
-    bytes: 1013
-    line: 37
+    bytes: 1110
+    line: 39
     character: 20
   token_type:
     type: Identifier
     identifier: param
 - start_position:
-    bytes: 1013
-    line: 37
+    bytes: 1110
+    line: 39
     character: 20
   end_position:
-    bytes: 1014
-    line: 37
+    bytes: 1111
+    line: 39
     character: 21
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1014
-    line: 37
+    bytes: 1111
+    line: 39
     character: 21
   end_position:
-    bytes: 1015
-    line: 37
+    bytes: 1112
+    line: 39
     character: 22
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1015
-    line: 37
+    bytes: 1112
+    line: 39
     character: 22
   end_position:
-    bytes: 1021
-    line: 37
+    bytes: 1118
+    line: 39
     character: 28
   token_type:
     type: Identifier
     identifier: string
 - start_position:
-    bytes: 1021
-    line: 37
+    bytes: 1118
+    line: 39
     character: 28
   end_position:
-    bytes: 1022
-    line: 37
+    bytes: 1119
+    line: 39
     character: 29
   token_type:
     type: Symbol
     symbol: )
 - start_position:
-    bytes: 1022
-    line: 37
+    bytes: 1119
+    line: 39
     character: 29
   end_position:
-    bytes: 1023
-    line: 37
+    bytes: 1120
+    line: 39
     character: 30
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1023
-    line: 37
+    bytes: 1120
+    line: 39
     character: 30
   end_position:
-    bytes: 1024
-    line: 37
+    bytes: 1121
+    line: 39
     character: 31
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1024
-    line: 37
+    bytes: 1121
+    line: 39
     character: 31
   end_position:
-    bytes: 1030
-    line: 37
+    bytes: 1127
+    line: 39
     character: 37
   token_type:
     type: Identifier
     identifier: string
 - start_position:
-    bytes: 1030
-    line: 37
+    bytes: 1127
+    line: 39
     character: 37
   end_position:
-    bytes: 1031
-    line: 37
+    bytes: 1128
+    line: 39
     character: 37
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1031
-    line: 38
+    bytes: 1128
+    line: 40
     character: 1
   end_position:
-    bytes: 1032
-    line: 38
+    bytes: 1129
+    line: 40
     character: 2
   token_type:
     type: Whitespace
     characters: "\t"
 - start_position:
-    bytes: 1032
-    line: 38
+    bytes: 1129
+    line: 40
     character: 2
   end_position:
-    bytes: 1038
-    line: 38
+    bytes: 1135
+    line: 40
     character: 8
   token_type:
     type: Symbol
     symbol: return
 - start_position:
-    bytes: 1038
-    line: 38
+    bytes: 1135
+    line: 40
     character: 8
   end_position:
-    bytes: 1039
-    line: 38
+    bytes: 1136
+    line: 40
     character: 9
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1039
-    line: 38
+    bytes: 1136
+    line: 40
     character: 9
   end_position:
-    bytes: 1044
-    line: 38
+    bytes: 1141
+    line: 40
     character: 14
   token_type:
     type: Identifier
     identifier: param
 - start_position:
-    bytes: 1044
-    line: 38
+    bytes: 1141
+    line: 40
     character: 14
   end_position:
-    bytes: 1045
-    line: 38
+    bytes: 1142
+    line: 40
     character: 14
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1045
-    line: 39
+    bytes: 1142
+    line: 41
     character: 1
   end_position:
-    bytes: 1048
-    line: 39
+    bytes: 1145
+    line: 41
     character: 4
   token_type:
     type: Symbol
     symbol: end
 - start_position:
-    bytes: 1048
-    line: 39
+    bytes: 1145
+    line: 41
     character: 4
   end_position:
-    bytes: 1049
-    line: 39
+    bytes: 1146
+    line: 41
     character: 4
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1049
-    line: 40
+    bytes: 1146
+    line: 42
     character: 1
   end_position:
-    bytes: 1050
-    line: 40
+    bytes: 1147
+    line: 42
     character: 1
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1050
-    line: 41
+    bytes: 1147
+    line: 43
     character: 1
   end_position:
-    bytes: 1058
-    line: 41
+    bytes: 1155
+    line: 43
     character: 9
   token_type:
     type: Symbol
     symbol: function
 - start_position:
-    bytes: 1058
-    line: 41
+    bytes: 1155
+    line: 43
     character: 9
   end_position:
-    bytes: 1059
-    line: 41
+    bytes: 1156
+    line: 43
     character: 10
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1059
-    line: 41
+    bytes: 1156
+    line: 43
     character: 10
   end_position:
-    bytes: 1063
-    line: 41
+    bytes: 1160
+    line: 43
     character: 14
   token_type:
     type: Identifier
     identifier: _fn2
 - start_position:
-    bytes: 1063
-    line: 41
+    bytes: 1160
+    line: 43
     character: 14
   end_position:
-    bytes: 1064
-    line: 41
+    bytes: 1161
+    line: 43
     character: 15
   token_type:
     type: Symbol
     symbol: (
 - start_position:
-    bytes: 1064
-    line: 41
+    bytes: 1161
+    line: 43
     character: 15
   end_position:
-    bytes: 1065
-    line: 41
+    bytes: 1162
+    line: 43
     character: 16
   token_type:
     type: Identifier
     identifier: a
 - start_position:
-    bytes: 1065
-    line: 41
+    bytes: 1162
+    line: 43
     character: 16
   end_position:
-    bytes: 1066
-    line: 41
+    bytes: 1163
+    line: 43
     character: 17
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1066
-    line: 41
+    bytes: 1163
+    line: 43
     character: 17
   end_position:
-    bytes: 1067
-    line: 41
+    bytes: 1164
+    line: 43
     character: 18
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1067
-    line: 41
+    bytes: 1164
+    line: 43
     character: 18
   end_position:
-    bytes: 1073
-    line: 41
+    bytes: 1170
+    line: 43
     character: 24
   token_type:
     type: Identifier
     identifier: string
 - start_position:
-    bytes: 1073
-    line: 41
+    bytes: 1170
+    line: 43
     character: 24
   end_position:
-    bytes: 1074
-    line: 41
+    bytes: 1171
+    line: 43
     character: 25
   token_type:
     type: Symbol
     symbol: ","
 - start_position:
-    bytes: 1074
-    line: 41
+    bytes: 1171
+    line: 43
     character: 25
   end_position:
-    bytes: 1075
-    line: 41
+    bytes: 1172
+    line: 43
     character: 26
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1075
-    line: 41
+    bytes: 1172
+    line: 43
     character: 26
   end_position:
-    bytes: 1076
-    line: 41
+    bytes: 1173
+    line: 43
     character: 27
   token_type:
     type: Identifier
     identifier: b
 - start_position:
-    bytes: 1076
-    line: 41
+    bytes: 1173
+    line: 43
     character: 27
   end_position:
-    bytes: 1077
-    line: 41
+    bytes: 1174
+    line: 43
     character: 28
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1077
-    line: 41
+    bytes: 1174
+    line: 43
     character: 28
   end_position:
-    bytes: 1078
-    line: 41
+    bytes: 1175
+    line: 43
     character: 29
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1078
-    line: 41
+    bytes: 1175
+    line: 43
     character: 29
   end_position:
-    bytes: 1084
-    line: 41
+    bytes: 1181
+    line: 43
     character: 35
   token_type:
     type: Identifier
     identifier: string
 - start_position:
-    bytes: 1084
-    line: 41
+    bytes: 1181
+    line: 43
     character: 35
   end_position:
-    bytes: 1085
-    line: 41
+    bytes: 1182
+    line: 43
     character: 36
   token_type:
     type: Symbol
     symbol: ","
 - start_position:
-    bytes: 1085
-    line: 41
+    bytes: 1182
+    line: 43
     character: 36
   end_position:
-    bytes: 1086
-    line: 41
+    bytes: 1183
+    line: 43
     character: 37
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1086
-    line: 41
+    bytes: 1183
+    line: 43
     character: 37
   end_position:
-    bytes: 1089
-    line: 41
+    bytes: 1186
+    line: 43
     character: 40
   token_type:
     type: Symbol
     symbol: "..."
 - start_position:
-    bytes: 1089
-    line: 41
+    bytes: 1186
+    line: 43
     character: 40
   end_position:
-    bytes: 1090
-    line: 41
+    bytes: 1187
+    line: 43
     character: 41
   token_type:
     type: Symbol
     symbol: )
 - start_position:
-    bytes: 1090
-    line: 41
+    bytes: 1187
+    line: 43
     character: 41
   end_position:
-    bytes: 1091
-    line: 41
+    bytes: 1188
+    line: 43
     character: 42
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1091
-    line: 41
+    bytes: 1188
+    line: 43
     character: 42
   end_position:
-    bytes: 1094
-    line: 41
+    bytes: 1191
+    line: 43
     character: 45
   token_type:
     type: Symbol
     symbol: end
 - start_position:
-    bytes: 1094
-    line: 41
+    bytes: 1191
+    line: 43
     character: 45
   end_position:
-    bytes: 1095
-    line: 41
+    bytes: 1192
+    line: 43
     character: 45
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1095
-    line: 42
+    bytes: 1192
+    line: 44
     character: 1
   end_position:
-    bytes: 1096
-    line: 42
+    bytes: 1193
+    line: 44
     character: 1
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1096
-    line: 43
+    bytes: 1193
+    line: 45
     character: 1
   end_position:
-    bytes: 1101
-    line: 43
+    bytes: 1198
+    line: 45
     character: 6
   token_type:
     type: Symbol
     symbol: local
 - start_position:
-    bytes: 1101
-    line: 43
+    bytes: 1198
+    line: 45
     character: 6
   end_position:
-    bytes: 1102
-    line: 43
+    bytes: 1199
+    line: 45
     character: 7
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1102
-    line: 43
+    bytes: 1199
+    line: 45
     character: 7
   end_position:
-    bytes: 1106
-    line: 43
+    bytes: 1203
+    line: 45
     character: 11
   token_type:
     type: Identifier
     identifier: _fn3
 - start_position:
-    bytes: 1106
-    line: 43
+    bytes: 1203
+    line: 45
     character: 11
   end_position:
-    bytes: 1107
-    line: 43
+    bytes: 1204
+    line: 45
     character: 12
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1107
-    line: 43
+    bytes: 1204
+    line: 45
     character: 12
   end_position:
-    bytes: 1108
-    line: 43
+    bytes: 1205
+    line: 45
     character: 13
   token_type:
     type: Symbol
     symbol: "="
 - start_position:
-    bytes: 1108
-    line: 43
+    bytes: 1205
+    line: 45
     character: 13
   end_position:
-    bytes: 1109
-    line: 43
+    bytes: 1206
+    line: 45
     character: 14
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1109
-    line: 43
+    bytes: 1206
+    line: 45
     character: 14
   end_position:
-    bytes: 1117
-    line: 43
+    bytes: 1214
+    line: 45
     character: 22
   token_type:
     type: Symbol
     symbol: function
 - start_position:
-    bytes: 1117
-    line: 43
+    bytes: 1214
+    line: 45
     character: 22
   end_position:
-    bytes: 1118
-    line: 43
+    bytes: 1215
+    line: 45
     character: 23
   token_type:
     type: Symbol
     symbol: (
 - start_position:
-    bytes: 1118
-    line: 43
+    bytes: 1215
+    line: 45
     character: 23
   end_position:
-    bytes: 1119
-    line: 43
+    bytes: 1216
+    line: 45
     character: 24
   token_type:
     type: Symbol
     symbol: )
 - start_position:
-    bytes: 1119
-    line: 43
+    bytes: 1216
+    line: 45
     character: 24
   end_position:
-    bytes: 1120
-    line: 43
+    bytes: 1217
+    line: 45
     character: 25
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1120
-    line: 43
+    bytes: 1217
+    line: 45
     character: 25
   end_position:
-    bytes: 1121
-    line: 43
+    bytes: 1218
+    line: 45
     character: 26
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1121
-    line: 43
+    bytes: 1218
+    line: 45
     character: 26
   end_position:
-    bytes: 1127
-    line: 43
+    bytes: 1224
+    line: 45
     character: 32
   token_type:
     type: Identifier
     identifier: number
 - start_position:
-    bytes: 1127
-    line: 43
+    bytes: 1224
+    line: 45
     character: 32
   end_position:
-    bytes: 1128
-    line: 43
+    bytes: 1225
+    line: 45
     character: 33
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1128
-    line: 43
+    bytes: 1225
+    line: 45
     character: 33
   end_position:
-    bytes: 1129
-    line: 43
+    bytes: 1226
+    line: 45
     character: 34
   token_type:
     type: Symbol
     symbol: "|"
 - start_position:
-    bytes: 1129
-    line: 43
+    bytes: 1226
+    line: 45
     character: 34
   end_position:
-    bytes: 1130
-    line: 43
+    bytes: 1227
+    line: 45
     character: 35
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1130
-    line: 43
+    bytes: 1227
+    line: 45
     character: 35
   end_position:
-    bytes: 1133
-    line: 43
+    bytes: 1230
+    line: 45
     character: 38
   token_type:
     type: Symbol
     symbol: nil
 - start_position:
-    bytes: 1133
-    line: 43
+    bytes: 1230
+    line: 45
     character: 38
   end_position:
-    bytes: 1134
-    line: 43
+    bytes: 1231
+    line: 45
     character: 38
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1134
-    line: 44
+    bytes: 1231
+    line: 46
     character: 1
   end_position:
-    bytes: 1135
-    line: 44
+    bytes: 1232
+    line: 46
     character: 2
   token_type:
     type: Whitespace
     characters: "\t"
 - start_position:
-    bytes: 1135
-    line: 44
+    bytes: 1232
+    line: 46
     character: 2
   end_position:
-    bytes: 1141
-    line: 44
+    bytes: 1238
+    line: 46
     character: 8
   token_type:
     type: Symbol
     symbol: return
 - start_position:
-    bytes: 1141
-    line: 44
+    bytes: 1238
+    line: 46
     character: 8
   end_position:
-    bytes: 1142
-    line: 44
+    bytes: 1239
+    line: 46
     character: 9
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1142
-    line: 44
+    bytes: 1239
+    line: 46
     character: 9
   end_position:
-    bytes: 1143
-    line: 44
+    bytes: 1240
+    line: 46
     character: 10
   token_type:
     type: Number
     text: "3"
 - start_position:
-    bytes: 1143
-    line: 44
+    bytes: 1240
+    line: 46
     character: 10
   end_position:
-    bytes: 1144
-    line: 44
+    bytes: 1241
+    line: 46
     character: 10
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1144
-    line: 45
+    bytes: 1241
+    line: 47
     character: 1
   end_position:
-    bytes: 1147
-    line: 45
+    bytes: 1244
+    line: 47
     character: 4
   token_type:
     type: Symbol
     symbol: end
 - start_position:
-    bytes: 1147
-    line: 45
+    bytes: 1244
+    line: 47
     character: 4
   end_position:
-    bytes: 1148
-    line: 45
+    bytes: 1245
+    line: 47
     character: 4
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1148
-    line: 46
+    bytes: 1245
+    line: 48
     character: 1
   end_position:
-    bytes: 1149
-    line: 46
+    bytes: 1246
+    line: 48
     character: 1
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1149
-    line: 47
+    bytes: 1246
+    line: 49
     character: 1
   end_position:
-    bytes: 1154
-    line: 47
+    bytes: 1251
+    line: 49
     character: 6
   token_type:
     type: Symbol
     symbol: local
 - start_position:
-    bytes: 1154
-    line: 47
+    bytes: 1251
+    line: 49
     character: 6
   end_position:
-    bytes: 1155
-    line: 47
+    bytes: 1252
+    line: 49
     character: 7
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1155
-    line: 47
+    bytes: 1252
+    line: 49
     character: 7
   end_position:
-    bytes: 1163
-    line: 47
+    bytes: 1260
+    line: 49
     character: 15
   token_type:
     type: Symbol
     symbol: function
 - start_position:
-    bytes: 1163
-    line: 47
+    bytes: 1260
+    line: 49
     character: 15
   end_position:
-    bytes: 1164
-    line: 47
+    bytes: 1261
+    line: 49
     character: 16
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1164
-    line: 47
+    bytes: 1261
+    line: 49
     character: 16
   end_position:
-    bytes: 1171
-    line: 47
+    bytes: 1268
+    line: 49
     character: 23
   token_type:
     type: Identifier
     identifier: _concat
 - start_position:
-    bytes: 1171
-    line: 47
+    bytes: 1268
+    line: 49
     character: 23
   end_position:
-    bytes: 1172
-    line: 47
+    bytes: 1269
+    line: 49
     character: 24
   token_type:
     type: Symbol
     symbol: "<"
 - start_position:
-    bytes: 1172
-    line: 47
+    bytes: 1269
+    line: 49
     character: 24
   end_position:
-    bytes: 1173
-    line: 47
+    bytes: 1270
+    line: 49
     character: 25
   token_type:
     type: Identifier
     identifier: T
 - start_position:
-    bytes: 1173
-    line: 47
+    bytes: 1270
+    line: 49
     character: 25
   end_position:
-    bytes: 1174
-    line: 47
+    bytes: 1271
+    line: 49
     character: 26
   token_type:
     type: Symbol
     symbol: ","
 - start_position:
-    bytes: 1174
-    line: 47
+    bytes: 1271
+    line: 49
     character: 26
   end_position:
-    bytes: 1175
-    line: 47
+    bytes: 1272
+    line: 49
     character: 27
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1175
-    line: 47
+    bytes: 1272
+    line: 49
     character: 27
   end_position:
-    bytes: 1176
-    line: 47
+    bytes: 1273
+    line: 49
     character: 28
   token_type:
     type: Identifier
     identifier: S
 - start_position:
-    bytes: 1176
-    line: 47
+    bytes: 1273
+    line: 49
     character: 28
   end_position:
-    bytes: 1177
-    line: 47
+    bytes: 1274
+    line: 49
     character: 29
   token_type:
     type: Symbol
     symbol: ">"
 - start_position:
-    bytes: 1177
-    line: 47
+    bytes: 1274
+    line: 49
     character: 29
   end_position:
-    bytes: 1178
-    line: 47
+    bytes: 1275
+    line: 49
     character: 30
   token_type:
     type: Symbol
     symbol: (
 - start_position:
-    bytes: 1178
-    line: 47
+    bytes: 1275
+    line: 49
     character: 30
   end_position:
-    bytes: 1184
-    line: 47
+    bytes: 1281
+    line: 49
     character: 36
   token_type:
     type: Identifier
     identifier: source
 - start_position:
-    bytes: 1184
-    line: 47
+    bytes: 1281
+    line: 49
     character: 36
   end_position:
-    bytes: 1185
-    line: 47
+    bytes: 1282
+    line: 49
     character: 37
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1185
-    line: 47
+    bytes: 1282
+    line: 49
     character: 37
   end_position:
-    bytes: 1186
-    line: 47
+    bytes: 1283
+    line: 49
     character: 38
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1186
-    line: 47
+    bytes: 1283
+    line: 49
     character: 38
   end_position:
-    bytes: 1191
-    line: 47
+    bytes: 1288
+    line: 49
     character: 43
   token_type:
     type: Identifier
     identifier: Array
 - start_position:
-    bytes: 1191
-    line: 47
+    bytes: 1288
+    line: 49
     character: 43
   end_position:
-    bytes: 1192
-    line: 47
+    bytes: 1289
+    line: 49
     character: 44
   token_type:
     type: Symbol
     symbol: "<"
 - start_position:
-    bytes: 1192
-    line: 47
+    bytes: 1289
+    line: 49
     character: 44
   end_position:
-    bytes: 1193
-    line: 47
+    bytes: 1290
+    line: 49
     character: 45
   token_type:
     type: Identifier
     identifier: T
 - start_position:
-    bytes: 1193
-    line: 47
+    bytes: 1290
+    line: 49
     character: 45
   end_position:
-    bytes: 1194
-    line: 47
+    bytes: 1291
+    line: 49
     character: 46
   token_type:
     type: Symbol
     symbol: ">"
 - start_position:
-    bytes: 1194
-    line: 47
+    bytes: 1291
+    line: 49
     character: 46
   end_position:
-    bytes: 1195
-    line: 47
+    bytes: 1292
+    line: 49
     character: 47
   token_type:
     type: Symbol
     symbol: ","
 - start_position:
-    bytes: 1195
-    line: 47
+    bytes: 1292
+    line: 49
     character: 47
   end_position:
-    bytes: 1196
-    line: 47
+    bytes: 1293
+    line: 49
     character: 48
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1196
-    line: 47
+    bytes: 1293
+    line: 49
     character: 48
   end_position:
-    bytes: 1199
-    line: 47
+    bytes: 1296
+    line: 49
     character: 51
   token_type:
     type: Symbol
     symbol: "..."
 - start_position:
-    bytes: 1199
-    line: 47
+    bytes: 1296
+    line: 49
     character: 51
   end_position:
-    bytes: 1200
-    line: 47
+    bytes: 1297
+    line: 49
     character: 52
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1200
-    line: 47
+    bytes: 1297
+    line: 49
     character: 52
   end_position:
-    bytes: 1201
-    line: 47
+    bytes: 1298
+    line: 49
     character: 53
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1201
-    line: 47
+    bytes: 1298
+    line: 49
     character: 53
   end_position:
-    bytes: 1206
-    line: 47
+    bytes: 1303
+    line: 49
     character: 58
   token_type:
     type: Identifier
     identifier: Array
 - start_position:
-    bytes: 1206
-    line: 47
+    bytes: 1303
+    line: 49
     character: 58
   end_position:
-    bytes: 1207
-    line: 47
+    bytes: 1304
+    line: 49
     character: 59
   token_type:
     type: Symbol
     symbol: "<"
 - start_position:
-    bytes: 1207
-    line: 47
+    bytes: 1304
+    line: 49
     character: 59
   end_position:
-    bytes: 1208
-    line: 47
+    bytes: 1305
+    line: 49
     character: 60
   token_type:
     type: Identifier
     identifier: S
 - start_position:
-    bytes: 1208
-    line: 47
+    bytes: 1305
+    line: 49
     character: 60
   end_position:
-    bytes: 1209
-    line: 47
+    bytes: 1306
+    line: 49
     character: 61
   token_type:
     type: Symbol
     symbol: ">"
 - start_position:
-    bytes: 1209
-    line: 47
+    bytes: 1306
+    line: 49
     character: 61
   end_position:
-    bytes: 1210
-    line: 47
+    bytes: 1307
+    line: 49
     character: 62
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1210
-    line: 47
+    bytes: 1307
+    line: 49
     character: 62
   end_position:
-    bytes: 1211
-    line: 47
+    bytes: 1308
+    line: 49
     character: 63
   token_type:
     type: Symbol
     symbol: "|"
 - start_position:
-    bytes: 1211
-    line: 47
+    bytes: 1308
+    line: 49
     character: 63
   end_position:
-    bytes: 1212
-    line: 47
+    bytes: 1309
+    line: 49
     character: 64
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1212
-    line: 47
+    bytes: 1309
+    line: 49
     character: 64
   end_position:
-    bytes: 1213
-    line: 47
+    bytes: 1310
+    line: 49
     character: 65
   token_type:
     type: Identifier
     identifier: S
 - start_position:
-    bytes: 1213
-    line: 47
+    bytes: 1310
+    line: 49
     character: 65
   end_position:
-    bytes: 1214
-    line: 47
+    bytes: 1311
+    line: 49
     character: 66
   token_type:
     type: Symbol
     symbol: )
 - start_position:
-    bytes: 1214
-    line: 47
+    bytes: 1311
+    line: 49
     character: 66
   end_position:
-    bytes: 1215
-    line: 47
+    bytes: 1312
+    line: 49
     character: 67
   token_type:
     type: Symbol
     symbol: ":"
 - start_position:
-    bytes: 1215
-    line: 47
+    bytes: 1312
+    line: 49
     character: 67
   end_position:
-    bytes: 1216
-    line: 47
+    bytes: 1313
+    line: 49
     character: 68
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1216
-    line: 47
+    bytes: 1313
+    line: 49
     character: 68
   end_position:
-    bytes: 1221
-    line: 47
+    bytes: 1318
+    line: 49
     character: 73
   token_type:
     type: Identifier
     identifier: Array
 - start_position:
-    bytes: 1221
-    line: 47
+    bytes: 1318
+    line: 49
     character: 73
   end_position:
-    bytes: 1222
-    line: 47
+    bytes: 1319
+    line: 49
     character: 74
   token_type:
     type: Symbol
     symbol: "<"
 - start_position:
-    bytes: 1222
-    line: 47
+    bytes: 1319
+    line: 49
     character: 74
   end_position:
-    bytes: 1223
-    line: 47
+    bytes: 1320
+    line: 49
     character: 75
   token_type:
     type: Identifier
     identifier: T
 - start_position:
-    bytes: 1223
-    line: 47
+    bytes: 1320
+    line: 49
     character: 75
   end_position:
-    bytes: 1224
-    line: 47
+    bytes: 1321
+    line: 49
     character: 76
   token_type:
     type: Symbol
     symbol: ">"
 - start_position:
-    bytes: 1224
-    line: 47
+    bytes: 1321
+    line: 49
     character: 76
   end_position:
-    bytes: 1225
-    line: 47
+    bytes: 1322
+    line: 49
     character: 77
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1225
-    line: 47
+    bytes: 1322
+    line: 49
     character: 77
   end_position:
-    bytes: 1226
-    line: 47
+    bytes: 1323
+    line: 49
     character: 78
   token_type:
     type: Symbol
     symbol: "&"
 - start_position:
-    bytes: 1226
-    line: 47
+    bytes: 1323
+    line: 49
     character: 78
   end_position:
-    bytes: 1227
-    line: 47
+    bytes: 1324
+    line: 49
     character: 79
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1227
-    line: 47
+    bytes: 1324
+    line: 49
     character: 79
   end_position:
-    bytes: 1232
-    line: 47
+    bytes: 1329
+    line: 49
     character: 84
   token_type:
     type: Identifier
     identifier: Array
 - start_position:
-    bytes: 1232
-    line: 47
+    bytes: 1329
+    line: 49
     character: 84
   end_position:
-    bytes: 1233
-    line: 47
+    bytes: 1330
+    line: 49
     character: 85
   token_type:
     type: Symbol
     symbol: "<"
 - start_position:
-    bytes: 1233
-    line: 47
+    bytes: 1330
+    line: 49
     character: 85
   end_position:
-    bytes: 1234
-    line: 47
+    bytes: 1331
+    line: 49
     character: 86
   token_type:
     type: Identifier
     identifier: S
 - start_position:
-    bytes: 1234
-    line: 47
+    bytes: 1331
+    line: 49
     character: 86
   end_position:
-    bytes: 1235
-    line: 47
+    bytes: 1332
+    line: 49
     character: 87
   token_type:
     type: Symbol
     symbol: ">"
 - start_position:
-    bytes: 1235
-    line: 47
+    bytes: 1332
+    line: 49
     character: 87
   end_position:
-    bytes: 1236
-    line: 47
+    bytes: 1333
+    line: 49
     character: 87
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1236
-    line: 48
+    bytes: 1333
+    line: 50
     character: 1
   end_position:
-    bytes: 1240
-    line: 48
+    bytes: 1337
+    line: 50
     character: 5
   token_type:
     type: Whitespace
     characters: "    "
 - start_position:
-    bytes: 1240
-    line: 48
+    bytes: 1337
+    line: 50
     character: 5
   end_position:
-    bytes: 1246
-    line: 48
+    bytes: 1343
+    line: 50
     character: 11
   token_type:
     type: Symbol
     symbol: return
 - start_position:
-    bytes: 1246
-    line: 48
+    bytes: 1343
+    line: 50
     character: 11
   end_position:
-    bytes: 1247
-    line: 48
+    bytes: 1344
+    line: 50
     character: 12
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1247
-    line: 48
+    bytes: 1344
+    line: 50
     character: 12
   end_position:
-    bytes: 1248
-    line: 48
+    bytes: 1345
+    line: 50
     character: 13
   token_type:
     type: Symbol
     symbol: (
 - start_position:
-    bytes: 1248
-    line: 48
+    bytes: 1345
+    line: 50
     character: 13
   end_position:
-    bytes: 1254
-    line: 48
+    bytes: 1351
+    line: 50
     character: 19
   token_type:
     type: Identifier
     identifier: source
 - start_position:
-    bytes: 1254
-    line: 48
+    bytes: 1351
+    line: 50
     character: 19
   end_position:
-    bytes: 1255
-    line: 48
+    bytes: 1352
+    line: 50
     character: 20
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1255
-    line: 48
+    bytes: 1352
+    line: 50
     character: 20
   end_position:
-    bytes: 1257
-    line: 48
+    bytes: 1354
+    line: 50
     character: 22
   token_type:
     type: Symbol
     symbol: "::"
 - start_position:
-    bytes: 1257
-    line: 48
+    bytes: 1354
+    line: 50
     character: 22
   end_position:
-    bytes: 1258
-    line: 48
+    bytes: 1355
+    line: 50
     character: 23
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1258
-    line: 48
+    bytes: 1355
+    line: 50
     character: 23
   end_position:
-    bytes: 1261
-    line: 48
+    bytes: 1358
+    line: 50
     character: 26
   token_type:
     type: Identifier
     identifier: any
 - start_position:
-    bytes: 1261
-    line: 48
+    bytes: 1358
+    line: 50
     character: 26
   end_position:
-    bytes: 1262
-    line: 48
+    bytes: 1359
+    line: 50
     character: 27
   token_type:
     type: Symbol
     symbol: )
 - start_position:
-    bytes: 1262
-    line: 48
+    bytes: 1359
+    line: 50
     character: 27
   end_position:
-    bytes: 1263
-    line: 48
+    bytes: 1360
+    line: 50
     character: 28
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1263
-    line: 48
+    bytes: 1360
+    line: 50
     character: 28
   end_position:
-    bytes: 1265
-    line: 48
+    bytes: 1362
+    line: 50
     character: 30
   token_type:
     type: Symbol
     symbol: "::"
 - start_position:
-    bytes: 1265
-    line: 48
+    bytes: 1362
+    line: 50
     character: 30
   end_position:
-    bytes: 1266
-    line: 48
+    bytes: 1363
+    line: 50
     character: 31
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1266
-    line: 48
+    bytes: 1363
+    line: 50
     character: 31
   end_position:
-    bytes: 1271
-    line: 48
+    bytes: 1368
+    line: 50
     character: 36
   token_type:
     type: Identifier
     identifier: Array
 - start_position:
-    bytes: 1271
-    line: 48
+    bytes: 1368
+    line: 50
     character: 36
   end_position:
-    bytes: 1272
-    line: 48
+    bytes: 1369
+    line: 50
     character: 37
   token_type:
     type: Symbol
     symbol: "<"
 - start_position:
-    bytes: 1272
-    line: 48
+    bytes: 1369
+    line: 50
     character: 37
   end_position:
-    bytes: 1273
-    line: 48
+    bytes: 1370
+    line: 50
     character: 38
   token_type:
     type: Identifier
     identifier: S
 - start_position:
-    bytes: 1273
-    line: 48
+    bytes: 1370
+    line: 50
     character: 38
   end_position:
-    bytes: 1274
-    line: 48
+    bytes: 1371
+    line: 50
     character: 39
   token_type:
     type: Symbol
     symbol: ">"
 - start_position:
-    bytes: 1274
-    line: 48
+    bytes: 1371
+    line: 50
     character: 39
   end_position:
-    bytes: 1275
-    line: 48
+    bytes: 1372
+    line: 50
     character: 40
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1275
-    line: 48
+    bytes: 1372
+    line: 50
     character: 40
   end_position:
-    bytes: 1276
-    line: 48
+    bytes: 1373
+    line: 50
     character: 41
   token_type:
     type: Symbol
     symbol: "&"
 - start_position:
-    bytes: 1276
-    line: 48
+    bytes: 1373
+    line: 50
     character: 41
   end_position:
-    bytes: 1277
-    line: 48
+    bytes: 1374
+    line: 50
     character: 42
   token_type:
     type: Whitespace
     characters: " "
 - start_position:
-    bytes: 1277
-    line: 48
+    bytes: 1374
+    line: 50
     character: 42
   end_position:
-    bytes: 1282
-    line: 48
+    bytes: 1379
+    line: 50
     character: 47
   token_type:
     type: Identifier
     identifier: Array
 - start_position:
-    bytes: 1282
-    line: 48
+    bytes: 1379
+    line: 50
     character: 47
   end_position:
-    bytes: 1283
-    line: 48
+    bytes: 1380
+    line: 50
     character: 48
   token_type:
     type: Symbol
     symbol: "<"
 - start_position:
-    bytes: 1283
-    line: 48
+    bytes: 1380
+    line: 50
     character: 48
   end_position:
-    bytes: 1284
-    line: 48
+    bytes: 1381
+    line: 50
     character: 49
   token_type:
     type: Identifier
     identifier: T
 - start_position:
-    bytes: 1284
-    line: 48
+    bytes: 1381
+    line: 50
     character: 49
   end_position:
-    bytes: 1285
-    line: 48
+    bytes: 1382
+    line: 50
     character: 50
   token_type:
     type: Symbol
     symbol: ">"
 - start_position:
-    bytes: 1285
-    line: 48
+    bytes: 1382
+    line: 50
     character: 50
   end_position:
-    bytes: 1286
-    line: 48
+    bytes: 1383
+    line: 50
     character: 50
   token_type:
     type: Whitespace
     characters: "\n"
 - start_position:
-    bytes: 1286
-    line: 49
+    bytes: 1383
+    line: 51
     character: 1
   end_position:
-    bytes: 1289
-    line: 49
+    bytes: 1386
+    line: 51
     character: 4
   token_type:
     type: Symbol
     symbol: end
 - start_position:
-    bytes: 1289
-    line: 49
+    bytes: 1386
+    line: 51
     character: 4
   end_position:
-    bytes: 1289
-    line: 49
+    bytes: 1386
+    line: 51
     character: 4
   token_type:
     type: Eof
-

--- a/full-moon/tests/roblox_cases/pass/types_compound_precedence/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_compound_precedence/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/types_compound_precedence
 ---
 stmts:
   - - TypeDeclaration:
@@ -229,86 +230,88 @@ stmts:
                   trailing_trivia: []
                 type_info:
                   Intersection:
-                    left:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 169
-                            line: 4
-                            character: 21
-                          end_position:
-                            bytes: 175
-                            line: 4
-                            character: 27
-                          token_type:
-                            type: Identifier
-                            identifier: string
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 175
-                              line: 4
-                              character: 27
-                            end_position:
-                              bytes: 176
-                              line: 4
-                              character: 28
-                            token_type:
-                              type: Whitespace
-                              characters: " "
-                    ampersand:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 176
-                          line: 4
-                          character: 28
-                        end_position:
-                          bytes: 177
-                          line: 4
-                          character: 29
-                        token_type:
-                          type: Symbol
-                          symbol: "&"
-                      trailing_trivia:
-                        - start_position:
-                            bytes: 177
-                            line: 4
-                            character: 29
-                          end_position:
-                            bytes: 178
-                            line: 4
-                            character: 30
-                          token_type:
-                            type: Whitespace
-                            characters: " "
-                    right:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 178
-                            line: 4
-                            character: 30
-                          end_position:
-                            bytes: 179
-                            line: 4
-                            character: 31
-                          token_type:
-                            type: Identifier
-                            identifier: T
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 179
-                              line: 4
-                              character: 31
-                            end_position:
-                              bytes: 180
-                              line: 4
-                              character: 31
-                            token_type:
-                              type: Whitespace
-                              characters: "\n"
+                    leading: ~
+                    types:
+                      pairs:
+                        - Punctuated:
+                            - Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 169
+                                    line: 4
+                                    character: 21
+                                  end_position:
+                                    bytes: 175
+                                    line: 4
+                                    character: 27
+                                  token_type:
+                                    type: Identifier
+                                    identifier: string
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 175
+                                      line: 4
+                                      character: 27
+                                    end_position:
+                                      bytes: 176
+                                      line: 4
+                                      character: 28
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                            - leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 176
+                                  line: 4
+                                  character: 28
+                                end_position:
+                                  bytes: 177
+                                  line: 4
+                                  character: 29
+                                token_type:
+                                  type: Symbol
+                                  symbol: "&"
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 177
+                                    line: 4
+                                    character: 29
+                                  end_position:
+                                    bytes: 178
+                                    line: 4
+                                    character: 30
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                        - End:
+                            Basic:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 178
+                                  line: 4
+                                  character: 30
+                                end_position:
+                                  bytes: 179
+                                  line: 4
+                                  character: 31
+                                token_type:
+                                  type: Identifier
+                                  identifier: T
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 179
+                                    line: 4
+                                    character: 31
+                                  end_position:
+                                    bytes: 180
+                                    line: 4
+                                    character: 31
+                                  token_type:
+                                    type: Whitespace
+                                    characters: "\n"
     - ~
   - - TypeDeclaration:
         type_token:
@@ -491,173 +494,174 @@ stmts:
                 characters: " "
         declare_as:
           Intersection:
-            left:
-              Callback:
-                generics: ~
-                parentheses:
-                  tokens:
+            leading: ~
+            types:
+              pairs:
+                - Punctuated:
+                    - Callback:
+                        generics: ~
+                        parentheses:
+                          tokens:
+                            - leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 296
+                                  line: 7
+                                  character: 18
+                                end_position:
+                                  bytes: 297
+                                  line: 7
+                                  character: 19
+                                token_type:
+                                  type: Symbol
+                                  symbol: (
+                              trailing_trivia: []
+                            - leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 297
+                                  line: 7
+                                  character: 19
+                                end_position:
+                                  bytes: 298
+                                  line: 7
+                                  character: 20
+                                token_type:
+                                  type: Symbol
+                                  symbol: )
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 298
+                                    line: 7
+                                    character: 20
+                                  end_position:
+                                    bytes: 299
+                                    line: 7
+                                    character: 21
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                        arguments:
+                          pairs: []
+                        arrow:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 299
+                              line: 7
+                              character: 21
+                            end_position:
+                              bytes: 301
+                              line: 7
+                              character: 23
+                            token_type:
+                              type: Symbol
+                              symbol: "->"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 301
+                                line: 7
+                                character: 23
+                              end_position:
+                                bytes: 302
+                                line: 7
+                                character: 24
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                        return_type:
+                          GenericPack:
+                            name:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 302
+                                  line: 7
+                                  character: 24
+                                end_position:
+                                  bytes: 303
+                                  line: 7
+                                  character: 25
+                                token_type:
+                                  type: Identifier
+                                  identifier: U
+                              trailing_trivia: []
+                            ellipsis:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 303
+                                  line: 7
+                                  character: 25
+                                end_position:
+                                  bytes: 306
+                                  line: 7
+                                  character: 28
+                                token_type:
+                                  type: Symbol
+                                  symbol: "..."
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 306
+                                    line: 7
+                                    character: 28
+                                  end_position:
+                                    bytes: 307
+                                    line: 7
+                                    character: 29
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
                     - leading_trivia: []
                       token:
                         start_position:
-                          bytes: 296
+                          bytes: 307
                           line: 7
-                          character: 18
+                          character: 29
                         end_position:
-                          bytes: 297
+                          bytes: 308
                           line: 7
-                          character: 19
+                          character: 30
                         token_type:
                           type: Symbol
-                          symbol: (
-                      trailing_trivia: []
-                    - leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 297
-                          line: 7
-                          character: 19
-                        end_position:
-                          bytes: 298
-                          line: 7
-                          character: 20
-                        token_type:
-                          type: Symbol
-                          symbol: )
+                          symbol: "&"
                       trailing_trivia:
                         - start_position:
-                            bytes: 298
+                            bytes: 308
                             line: 7
-                            character: 20
+                            character: 30
                           end_position:
-                            bytes: 299
+                            bytes: 309
                             line: 7
-                            character: 21
+                            character: 31
                           token_type:
                             type: Whitespace
                             characters: " "
-                arguments:
-                  pairs: []
-                arrow:
-                  leading_trivia: []
-                  token:
-                    start_position:
-                      bytes: 299
-                      line: 7
-                      character: 21
-                    end_position:
-                      bytes: 301
-                      line: 7
-                      character: 23
-                    token_type:
-                      type: Symbol
-                      symbol: "->"
-                  trailing_trivia:
-                    - start_position:
-                        bytes: 301
-                        line: 7
-                        character: 23
-                      end_position:
-                        bytes: 302
-                        line: 7
-                        character: 24
-                      token_type:
-                        type: Whitespace
-                        characters: " "
-                return_type:
-                  GenericPack:
-                    name:
+                - End:
+                    Basic:
                       leading_trivia: []
                       token:
                         start_position:
-                          bytes: 302
+                          bytes: 309
                           line: 7
-                          character: 24
+                          character: 31
                         end_position:
-                          bytes: 303
+                          bytes: 310
                           line: 7
-                          character: 25
+                          character: 32
                         token_type:
                           type: Identifier
-                          identifier: U
-                      trailing_trivia: []
-                    ellipsis:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 303
-                          line: 7
-                          character: 25
-                        end_position:
-                          bytes: 306
-                          line: 7
-                          character: 28
-                        token_type:
-                          type: Symbol
-                          symbol: "..."
+                          identifier: T
                       trailing_trivia:
                         - start_position:
-                            bytes: 306
+                            bytes: 310
                             line: 7
-                            character: 28
+                            character: 32
                           end_position:
-                            bytes: 307
+                            bytes: 311
                             line: 7
-                            character: 29
+                            character: 32
                           token_type:
                             type: Whitespace
-                            characters: " "
-            ampersand:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 307
-                  line: 7
-                  character: 29
-                end_position:
-                  bytes: 308
-                  line: 7
-                  character: 30
-                token_type:
-                  type: Symbol
-                  symbol: "&"
-              trailing_trivia:
-                - start_position:
-                    bytes: 308
-                    line: 7
-                    character: 30
-                  end_position:
-                    bytes: 309
-                    line: 7
-                    character: 31
-                  token_type:
-                    type: Whitespace
-                    characters: " "
-            right:
-              Basic:
-                leading_trivia: []
-                token:
-                  start_position:
-                    bytes: 309
-                    line: 7
-                    character: 31
-                  end_position:
-                    bytes: 310
-                    line: 7
-                    character: 32
-                  token_type:
-                    type: Identifier
-                    identifier: T
-                trailing_trivia:
-                  - start_position:
-                      bytes: 310
-                      line: 7
-                      character: 32
-                    end_position:
-                      bytes: 311
-                      line: 7
-                      character: 32
-                    token_type:
-                      type: Whitespace
-                      characters: "\n"
+                            characters: "\n"
     - ~
-

--- a/full-moon/tests/roblox_cases/pass/types_indexable/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_indexable/ast.snap
@@ -1,6 +1,8 @@
 ---
 source: full-moon/tests/pass_cases.rs
+assertion_line: 48
 expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/types_indexable
 ---
 stmts:
   - - LocalAssignment:
@@ -538,118 +540,120 @@ stmts:
                     characters: " "
             type_info:
               Union:
-                left:
-                  Module:
-                    module:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 77
-                          line: 3
-                          character: 10
-                        end_position:
-                          bytes: 83
-                          line: 3
-                          character: 16
-                        token_type:
-                          type: Identifier
-                          identifier: module
-                      trailing_trivia: []
-                    punctuation:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 83
-                          line: 3
-                          character: 16
-                        end_position:
-                          bytes: 84
-                          line: 3
-                          character: 17
-                        token_type:
-                          type: Symbol
-                          symbol: "."
-                      trailing_trivia: []
-                    type_info:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 84
-                            line: 3
-                            character: 17
-                          end_position:
-                            bytes: 87
-                            line: 3
-                            character: 20
-                          token_type:
-                            type: Identifier
-                            identifier: Foo
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 87
-                              line: 3
-                              character: 20
-                            end_position:
+                leading: ~
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Module:
+                            module:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 77
+                                  line: 3
+                                  character: 10
+                                end_position:
+                                  bytes: 83
+                                  line: 3
+                                  character: 16
+                                token_type:
+                                  type: Identifier
+                                  identifier: module
+                              trailing_trivia: []
+                            punctuation:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 83
+                                  line: 3
+                                  character: 16
+                                end_position:
+                                  bytes: 84
+                                  line: 3
+                                  character: 17
+                                token_type:
+                                  type: Symbol
+                                  symbol: "."
+                              trailing_trivia: []
+                            type_info:
+                              Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 84
+                                    line: 3
+                                    character: 17
+                                  end_position:
+                                    bytes: 87
+                                    line: 3
+                                    character: 20
+                                  token_type:
+                                    type: Identifier
+                                    identifier: Foo
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 87
+                                      line: 3
+                                      character: 20
+                                    end_position:
+                                      bytes: 88
+                                      line: 3
+                                      character: 21
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
                               bytes: 88
                               line: 3
                               character: 21
+                            end_position:
+                              bytes: 89
+                              line: 3
+                              character: 22
                             token_type:
-                              type: Whitespace
-                              characters: " "
-                pipe:
-                  leading_trivia: []
-                  token:
-                    start_position:
-                      bytes: 88
-                      line: 3
-                      character: 21
-                    end_position:
-                      bytes: 89
-                      line: 3
-                      character: 22
-                    token_type:
-                      type: Symbol
-                      symbol: "|"
-                  trailing_trivia:
-                    - start_position:
-                        bytes: 89
-                        line: 3
-                        character: 22
-                      end_position:
-                        bytes: 90
-                        line: 3
-                        character: 23
-                      token_type:
-                        type: Whitespace
-                        characters: " "
-                right:
-                  Basic:
-                    leading_trivia: []
-                    token:
-                      start_position:
-                        bytes: 90
-                        line: 3
-                        character: 23
-                      end_position:
-                        bytes: 96
-                        line: 3
-                        character: 29
-                      token_type:
-                        type: Identifier
-                        identifier: string
-                    trailing_trivia:
-                      - start_position:
-                          bytes: 96
-                          line: 3
-                          character: 29
-                        end_position:
-                          bytes: 97
-                          line: 3
-                          character: 30
-                        token_type:
-                          type: Whitespace
-                          characters: " "
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 89
+                                line: 3
+                                character: 22
+                              end_position:
+                                bytes: 90
+                                line: 3
+                                character: 23
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 90
+                              line: 3
+                              character: 23
+                            end_position:
+                              bytes: 96
+                              line: 3
+                              character: 29
+                            token_type:
+                              type: Identifier
+                              identifier: string
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 96
+                                line: 3
+                                character: 29
+                              end_position:
+                                bytes: 97
+                                line: 3
+                                character: 30
+                              token_type:
+                                type: Whitespace
+                                characters: " "
         name_list:
           pairs:
             - End:
@@ -1168,4 +1172,3 @@ stmts:
                       symbol: nil
                   trailing_trivia: []
     - ~
-

--- a/full-moon/tests/roblox_cases/pass/types_parentheses/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_parentheses/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/types_parentheses
 ---
 stmts:
   - - TypeDeclaration:
@@ -1014,192 +1015,194 @@ stmts:
                   characters: " "
           declare_as:
             Union:
-              left:
-                Tuple:
-                  parentheses:
-                    tokens:
-                      - leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 162
-                            line: 9
-                            character: 24
-                          end_position:
-                            bytes: 163
-                            line: 9
-                            character: 25
-                          token_type:
-                            type: Symbol
-                            symbol: (
-                        trailing_trivia: []
-                      - leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 170
-                            line: 9
-                            character: 32
-                          end_position:
-                            bytes: 171
-                            line: 9
-                            character: 33
-                          token_type:
-                            type: Symbol
-                            symbol: )
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 171
-                              line: 9
-                              character: 33
-                            end_position:
-                              bytes: 172
-                              line: 9
-                              character: 34
-                            token_type:
-                              type: Whitespace
-                              characters: " "
-                  types:
-                    pairs:
-                      - End:
-                          Callback:
-                            generics: ~
-                            parentheses:
-                              tokens:
-                                - leading_trivia: []
-                                  token:
-                                    start_position:
-                                      bytes: 163
-                                      line: 9
-                                      character: 25
-                                    end_position:
-                                      bytes: 164
-                                      line: 9
-                                      character: 26
-                                    token_type:
-                                      type: Symbol
-                                      symbol: (
-                                  trailing_trivia: []
-                                - leading_trivia: []
-                                  token:
-                                    start_position:
-                                      bytes: 164
-                                      line: 9
-                                      character: 26
-                                    end_position:
-                                      bytes: 165
-                                      line: 9
-                                      character: 27
-                                    token_type:
-                                      type: Symbol
-                                      symbol: )
-                                  trailing_trivia:
-                                    - start_position:
-                                        bytes: 165
-                                        line: 9
-                                        character: 27
-                                      end_position:
-                                        bytes: 166
-                                        line: 9
-                                        character: 28
-                                      token_type:
-                                        type: Whitespace
-                                        characters: " "
-                            arguments:
-                              pairs: []
-                            arrow:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 166
-                                  line: 9
-                                  character: 28
-                                end_position:
-                                  bytes: 168
-                                  line: 9
-                                  character: 30
-                                token_type:
-                                  type: Symbol
-                                  symbol: "->"
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 168
-                                    line: 9
-                                    character: 30
-                                  end_position:
-                                    bytes: 169
-                                    line: 9
-                                    character: 31
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                            return_type:
-                              Basic:
-                                leading_trivia: []
+              leading: ~
+              types:
+                pairs:
+                  - Punctuated:
+                      - Tuple:
+                          parentheses:
+                            tokens:
+                              - leading_trivia: []
                                 token:
                                   start_position:
-                                    bytes: 169
+                                    bytes: 162
                                     line: 9
-                                    character: 31
+                                    character: 24
                                   end_position:
+                                    bytes: 163
+                                    line: 9
+                                    character: 25
+                                  token_type:
+                                    type: Symbol
+                                    symbol: (
+                                trailing_trivia: []
+                              - leading_trivia: []
+                                token:
+                                  start_position:
                                     bytes: 170
                                     line: 9
                                     character: 32
+                                  end_position:
+                                    bytes: 171
+                                    line: 9
+                                    character: 33
                                   token_type:
-                                    type: Identifier
-                                    identifier: T
-                                trailing_trivia: []
-              pipe:
-                leading_trivia: []
-                token:
-                  start_position:
-                    bytes: 172
-                    line: 9
-                    character: 34
-                  end_position:
-                    bytes: 173
-                    line: 9
-                    character: 35
-                  token_type:
-                    type: Symbol
-                    symbol: "|"
-                trailing_trivia:
-                  - start_position:
-                      bytes: 173
-                      line: 9
-                      character: 35
-                    end_position:
-                      bytes: 174
-                      line: 9
-                      character: 36
-                    token_type:
-                      type: Whitespace
-                      characters: " "
-              right:
-                Basic:
-                  leading_trivia: []
-                  token:
-                    start_position:
-                      bytes: 174
-                      line: 9
-                      character: 36
-                    end_position:
-                      bytes: 175
-                      line: 9
-                      character: 37
-                    token_type:
-                      type: Identifier
-                      identifier: T
-                  trailing_trivia:
-                    - start_position:
-                        bytes: 175
-                        line: 9
-                        character: 37
-                      end_position:
-                        bytes: 176
-                        line: 9
-                        character: 37
-                      token_type:
-                        type: Whitespace
-                        characters: "\n"
+                                    type: Symbol
+                                    symbol: )
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 171
+                                      line: 9
+                                      character: 33
+                                    end_position:
+                                      bytes: 172
+                                      line: 9
+                                      character: 34
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                          types:
+                            pairs:
+                              - End:
+                                  Callback:
+                                    generics: ~
+                                    parentheses:
+                                      tokens:
+                                        - leading_trivia: []
+                                          token:
+                                            start_position:
+                                              bytes: 163
+                                              line: 9
+                                              character: 25
+                                            end_position:
+                                              bytes: 164
+                                              line: 9
+                                              character: 26
+                                            token_type:
+                                              type: Symbol
+                                              symbol: (
+                                          trailing_trivia: []
+                                        - leading_trivia: []
+                                          token:
+                                            start_position:
+                                              bytes: 164
+                                              line: 9
+                                              character: 26
+                                            end_position:
+                                              bytes: 165
+                                              line: 9
+                                              character: 27
+                                            token_type:
+                                              type: Symbol
+                                              symbol: )
+                                          trailing_trivia:
+                                            - start_position:
+                                                bytes: 165
+                                                line: 9
+                                                character: 27
+                                              end_position:
+                                                bytes: 166
+                                                line: 9
+                                                character: 28
+                                              token_type:
+                                                type: Whitespace
+                                                characters: " "
+                                    arguments:
+                                      pairs: []
+                                    arrow:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 166
+                                          line: 9
+                                          character: 28
+                                        end_position:
+                                          bytes: 168
+                                          line: 9
+                                          character: 30
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "->"
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 168
+                                            line: 9
+                                            character: 30
+                                          end_position:
+                                            bytes: 169
+                                            line: 9
+                                            character: 31
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                    return_type:
+                                      Basic:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 169
+                                            line: 9
+                                            character: 31
+                                          end_position:
+                                            bytes: 170
+                                            line: 9
+                                            character: 32
+                                          token_type:
+                                            type: Identifier
+                                            identifier: T
+                                        trailing_trivia: []
+                      - leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 172
+                            line: 9
+                            character: 34
+                          end_position:
+                            bytes: 173
+                            line: 9
+                            character: 35
+                          token_type:
+                            type: Symbol
+                            symbol: "|"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 173
+                              line: 9
+                              character: 35
+                            end_position:
+                              bytes: 174
+                              line: 9
+                              character: 36
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                  - End:
+                      Basic:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 174
+                            line: 9
+                            character: 36
+                          end_position:
+                            bytes: 175
+                            line: 9
+                            character: 37
+                          token_type:
+                            type: Identifier
+                            identifier: T
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 175
+                              line: 9
+                              character: 37
+                            end_position:
+                              bytes: 176
+                              line: 9
+                              character: 37
+                            token_type:
+                              type: Whitespace
+                              characters: "\n"
     - ~
   - - ExportedTypeDeclaration:
         export_token:
@@ -1550,328 +1553,330 @@ stmts:
                               - Punctuated:
                                   - name: ~
                                     type_info:
-                                      Optional:
-                                        base:
-                                          Union:
-                                            left:
-                                              Optional:
-                                                base:
-                                                  Tuple:
-                                                    parentheses:
-                                                      tokens:
-                                                        - leading_trivia:
-                                                            - start_position:
-                                                                bytes: 223
-                                                                line: 13
-                                                                character: 1
-                                                              end_position:
-                                                                bytes: 239
-                                                                line: 13
-                                                                character: 17
-                                                              token_type:
-                                                                type: Whitespace
-                                                                characters: "                "
-                                                          token:
-                                                            start_position:
-                                                              bytes: 239
-                                                              line: 13
-                                                              character: 17
-                                                            end_position:
-                                                              bytes: 240
-                                                              line: 13
-                                                              character: 18
-                                                            token_type:
-                                                              type: Symbol
-                                                              symbol: (
-                                                          trailing_trivia: []
-                                                        - leading_trivia: []
-                                                          token:
-                                                            start_position:
-                                                              bytes: 248
-                                                              line: 13
-                                                              character: 26
-                                                            end_position:
-                                                              bytes: 249
-                                                              line: 13
-                                                              character: 27
-                                                            token_type:
-                                                              type: Symbol
-                                                              symbol: )
-                                                          trailing_trivia: []
-                                                    types:
-                                                      pairs:
-                                                        - End:
-                                                            Callback:
-                                                              generics: ~
-                                                              parentheses:
-                                                                tokens:
-                                                                  - leading_trivia: []
+                                      Union:
+                                        leading: ~
+                                        types:
+                                          pairs:
+                                            - Punctuated:
+                                                - Optional:
+                                                    base:
+                                                      Tuple:
+                                                        parentheses:
+                                                          tokens:
+                                                            - leading_trivia:
+                                                                - start_position:
+                                                                    bytes: 223
+                                                                    line: 13
+                                                                    character: 1
+                                                                  end_position:
+                                                                    bytes: 239
+                                                                    line: 13
+                                                                    character: 17
+                                                                  token_type:
+                                                                    type: Whitespace
+                                                                    characters: "                "
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 239
+                                                                  line: 13
+                                                                  character: 17
+                                                                end_position:
+                                                                  bytes: 240
+                                                                  line: 13
+                                                                  character: 18
+                                                                token_type:
+                                                                  type: Symbol
+                                                                  symbol: (
+                                                              trailing_trivia: []
+                                                            - leading_trivia: []
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 248
+                                                                  line: 13
+                                                                  character: 26
+                                                                end_position:
+                                                                  bytes: 249
+                                                                  line: 13
+                                                                  character: 27
+                                                                token_type:
+                                                                  type: Symbol
+                                                                  symbol: )
+                                                              trailing_trivia: []
+                                                        types:
+                                                          pairs:
+                                                            - End:
+                                                                Callback:
+                                                                  generics: ~
+                                                                  parentheses:
+                                                                    tokens:
+                                                                      - leading_trivia: []
+                                                                        token:
+                                                                          start_position:
+                                                                            bytes: 240
+                                                                            line: 13
+                                                                            character: 18
+                                                                          end_position:
+                                                                            bytes: 241
+                                                                            line: 13
+                                                                            character: 19
+                                                                          token_type:
+                                                                            type: Symbol
+                                                                            symbol: (
+                                                                        trailing_trivia: []
+                                                                      - leading_trivia: []
+                                                                        token:
+                                                                          start_position:
+                                                                            bytes: 242
+                                                                            line: 13
+                                                                            character: 20
+                                                                          end_position:
+                                                                            bytes: 243
+                                                                            line: 13
+                                                                            character: 21
+                                                                          token_type:
+                                                                            type: Symbol
+                                                                            symbol: )
+                                                                        trailing_trivia:
+                                                                          - start_position:
+                                                                              bytes: 243
+                                                                              line: 13
+                                                                              character: 21
+                                                                            end_position:
+                                                                              bytes: 244
+                                                                              line: 13
+                                                                              character: 22
+                                                                            token_type:
+                                                                              type: Whitespace
+                                                                              characters: " "
+                                                                  arguments:
+                                                                    pairs:
+                                                                      - End:
+                                                                          name: ~
+                                                                          type_info:
+                                                                            Basic:
+                                                                              leading_trivia: []
+                                                                              token:
+                                                                                start_position:
+                                                                                  bytes: 241
+                                                                                  line: 13
+                                                                                  character: 19
+                                                                                end_position:
+                                                                                  bytes: 242
+                                                                                  line: 13
+                                                                                  character: 20
+                                                                                token_type:
+                                                                                  type: Identifier
+                                                                                  identifier: T
+                                                                              trailing_trivia: []
+                                                                  arrow:
+                                                                    leading_trivia: []
                                                                     token:
                                                                       start_position:
-                                                                        bytes: 240
+                                                                        bytes: 244
                                                                         line: 13
-                                                                        character: 18
+                                                                        character: 22
                                                                       end_position:
-                                                                        bytes: 241
+                                                                        bytes: 246
                                                                         line: 13
-                                                                        character: 19
+                                                                        character: 24
                                                                       token_type:
                                                                         type: Symbol
-                                                                        symbol: (
-                                                                    trailing_trivia: []
-                                                                  - leading_trivia: []
-                                                                    token:
-                                                                      start_position:
-                                                                        bytes: 242
-                                                                        line: 13
-                                                                        character: 20
-                                                                      end_position:
-                                                                        bytes: 243
-                                                                        line: 13
-                                                                        character: 21
-                                                                      token_type:
-                                                                        type: Symbol
-                                                                        symbol: )
+                                                                        symbol: "->"
                                                                     trailing_trivia:
                                                                       - start_position:
-                                                                          bytes: 243
+                                                                          bytes: 246
                                                                           line: 13
-                                                                          character: 21
+                                                                          character: 24
                                                                         end_position:
-                                                                          bytes: 244
+                                                                          bytes: 247
                                                                           line: 13
-                                                                          character: 22
+                                                                          character: 25
                                                                         token_type:
                                                                           type: Whitespace
                                                                           characters: " "
-                                                              arguments:
-                                                                pairs:
-                                                                  - End:
-                                                                      name: ~
-                                                                      type_info:
+                                                                  return_type:
+                                                                    Basic:
+                                                                      leading_trivia: []
+                                                                      token:
+                                                                        start_position:
+                                                                          bytes: 247
+                                                                          line: 13
+                                                                          character: 25
+                                                                        end_position:
+                                                                          bytes: 248
+                                                                          line: 13
+                                                                          character: 26
+                                                                        token_type:
+                                                                          type: Identifier
+                                                                          identifier: T
+                                                                      trailing_trivia: []
+                                                    question_mark:
+                                                      leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 249
+                                                          line: 13
+                                                          character: 27
+                                                        end_position:
+                                                          bytes: 250
+                                                          line: 13
+                                                          character: 28
+                                                        token_type:
+                                                          type: Symbol
+                                                          symbol: "?"
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 250
+                                                            line: 13
+                                                            character: 28
+                                                          end_position:
+                                                            bytes: 251
+                                                            line: 13
+                                                            character: 29
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                - leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 251
+                                                      line: 13
+                                                      character: 29
+                                                    end_position:
+                                                      bytes: 252
+                                                      line: 13
+                                                      character: 30
+                                                    token_type:
+                                                      type: Symbol
+                                                      symbol: "|"
+                                                  trailing_trivia:
+                                                    - start_position:
+                                                        bytes: 252
+                                                        line: 13
+                                                        character: 30
+                                                      end_position:
+                                                        bytes: 253
+                                                        line: 13
+                                                        character: 31
+                                                      token_type:
+                                                        type: Whitespace
+                                                        characters: " "
+                                            - End:
+                                                Optional:
+                                                  base:
+                                                    Tuple:
+                                                      parentheses:
+                                                        tokens:
+                                                          - leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 253
+                                                                line: 13
+                                                                character: 31
+                                                              end_position:
+                                                                bytes: 254
+                                                                line: 13
+                                                                character: 32
+                                                              token_type:
+                                                                type: Symbol
+                                                                symbol: (
+                                                            trailing_trivia: []
+                                                          - leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 268
+                                                                line: 13
+                                                                character: 46
+                                                              end_position:
+                                                                bytes: 269
+                                                                line: 13
+                                                                character: 47
+                                                              token_type:
+                                                                type: Symbol
+                                                                symbol: )
+                                                            trailing_trivia: []
+                                                      types:
+                                                        pairs:
+                                                          - End:
+                                                              Generic:
+                                                                base:
+                                                                  leading_trivia: []
+                                                                  token:
+                                                                    start_position:
+                                                                      bytes: 254
+                                                                      line: 13
+                                                                      character: 32
+                                                                    end_position:
+                                                                      bytes: 265
+                                                                      line: 13
+                                                                      character: 43
+                                                                    token_type:
+                                                                      type: Identifier
+                                                                      identifier: PromiseLike
+                                                                  trailing_trivia: []
+                                                                arrows:
+                                                                  tokens:
+                                                                    - leading_trivia: []
+                                                                      token:
+                                                                        start_position:
+                                                                          bytes: 265
+                                                                          line: 13
+                                                                          character: 43
+                                                                        end_position:
+                                                                          bytes: 266
+                                                                          line: 13
+                                                                          character: 44
+                                                                        token_type:
+                                                                          type: Symbol
+                                                                          symbol: "<"
+                                                                      trailing_trivia: []
+                                                                    - leading_trivia: []
+                                                                      token:
+                                                                        start_position:
+                                                                          bytes: 267
+                                                                          line: 13
+                                                                          character: 45
+                                                                        end_position:
+                                                                          bytes: 268
+                                                                          line: 13
+                                                                          character: 46
+                                                                        token_type:
+                                                                          type: Symbol
+                                                                          symbol: ">"
+                                                                      trailing_trivia: []
+                                                                generics:
+                                                                  pairs:
+                                                                    - End:
                                                                         Basic:
                                                                           leading_trivia: []
                                                                           token:
                                                                             start_position:
-                                                                              bytes: 241
+                                                                              bytes: 266
                                                                               line: 13
-                                                                              character: 19
+                                                                              character: 44
                                                                             end_position:
-                                                                              bytes: 242
+                                                                              bytes: 267
                                                                               line: 13
-                                                                              character: 20
+                                                                              character: 45
                                                                             token_type:
                                                                               type: Identifier
                                                                               identifier: T
                                                                           trailing_trivia: []
-                                                              arrow:
-                                                                leading_trivia: []
-                                                                token:
-                                                                  start_position:
-                                                                    bytes: 244
-                                                                    line: 13
-                                                                    character: 22
-                                                                  end_position:
-                                                                    bytes: 246
-                                                                    line: 13
-                                                                    character: 24
-                                                                  token_type:
-                                                                    type: Symbol
-                                                                    symbol: "->"
-                                                                trailing_trivia:
-                                                                  - start_position:
-                                                                      bytes: 246
-                                                                      line: 13
-                                                                      character: 24
-                                                                    end_position:
-                                                                      bytes: 247
-                                                                      line: 13
-                                                                      character: 25
-                                                                    token_type:
-                                                                      type: Whitespace
-                                                                      characters: " "
-                                                              return_type:
-                                                                Basic:
-                                                                  leading_trivia: []
-                                                                  token:
-                                                                    start_position:
-                                                                      bytes: 247
-                                                                      line: 13
-                                                                      character: 25
-                                                                    end_position:
-                                                                      bytes: 248
-                                                                      line: 13
-                                                                      character: 26
-                                                                    token_type:
-                                                                      type: Identifier
-                                                                      identifier: T
-                                                                  trailing_trivia: []
-                                                question_mark:
-                                                  leading_trivia: []
-                                                  token:
-                                                    start_position:
-                                                      bytes: 249
-                                                      line: 13
-                                                      character: 27
-                                                    end_position:
-                                                      bytes: 250
-                                                      line: 13
-                                                      character: 28
-                                                    token_type:
-                                                      type: Symbol
-                                                      symbol: "?"
-                                                  trailing_trivia:
-                                                    - start_position:
-                                                        bytes: 250
+                                                  question_mark:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 269
                                                         line: 13
-                                                        character: 28
+                                                        character: 47
                                                       end_position:
-                                                        bytes: 251
+                                                        bytes: 270
                                                         line: 13
-                                                        character: 29
+                                                        character: 48
                                                       token_type:
-                                                        type: Whitespace
-                                                        characters: " "
-                                            pipe:
-                                              leading_trivia: []
-                                              token:
-                                                start_position:
-                                                  bytes: 251
-                                                  line: 13
-                                                  character: 29
-                                                end_position:
-                                                  bytes: 252
-                                                  line: 13
-                                                  character: 30
-                                                token_type:
-                                                  type: Symbol
-                                                  symbol: "|"
-                                              trailing_trivia:
-                                                - start_position:
-                                                    bytes: 252
-                                                    line: 13
-                                                    character: 30
-                                                  end_position:
-                                                    bytes: 253
-                                                    line: 13
-                                                    character: 31
-                                                  token_type:
-                                                    type: Whitespace
-                                                    characters: " "
-                                            right:
-                                              Tuple:
-                                                parentheses:
-                                                  tokens:
-                                                    - leading_trivia: []
-                                                      token:
-                                                        start_position:
-                                                          bytes: 253
-                                                          line: 13
-                                                          character: 31
-                                                        end_position:
-                                                          bytes: 254
-                                                          line: 13
-                                                          character: 32
-                                                        token_type:
-                                                          type: Symbol
-                                                          symbol: (
-                                                      trailing_trivia: []
-                                                    - leading_trivia: []
-                                                      token:
-                                                        start_position:
-                                                          bytes: 268
-                                                          line: 13
-                                                          character: 46
-                                                        end_position:
-                                                          bytes: 269
-                                                          line: 13
-                                                          character: 47
-                                                        token_type:
-                                                          type: Symbol
-                                                          symbol: )
-                                                      trailing_trivia: []
-                                                types:
-                                                  pairs:
-                                                    - End:
-                                                        Generic:
-                                                          base:
-                                                            leading_trivia: []
-                                                            token:
-                                                              start_position:
-                                                                bytes: 254
-                                                                line: 13
-                                                                character: 32
-                                                              end_position:
-                                                                bytes: 265
-                                                                line: 13
-                                                                character: 43
-                                                              token_type:
-                                                                type: Identifier
-                                                                identifier: PromiseLike
-                                                            trailing_trivia: []
-                                                          arrows:
-                                                            tokens:
-                                                              - leading_trivia: []
-                                                                token:
-                                                                  start_position:
-                                                                    bytes: 265
-                                                                    line: 13
-                                                                    character: 43
-                                                                  end_position:
-                                                                    bytes: 266
-                                                                    line: 13
-                                                                    character: 44
-                                                                  token_type:
-                                                                    type: Symbol
-                                                                    symbol: "<"
-                                                                trailing_trivia: []
-                                                              - leading_trivia: []
-                                                                token:
-                                                                  start_position:
-                                                                    bytes: 267
-                                                                    line: 13
-                                                                    character: 45
-                                                                  end_position:
-                                                                    bytes: 268
-                                                                    line: 13
-                                                                    character: 46
-                                                                  token_type:
-                                                                    type: Symbol
-                                                                    symbol: ">"
-                                                                trailing_trivia: []
-                                                          generics:
-                                                            pairs:
-                                                              - End:
-                                                                  Basic:
-                                                                    leading_trivia: []
-                                                                    token:
-                                                                      start_position:
-                                                                        bytes: 266
-                                                                        line: 13
-                                                                        character: 44
-                                                                      end_position:
-                                                                        bytes: 267
-                                                                        line: 13
-                                                                        character: 45
-                                                                      token_type:
-                                                                        type: Identifier
-                                                                        identifier: T
-                                                                    trailing_trivia: []
-                                        question_mark:
-                                          leading_trivia: []
-                                          token:
-                                            start_position:
-                                              bytes: 269
-                                              line: 13
-                                              character: 47
-                                            end_position:
-                                              bytes: 270
-                                              line: 13
-                                              character: 48
-                                            token_type:
-                                              type: Symbol
-                                              symbol: "?"
-                                          trailing_trivia: []
+                                                        type: Symbol
+                                                        symbol: "?"
+                                                    trailing_trivia: []
                                   - leading_trivia: []
                                     token:
                                       start_position:
@@ -1970,232 +1975,234 @@ stmts:
                                             pairs:
                                               - End:
                                                   Union:
-                                                    left:
-                                                      Callback:
-                                                        generics: ~
-                                                        parentheses:
-                                                          tokens:
-                                                            - leading_trivia: []
-                                                              token:
-                                                                start_position:
-                                                                  bytes: 300
-                                                                  line: 14
-                                                                  character: 18
-                                                                end_position:
-                                                                  bytes: 301
-                                                                  line: 14
-                                                                  character: 19
-                                                                token_type:
-                                                                  type: Symbol
-                                                                  symbol: (
-                                                              trailing_trivia: []
-                                                            - leading_trivia: []
-                                                              token:
-                                                                start_position:
-                                                                  bytes: 304
-                                                                  line: 14
-                                                                  character: 22
-                                                                end_position:
-                                                                  bytes: 305
-                                                                  line: 14
-                                                                  character: 23
-                                                                token_type:
-                                                                  type: Symbol
-                                                                  symbol: )
-                                                              trailing_trivia:
-                                                                - start_position:
-                                                                    bytes: 305
-                                                                    line: 14
-                                                                    character: 23
-                                                                  end_position:
-                                                                    bytes: 306
-                                                                    line: 14
-                                                                    character: 24
-                                                                  token_type:
-                                                                    type: Whitespace
-                                                                    characters: " "
-                                                        arguments:
-                                                          pairs:
-                                                            - End:
-                                                                name: ~
-                                                                type_info:
-                                                                  Basic:
-                                                                    leading_trivia: []
-                                                                    token:
-                                                                      start_position:
-                                                                        bytes: 301
-                                                                        line: 14
-                                                                        character: 19
-                                                                      end_position:
-                                                                        bytes: 304
-                                                                        line: 14
-                                                                        character: 22
-                                                                      token_type:
-                                                                        type: Identifier
-                                                                        identifier: any
-                                                                    trailing_trivia: []
-                                                        arrow:
-                                                          leading_trivia: []
-                                                          token:
-                                                            start_position:
-                                                              bytes: 306
-                                                              line: 14
-                                                              character: 24
-                                                            end_position:
-                                                              bytes: 308
-                                                              line: 14
-                                                              character: 26
-                                                            token_type:
-                                                              type: Symbol
-                                                              symbol: "->"
-                                                          trailing_trivia:
-                                                            - start_position:
-                                                                bytes: 308
-                                                                line: 14
-                                                                character: 26
-                                                              end_position:
-                                                                bytes: 309
-                                                                line: 14
-                                                                character: 27
-                                                              token_type:
-                                                                type: Whitespace
-                                                                characters: " "
-                                                        return_type:
-                                                          Tuple:
-                                                            parentheses:
-                                                              tokens:
-                                                                - leading_trivia: []
-                                                                  token:
-                                                                    start_position:
-                                                                      bytes: 309
-                                                                      line: 14
-                                                                      character: 27
-                                                                    end_position:
-                                                                      bytes: 310
-                                                                      line: 14
-                                                                      character: 28
-                                                                    token_type:
-                                                                      type: Symbol
-                                                                      symbol: (
-                                                                  trailing_trivia: []
-                                                                - leading_trivia: []
-                                                                  token:
-                                                                    start_position:
-                                                                      bytes: 310
-                                                                      line: 14
-                                                                      character: 28
-                                                                    end_position:
-                                                                      bytes: 311
-                                                                      line: 14
-                                                                      character: 29
-                                                                    token_type:
-                                                                      type: Symbol
-                                                                      symbol: )
-                                                                  trailing_trivia:
-                                                                    - start_position:
-                                                                        bytes: 311
-                                                                        line: 14
-                                                                        character: 29
-                                                                      end_position:
-                                                                        bytes: 312
-                                                                        line: 14
-                                                                        character: 30
-                                                                      token_type:
-                                                                        type: Whitespace
-                                                                        characters: " "
-                                                            types:
-                                                              pairs: []
-                                                    pipe:
-                                                      leading_trivia: []
-                                                      token:
-                                                        start_position:
-                                                          bytes: 312
-                                                          line: 14
-                                                          character: 30
-                                                        end_position:
-                                                          bytes: 313
-                                                          line: 14
-                                                          character: 31
-                                                        token_type:
-                                                          type: Symbol
-                                                          symbol: "|"
-                                                      trailing_trivia:
-                                                        - start_position:
-                                                            bytes: 313
-                                                            line: 14
-                                                            character: 31
-                                                          end_position:
-                                                            bytes: 314
-                                                            line: 14
-                                                            character: 32
-                                                          token_type:
-                                                            type: Whitespace
-                                                            characters: " "
-                                                    right:
-                                                      Generic:
-                                                        base:
-                                                          leading_trivia: []
-                                                          token:
-                                                            start_position:
-                                                              bytes: 314
-                                                              line: 14
-                                                              character: 32
-                                                            end_position:
-                                                              bytes: 325
-                                                              line: 14
-                                                              character: 43
-                                                            token_type:
-                                                              type: Identifier
-                                                              identifier: PromiseLike
-                                                          trailing_trivia: []
-                                                        arrows:
-                                                          tokens:
-                                                            - leading_trivia: []
-                                                              token:
-                                                                start_position:
-                                                                  bytes: 325
-                                                                  line: 14
-                                                                  character: 43
-                                                                end_position:
-                                                                  bytes: 326
-                                                                  line: 14
-                                                                  character: 44
-                                                                token_type:
-                                                                  type: Symbol
-                                                                  symbol: "<"
-                                                              trailing_trivia: []
-                                                            - leading_trivia: []
-                                                              token:
-                                                                start_position:
-                                                                  bytes: 327
-                                                                  line: 14
-                                                                  character: 45
-                                                                end_position:
-                                                                  bytes: 328
-                                                                  line: 14
-                                                                  character: 46
-                                                                token_type:
-                                                                  type: Symbol
-                                                                  symbol: ">"
-                                                              trailing_trivia: []
-                                                        generics:
-                                                          pairs:
-                                                            - End:
-                                                                Basic:
+                                                    leading: ~
+                                                    types:
+                                                      pairs:
+                                                        - Punctuated:
+                                                            - Callback:
+                                                                generics: ~
+                                                                parentheses:
+                                                                  tokens:
+                                                                    - leading_trivia: []
+                                                                      token:
+                                                                        start_position:
+                                                                          bytes: 300
+                                                                          line: 14
+                                                                          character: 18
+                                                                        end_position:
+                                                                          bytes: 301
+                                                                          line: 14
+                                                                          character: 19
+                                                                        token_type:
+                                                                          type: Symbol
+                                                                          symbol: (
+                                                                      trailing_trivia: []
+                                                                    - leading_trivia: []
+                                                                      token:
+                                                                        start_position:
+                                                                          bytes: 304
+                                                                          line: 14
+                                                                          character: 22
+                                                                        end_position:
+                                                                          bytes: 305
+                                                                          line: 14
+                                                                          character: 23
+                                                                        token_type:
+                                                                          type: Symbol
+                                                                          symbol: )
+                                                                      trailing_trivia:
+                                                                        - start_position:
+                                                                            bytes: 305
+                                                                            line: 14
+                                                                            character: 23
+                                                                          end_position:
+                                                                            bytes: 306
+                                                                            line: 14
+                                                                            character: 24
+                                                                          token_type:
+                                                                            type: Whitespace
+                                                                            characters: " "
+                                                                arguments:
+                                                                  pairs:
+                                                                    - End:
+                                                                        name: ~
+                                                                        type_info:
+                                                                          Basic:
+                                                                            leading_trivia: []
+                                                                            token:
+                                                                              start_position:
+                                                                                bytes: 301
+                                                                                line: 14
+                                                                                character: 19
+                                                                              end_position:
+                                                                                bytes: 304
+                                                                                line: 14
+                                                                                character: 22
+                                                                              token_type:
+                                                                                type: Identifier
+                                                                                identifier: any
+                                                                            trailing_trivia: []
+                                                                arrow:
                                                                   leading_trivia: []
                                                                   token:
                                                                     start_position:
-                                                                      bytes: 326
+                                                                      bytes: 306
                                                                       line: 14
-                                                                      character: 44
+                                                                      character: 24
                                                                     end_position:
-                                                                      bytes: 327
+                                                                      bytes: 308
                                                                       line: 14
-                                                                      character: 45
+                                                                      character: 26
                                                                     token_type:
-                                                                      type: Identifier
-                                                                      identifier: T
-                                                                  trailing_trivia: []
+                                                                      type: Symbol
+                                                                      symbol: "->"
+                                                                  trailing_trivia:
+                                                                    - start_position:
+                                                                        bytes: 308
+                                                                        line: 14
+                                                                        character: 26
+                                                                      end_position:
+                                                                        bytes: 309
+                                                                        line: 14
+                                                                        character: 27
+                                                                      token_type:
+                                                                        type: Whitespace
+                                                                        characters: " "
+                                                                return_type:
+                                                                  Tuple:
+                                                                    parentheses:
+                                                                      tokens:
+                                                                        - leading_trivia: []
+                                                                          token:
+                                                                            start_position:
+                                                                              bytes: 309
+                                                                              line: 14
+                                                                              character: 27
+                                                                            end_position:
+                                                                              bytes: 310
+                                                                              line: 14
+                                                                              character: 28
+                                                                            token_type:
+                                                                              type: Symbol
+                                                                              symbol: (
+                                                                          trailing_trivia: []
+                                                                        - leading_trivia: []
+                                                                          token:
+                                                                            start_position:
+                                                                              bytes: 310
+                                                                              line: 14
+                                                                              character: 28
+                                                                            end_position:
+                                                                              bytes: 311
+                                                                              line: 14
+                                                                              character: 29
+                                                                            token_type:
+                                                                              type: Symbol
+                                                                              symbol: )
+                                                                          trailing_trivia:
+                                                                            - start_position:
+                                                                                bytes: 311
+                                                                                line: 14
+                                                                                character: 29
+                                                                              end_position:
+                                                                                bytes: 312
+                                                                                line: 14
+                                                                                character: 30
+                                                                              token_type:
+                                                                                type: Whitespace
+                                                                                characters: " "
+                                                                    types:
+                                                                      pairs: []
+                                                            - leading_trivia: []
+                                                              token:
+                                                                start_position:
+                                                                  bytes: 312
+                                                                  line: 14
+                                                                  character: 30
+                                                                end_position:
+                                                                  bytes: 313
+                                                                  line: 14
+                                                                  character: 31
+                                                                token_type:
+                                                                  type: Symbol
+                                                                  symbol: "|"
+                                                              trailing_trivia:
+                                                                - start_position:
+                                                                    bytes: 313
+                                                                    line: 14
+                                                                    character: 31
+                                                                  end_position:
+                                                                    bytes: 314
+                                                                    line: 14
+                                                                    character: 32
+                                                                  token_type:
+                                                                    type: Whitespace
+                                                                    characters: " "
+                                                        - End:
+                                                            Generic:
+                                                              base:
+                                                                leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 314
+                                                                    line: 14
+                                                                    character: 32
+                                                                  end_position:
+                                                                    bytes: 325
+                                                                    line: 14
+                                                                    character: 43
+                                                                  token_type:
+                                                                    type: Identifier
+                                                                    identifier: PromiseLike
+                                                                trailing_trivia: []
+                                                              arrows:
+                                                                tokens:
+                                                                  - leading_trivia: []
+                                                                    token:
+                                                                      start_position:
+                                                                        bytes: 325
+                                                                        line: 14
+                                                                        character: 43
+                                                                      end_position:
+                                                                        bytes: 326
+                                                                        line: 14
+                                                                        character: 44
+                                                                      token_type:
+                                                                        type: Symbol
+                                                                        symbol: "<"
+                                                                    trailing_trivia: []
+                                                                  - leading_trivia: []
+                                                                    token:
+                                                                      start_position:
+                                                                        bytes: 327
+                                                                        line: 14
+                                                                        character: 45
+                                                                      end_position:
+                                                                        bytes: 328
+                                                                        line: 14
+                                                                        character: 46
+                                                                      token_type:
+                                                                        type: Symbol
+                                                                        symbol: ">"
+                                                                    trailing_trivia: []
+                                                              generics:
+                                                                pairs:
+                                                                  - End:
+                                                                      Basic:
+                                                                        leading_trivia: []
+                                                                        token:
+                                                                          start_position:
+                                                                            bytes: 326
+                                                                            line: 14
+                                                                            character: 44
+                                                                          end_position:
+                                                                            bytes: 327
+                                                                            line: 14
+                                                                            character: 45
+                                                                          token_type:
+                                                                            type: Identifier
+                                                                            identifier: T
+                                                                        trailing_trivia: []
                                       question_mark:
                                         leading_trivia: []
                                         token:
@@ -3211,191 +3218,193 @@ stmts:
                     pairs:
                       - End:
                           Intersection:
-                            left:
-                              Basic:
-                                leading_trivia: []
-                                token:
-                                  start_position:
-                                    bytes: 512
-                                    line: 22
-                                    character: 18
-                                  end_position:
-                                    bytes: 517
-                                    line: 22
-                                    character: 23
-                                  token_type:
-                                    type: Identifier
-                                    identifier: Error
-                                trailing_trivia:
-                                  - start_position:
-                                      bytes: 517
-                                      line: 22
-                                      character: 23
-                                    end_position:
-                                      bytes: 518
-                                      line: 22
-                                      character: 24
-                                    token_type:
-                                      type: Whitespace
-                                      characters: " "
-                            ampersand:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 518
-                                  line: 22
-                                  character: 24
-                                end_position:
-                                  bytes: 519
-                                  line: 22
-                                  character: 25
-                                token_type:
-                                  type: Symbol
-                                  symbol: "&"
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 519
-                                    line: 22
-                                    character: 25
-                                  end_position:
-                                    bytes: 520
-                                    line: 22
-                                    character: 26
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                            right:
-                              Table:
-                                braces:
-                                  tokens:
+                            leading: ~
+                            types:
+                              pairs:
+                                - Punctuated:
+                                    - Basic:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 512
+                                            line: 22
+                                            character: 18
+                                          end_position:
+                                            bytes: 517
+                                            line: 22
+                                            character: 23
+                                          token_type:
+                                            type: Identifier
+                                            identifier: Error
+                                        trailing_trivia:
+                                          - start_position:
+                                              bytes: 517
+                                              line: 22
+                                              character: 23
+                                            end_position:
+                                              bytes: 518
+                                              line: 22
+                                              character: 24
+                                            token_type:
+                                              type: Whitespace
+                                              characters: " "
                                     - leading_trivia: []
                                       token:
                                         start_position:
-                                          bytes: 520
+                                          bytes: 518
                                           line: 22
-                                          character: 26
+                                          character: 24
                                         end_position:
-                                          bytes: 521
+                                          bytes: 519
                                           line: 22
-                                          character: 27
+                                          character: 25
                                         token_type:
                                           type: Symbol
-                                          symbol: "{"
+                                          symbol: "&"
                                       trailing_trivia:
                                         - start_position:
-                                            bytes: 521
+                                            bytes: 519
                                             line: 22
-                                            character: 27
+                                            character: 25
                                           end_position:
-                                            bytes: 522
+                                            bytes: 520
                                             line: 22
-                                            character: 28
+                                            character: 26
                                           token_type:
                                             type: Whitespace
                                             characters: " "
-                                    - leading_trivia: []
-                                      token:
-                                        start_position:
-                                          bytes: 539
-                                          line: 22
-                                          character: 45
-                                        end_position:
-                                          bytes: 540
-                                          line: 22
-                                          character: 46
-                                        token_type:
-                                          type: Symbol
-                                          symbol: "}"
-                                      trailing_trivia: []
-                                fields:
-                                  pairs:
-                                    - End:
-                                        key:
-                                          Name:
-                                            leading_trivia: []
+                                - End:
+                                    Table:
+                                      braces:
+                                        tokens:
+                                          - leading_trivia: []
                                             token:
                                               start_position:
-                                                bytes: 522
+                                                bytes: 520
                                                 line: 22
-                                                character: 28
+                                                character: 26
                                               end_position:
-                                                bytes: 532
+                                                bytes: 521
                                                 line: 22
-                                                character: 38
+                                                character: 27
                                               token_type:
-                                                type: Identifier
-                                                identifier: extensions
+                                                type: Symbol
+                                                symbol: "{"
+                                            trailing_trivia:
+                                              - start_position:
+                                                  bytes: 521
+                                                  line: 22
+                                                  character: 27
+                                                end_position:
+                                                  bytes: 522
+                                                  line: 22
+                                                  character: 28
+                                                token_type:
+                                                  type: Whitespace
+                                                  characters: " "
+                                          - leading_trivia: []
+                                            token:
+                                              start_position:
+                                                bytes: 539
+                                                line: 22
+                                                character: 45
+                                              end_position:
+                                                bytes: 540
+                                                line: 22
+                                                character: 46
+                                              token_type:
+                                                type: Symbol
+                                                symbol: "}"
                                             trailing_trivia: []
-                                        colon:
-                                          leading_trivia: []
-                                          token:
-                                            start_position:
-                                              bytes: 532
-                                              line: 22
-                                              character: 38
-                                            end_position:
-                                              bytes: 533
-                                              line: 22
-                                              character: 39
-                                            token_type:
-                                              type: Symbol
-                                              symbol: ":"
-                                          trailing_trivia:
-                                            - start_position:
-                                                bytes: 533
-                                                line: 22
-                                                character: 39
-                                              end_position:
-                                                bytes: 534
-                                                line: 22
-                                                character: 40
-                                              token_type:
-                                                type: Whitespace
-                                                characters: " "
-                                        value:
-                                          Optional:
-                                            base:
-                                              Basic:
+                                      fields:
+                                        pairs:
+                                          - End:
+                                              key:
+                                                Name:
+                                                  leading_trivia: []
+                                                  token:
+                                                    start_position:
+                                                      bytes: 522
+                                                      line: 22
+                                                      character: 28
+                                                    end_position:
+                                                      bytes: 532
+                                                      line: 22
+                                                      character: 38
+                                                    token_type:
+                                                      type: Identifier
+                                                      identifier: extensions
+                                                  trailing_trivia: []
+                                              colon:
                                                 leading_trivia: []
                                                 token:
                                                   start_position:
-                                                    bytes: 534
+                                                    bytes: 532
                                                     line: 22
-                                                    character: 40
+                                                    character: 38
                                                   end_position:
-                                                    bytes: 537
+                                                    bytes: 533
                                                     line: 22
-                                                    character: 43
+                                                    character: 39
                                                   token_type:
-                                                    type: Identifier
-                                                    identifier: any
-                                                trailing_trivia: []
-                                            question_mark:
-                                              leading_trivia: []
-                                              token:
-                                                start_position:
-                                                  bytes: 537
-                                                  line: 22
-                                                  character: 43
-                                                end_position:
-                                                  bytes: 538
-                                                  line: 22
-                                                  character: 44
-                                                token_type:
-                                                  type: Symbol
-                                                  symbol: "?"
-                                              trailing_trivia:
-                                                - start_position:
-                                                    bytes: 538
-                                                    line: 22
-                                                    character: 44
-                                                  end_position:
-                                                    bytes: 539
-                                                    line: 22
-                                                    character: 45
-                                                  token_type:
-                                                    type: Whitespace
-                                                    characters: " "
+                                                    type: Symbol
+                                                    symbol: ":"
+                                                trailing_trivia:
+                                                  - start_position:
+                                                      bytes: 533
+                                                      line: 22
+                                                      character: 39
+                                                    end_position:
+                                                      bytes: 534
+                                                      line: 22
+                                                      character: 40
+                                                    token_type:
+                                                      type: Whitespace
+                                                      characters: " "
+                                              value:
+                                                Optional:
+                                                  base:
+                                                    Basic:
+                                                      leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 534
+                                                          line: 22
+                                                          character: 40
+                                                        end_position:
+                                                          bytes: 537
+                                                          line: 22
+                                                          character: 43
+                                                        token_type:
+                                                          type: Identifier
+                                                          identifier: any
+                                                      trailing_trivia: []
+                                                  question_mark:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 537
+                                                        line: 22
+                                                        character: 43
+                                                      end_position:
+                                                        bytes: 538
+                                                        line: 22
+                                                        character: 44
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: "?"
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 538
+                                                          line: 22
+                                                          character: 44
+                                                        end_position:
+                                                          bytes: 539
+                                                          line: 22
+                                                          character: 45
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
           return_type:
             punctuation:
               leading_trivia: []
@@ -3793,412 +3802,414 @@ stmts:
                                 pairs:
                                   - End:
                                       Union:
-                                        left:
-                                          Basic:
-                                            leading_trivia: []
-                                            token:
-                                              start_position:
-                                                bytes: 627
-                                                line: 28
-                                                character: 22
-                                              end_position:
-                                                bytes: 633
-                                                line: 28
-                                                character: 28
-                                              token_type:
-                                                type: Identifier
-                                                identifier: string
-                                            trailing_trivia:
-                                              - start_position:
-                                                  bytes: 633
-                                                  line: 28
-                                                  character: 28
-                                                end_position:
-                                                  bytes: 634
-                                                  line: 28
-                                                  character: 29
-                                                token_type:
-                                                  type: Whitespace
-                                                  characters: " "
-                                        pipe:
-                                          leading_trivia: []
-                                          token:
-                                            start_position:
-                                              bytes: 634
-                                              line: 28
-                                              character: 29
-                                            end_position:
-                                              bytes: 635
-                                              line: 28
-                                              character: 30
-                                            token_type:
-                                              type: Symbol
-                                              symbol: "|"
-                                          trailing_trivia:
-                                            - start_position:
-                                                bytes: 635
-                                                line: 28
-                                                character: 30
-                                              end_position:
-                                                bytes: 636
-                                                line: 28
-                                                character: 31
-                                              token_type:
-                                                type: Whitespace
-                                                characters: " "
-                                        right:
-                                          Callback:
-                                            generics: ~
-                                            parentheses:
-                                              tokens:
+                                        leading: ~
+                                        types:
+                                          pairs:
+                                            - Punctuated:
+                                                - Basic:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 627
+                                                        line: 28
+                                                        character: 22
+                                                      end_position:
+                                                        bytes: 633
+                                                        line: 28
+                                                        character: 28
+                                                      token_type:
+                                                        type: Identifier
+                                                        identifier: string
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 633
+                                                          line: 28
+                                                          character: 28
+                                                        end_position:
+                                                          bytes: 634
+                                                          line: 28
+                                                          character: 29
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
                                                 - leading_trivia: []
                                                   token:
                                                     start_position:
-                                                      bytes: 636
+                                                      bytes: 634
                                                       line: 28
-                                                      character: 31
+                                                      character: 29
                                                     end_position:
-                                                      bytes: 637
+                                                      bytes: 635
                                                       line: 28
-                                                      character: 32
+                                                      character: 30
                                                     token_type:
                                                       type: Symbol
-                                                      symbol: (
-                                                  trailing_trivia: []
-                                                - leading_trivia: []
-                                                  token:
-                                                    start_position:
-                                                      bytes: 699
-                                                      line: 28
-                                                      character: 94
-                                                    end_position:
-                                                      bytes: 700
-                                                      line: 28
-                                                      character: 95
-                                                    token_type:
-                                                      type: Symbol
-                                                      symbol: )
+                                                      symbol: "|"
                                                   trailing_trivia:
                                                     - start_position:
-                                                        bytes: 700
+                                                        bytes: 635
                                                         line: 28
-                                                        character: 95
+                                                        character: 30
                                                       end_position:
-                                                        bytes: 701
+                                                        bytes: 636
                                                         line: 28
-                                                        character: 96
+                                                        character: 31
                                                       token_type:
                                                         type: Whitespace
                                                         characters: " "
-                                            arguments:
-                                              pairs:
-                                                - Punctuated:
-                                                    - name: ~
-                                                      type_info:
-                                                        Basic:
-                                                          leading_trivia: []
-                                                          token:
-                                                            start_position:
-                                                              bytes: 637
-                                                              line: 28
-                                                              character: 32
-                                                            end_position:
-                                                              bytes: 648
-                                                              line: 28
-                                                              character: 43
-                                                            token_type:
-                                                              type: Identifier
-                                                              identifier: IProperties
-                                                          trailing_trivia: []
-                                                    - leading_trivia: []
-                                                      token:
-                                                        start_position:
-                                                          bytes: 648
-                                                          line: 28
-                                                          character: 43
-                                                        end_position:
-                                                          bytes: 649
-                                                          line: 28
-                                                          character: 44
-                                                        token_type:
-                                                          type: Symbol
-                                                          symbol: ","
-                                                      trailing_trivia:
-                                                        - start_position:
-                                                            bytes: 649
+                                            - End:
+                                                Callback:
+                                                  generics: ~
+                                                  parentheses:
+                                                    tokens:
+                                                      - leading_trivia: []
+                                                        token:
+                                                          start_position:
+                                                            bytes: 636
                                                             line: 28
-                                                            character: 44
+                                                            character: 31
                                                           end_position:
-                                                            bytes: 650
+                                                            bytes: 637
                                                             line: 28
-                                                            character: 45
+                                                            character: 32
                                                           token_type:
-                                                            type: Whitespace
-                                                            characters: " "
-                                                - Punctuated:
-                                                    - name: ~
-                                                      type_info:
-                                                        Basic:
-                                                          leading_trivia: []
-                                                          token:
-                                                            start_position:
-                                                              bytes: 650
-                                                              line: 28
-                                                              character: 45
-                                                            end_position:
-                                                              bytes: 658
-                                                              line: 28
-                                                              character: 53
-                                                            token_type:
-                                                              type: Identifier
-                                                              identifier: BasePart
-                                                          trailing_trivia: []
-                                                    - leading_trivia: []
-                                                      token:
-                                                        start_position:
-                                                          bytes: 658
-                                                          line: 28
-                                                          character: 53
-                                                        end_position:
-                                                          bytes: 659
-                                                          line: 28
-                                                          character: 54
-                                                        token_type:
-                                                          type: Symbol
-                                                          symbol: ","
-                                                      trailing_trivia:
-                                                        - start_position:
-                                                            bytes: 659
+                                                            type: Symbol
+                                                            symbol: (
+                                                        trailing_trivia: []
+                                                      - leading_trivia: []
+                                                        token:
+                                                          start_position:
+                                                            bytes: 699
                                                             line: 28
-                                                            character: 54
+                                                            character: 94
                                                           end_position:
-                                                            bytes: 660
+                                                            bytes: 700
                                                             line: 28
-                                                            character: 55
+                                                            character: 95
                                                           token_type:
-                                                            type: Whitespace
-                                                            characters: " "
-                                                - Punctuated:
-                                                    - name: ~
-                                                      type_info:
-                                                        Basic:
-                                                          leading_trivia: []
-                                                          token:
-                                                            start_position:
-                                                              bytes: 660
+                                                            type: Symbol
+                                                            symbol: )
+                                                        trailing_trivia:
+                                                          - start_position:
+                                                              bytes: 700
                                                               line: 28
-                                                              character: 55
+                                                              character: 95
                                                             end_position:
-                                                              bytes: 667
+                                                              bytes: 701
                                                               line: 28
-                                                              character: 62
+                                                              character: 96
                                                             token_type:
-                                                              type: Identifier
-                                                              identifier: Vector3
-                                                          trailing_trivia: []
-                                                    - leading_trivia: []
-                                                      token:
-                                                        start_position:
-                                                          bytes: 667
-                                                          line: 28
-                                                          character: 62
-                                                        end_position:
-                                                          bytes: 668
-                                                          line: 28
-                                                          character: 63
-                                                        token_type:
-                                                          type: Symbol
-                                                          symbol: ","
-                                                      trailing_trivia:
-                                                        - start_position:
-                                                            bytes: 668
-                                                            line: 28
-                                                            character: 63
-                                                          end_position:
-                                                            bytes: 669
-                                                            line: 28
-                                                            character: 64
-                                                          token_type:
-                                                            type: Whitespace
-                                                            characters: " "
-                                                - Punctuated:
-                                                    - name: ~
-                                                      type_info:
-                                                        Basic:
-                                                          leading_trivia: []
-                                                          token:
-                                                            start_position:
-                                                              bytes: 669
-                                                              line: 28
-                                                              character: 64
-                                                            end_position:
-                                                              bytes: 676
-                                                              line: 28
-                                                              character: 71
-                                                            token_type:
-                                                              type: Identifier
-                                                              identifier: Vector3
-                                                          trailing_trivia: []
-                                                    - leading_trivia: []
-                                                      token:
-                                                        start_position:
-                                                          bytes: 676
-                                                          line: 28
-                                                          character: 71
-                                                        end_position:
-                                                          bytes: 677
-                                                          line: 28
-                                                          character: 72
-                                                        token_type:
-                                                          type: Symbol
-                                                          symbol: ","
-                                                      trailing_trivia:
-                                                        - start_position:
-                                                            bytes: 677
-                                                            line: 28
-                                                            character: 72
-                                                          end_position:
-                                                            bytes: 678
-                                                            line: 28
-                                                            character: 73
-                                                          token_type:
-                                                            type: Whitespace
-                                                            characters: " "
-                                                - Punctuated:
-                                                    - name: ~
-                                                      type_info:
-                                                        Module:
-                                                          module:
-                                                            leading_trivia: []
+                                                              type: Whitespace
+                                                              characters: " "
+                                                  arguments:
+                                                    pairs:
+                                                      - Punctuated:
+                                                          - name: ~
+                                                            type_info:
+                                                              Basic:
+                                                                leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 637
+                                                                    line: 28
+                                                                    character: 32
+                                                                  end_position:
+                                                                    bytes: 648
+                                                                    line: 28
+                                                                    character: 43
+                                                                  token_type:
+                                                                    type: Identifier
+                                                                    identifier: IProperties
+                                                                trailing_trivia: []
+                                                          - leading_trivia: []
                                                             token:
                                                               start_position:
-                                                                bytes: 678
+                                                                bytes: 648
                                                                 line: 28
-                                                                character: 73
+                                                                character: 43
                                                               end_position:
-                                                                bytes: 682
+                                                                bytes: 649
                                                                 line: 28
-                                                                character: 77
-                                                              token_type:
-                                                                type: Identifier
-                                                                identifier: Enum
-                                                            trailing_trivia: []
-                                                          punctuation:
-                                                            leading_trivia: []
-                                                            token:
-                                                              start_position:
-                                                                bytes: 682
-                                                                line: 28
-                                                                character: 77
-                                                              end_position:
-                                                                bytes: 683
-                                                                line: 28
-                                                                character: 78
+                                                                character: 44
                                                               token_type:
                                                                 type: Symbol
-                                                                symbol: "."
-                                                            trailing_trivia: []
+                                                                symbol: ","
+                                                            trailing_trivia:
+                                                              - start_position:
+                                                                  bytes: 649
+                                                                  line: 28
+                                                                  character: 44
+                                                                end_position:
+                                                                  bytes: 650
+                                                                  line: 28
+                                                                  character: 45
+                                                                token_type:
+                                                                  type: Whitespace
+                                                                  characters: " "
+                                                      - Punctuated:
+                                                          - name: ~
+                                                            type_info:
+                                                              Basic:
+                                                                leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 650
+                                                                    line: 28
+                                                                    character: 45
+                                                                  end_position:
+                                                                    bytes: 658
+                                                                    line: 28
+                                                                    character: 53
+                                                                  token_type:
+                                                                    type: Identifier
+                                                                    identifier: BasePart
+                                                                trailing_trivia: []
+                                                          - leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 658
+                                                                line: 28
+                                                                character: 53
+                                                              end_position:
+                                                                bytes: 659
+                                                                line: 28
+                                                                character: 54
+                                                              token_type:
+                                                                type: Symbol
+                                                                symbol: ","
+                                                            trailing_trivia:
+                                                              - start_position:
+                                                                  bytes: 659
+                                                                  line: 28
+                                                                  character: 54
+                                                                end_position:
+                                                                  bytes: 660
+                                                                  line: 28
+                                                                  character: 55
+                                                                token_type:
+                                                                  type: Whitespace
+                                                                  characters: " "
+                                                      - Punctuated:
+                                                          - name: ~
+                                                            type_info:
+                                                              Basic:
+                                                                leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 660
+                                                                    line: 28
+                                                                    character: 55
+                                                                  end_position:
+                                                                    bytes: 667
+                                                                    line: 28
+                                                                    character: 62
+                                                                  token_type:
+                                                                    type: Identifier
+                                                                    identifier: Vector3
+                                                                trailing_trivia: []
+                                                          - leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 667
+                                                                line: 28
+                                                                character: 62
+                                                              end_position:
+                                                                bytes: 668
+                                                                line: 28
+                                                                character: 63
+                                                              token_type:
+                                                                type: Symbol
+                                                                symbol: ","
+                                                            trailing_trivia:
+                                                              - start_position:
+                                                                  bytes: 668
+                                                                  line: 28
+                                                                  character: 63
+                                                                end_position:
+                                                                  bytes: 669
+                                                                  line: 28
+                                                                  character: 64
+                                                                token_type:
+                                                                  type: Whitespace
+                                                                  characters: " "
+                                                      - Punctuated:
+                                                          - name: ~
+                                                            type_info:
+                                                              Basic:
+                                                                leading_trivia: []
+                                                                token:
+                                                                  start_position:
+                                                                    bytes: 669
+                                                                    line: 28
+                                                                    character: 64
+                                                                  end_position:
+                                                                    bytes: 676
+                                                                    line: 28
+                                                                    character: 71
+                                                                  token_type:
+                                                                    type: Identifier
+                                                                    identifier: Vector3
+                                                                trailing_trivia: []
+                                                          - leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 676
+                                                                line: 28
+                                                                character: 71
+                                                              end_position:
+                                                                bytes: 677
+                                                                line: 28
+                                                                character: 72
+                                                              token_type:
+                                                                type: Symbol
+                                                                symbol: ","
+                                                            trailing_trivia:
+                                                              - start_position:
+                                                                  bytes: 677
+                                                                  line: 28
+                                                                  character: 72
+                                                                end_position:
+                                                                  bytes: 678
+                                                                  line: 28
+                                                                  character: 73
+                                                                token_type:
+                                                                  type: Whitespace
+                                                                  characters: " "
+                                                      - Punctuated:
+                                                          - name: ~
+                                                            type_info:
+                                                              Module:
+                                                                module:
+                                                                  leading_trivia: []
+                                                                  token:
+                                                                    start_position:
+                                                                      bytes: 678
+                                                                      line: 28
+                                                                      character: 73
+                                                                    end_position:
+                                                                      bytes: 682
+                                                                      line: 28
+                                                                      character: 77
+                                                                    token_type:
+                                                                      type: Identifier
+                                                                      identifier: Enum
+                                                                  trailing_trivia: []
+                                                                punctuation:
+                                                                  leading_trivia: []
+                                                                  token:
+                                                                    start_position:
+                                                                      bytes: 682
+                                                                      line: 28
+                                                                      character: 77
+                                                                    end_position:
+                                                                      bytes: 683
+                                                                      line: 28
+                                                                      character: 78
+                                                                    token_type:
+                                                                      type: Symbol
+                                                                      symbol: "."
+                                                                  trailing_trivia: []
+                                                                type_info:
+                                                                  Basic:
+                                                                    leading_trivia: []
+                                                                    token:
+                                                                      start_position:
+                                                                        bytes: 683
+                                                                        line: 28
+                                                                        character: 78
+                                                                      end_position:
+                                                                        bytes: 691
+                                                                        line: 28
+                                                                        character: 86
+                                                                      token_type:
+                                                                        type: Identifier
+                                                                        identifier: Material
+                                                                    trailing_trivia: []
+                                                          - leading_trivia: []
+                                                            token:
+                                                              start_position:
+                                                                bytes: 691
+                                                                line: 28
+                                                                character: 86
+                                                              end_position:
+                                                                bytes: 692
+                                                                line: 28
+                                                                character: 87
+                                                              token_type:
+                                                                type: Symbol
+                                                                symbol: ","
+                                                            trailing_trivia:
+                                                              - start_position:
+                                                                  bytes: 692
+                                                                  line: 28
+                                                                  character: 87
+                                                                end_position:
+                                                                  bytes: 693
+                                                                  line: 28
+                                                                  character: 88
+                                                                token_type:
+                                                                  type: Whitespace
+                                                                  characters: " "
+                                                      - End:
+                                                          name: ~
                                                           type_info:
                                                             Basic:
                                                               leading_trivia: []
                                                               token:
                                                                 start_position:
-                                                                  bytes: 683
+                                                                  bytes: 693
                                                                   line: 28
-                                                                  character: 78
+                                                                  character: 88
                                                                 end_position:
-                                                                  bytes: 691
+                                                                  bytes: 699
                                                                   line: 28
-                                                                  character: 86
+                                                                  character: 94
                                                                 token_type:
                                                                   type: Identifier
-                                                                  identifier: Material
+                                                                  identifier: number
                                                               trailing_trivia: []
-                                                    - leading_trivia: []
+                                                  arrow:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 701
+                                                        line: 28
+                                                        character: 96
+                                                      end_position:
+                                                        bytes: 703
+                                                        line: 28
+                                                        character: 98
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: "->"
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 703
+                                                          line: 28
+                                                          character: 98
+                                                        end_position:
+                                                          bytes: 704
+                                                          line: 28
+                                                          character: 99
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                                  return_type:
+                                                    Basic:
+                                                      leading_trivia: []
                                                       token:
                                                         start_position:
-                                                          bytes: 691
+                                                          bytes: 704
                                                           line: 28
-                                                          character: 86
+                                                          character: 99
                                                         end_position:
-                                                          bytes: 692
+                                                          bytes: 711
                                                           line: 28
-                                                          character: 87
+                                                          character: 106
                                                         token_type:
-                                                          type: Symbol
-                                                          symbol: ","
-                                                      trailing_trivia:
-                                                        - start_position:
-                                                            bytes: 692
-                                                            line: 28
-                                                            character: 87
-                                                          end_position:
-                                                            bytes: 693
-                                                            line: 28
-                                                            character: 88
-                                                          token_type:
-                                                            type: Whitespace
-                                                            characters: " "
-                                                - End:
-                                                    name: ~
-                                                    type_info:
-                                                      Basic:
-                                                        leading_trivia: []
-                                                        token:
-                                                          start_position:
-                                                            bytes: 693
-                                                            line: 28
-                                                            character: 88
-                                                          end_position:
-                                                            bytes: 699
-                                                            line: 28
-                                                            character: 94
-                                                          token_type:
-                                                            type: Identifier
-                                                            identifier: number
-                                                        trailing_trivia: []
-                                            arrow:
-                                              leading_trivia: []
-                                              token:
-                                                start_position:
-                                                  bytes: 701
-                                                  line: 28
-                                                  character: 96
-                                                end_position:
-                                                  bytes: 703
-                                                  line: 28
-                                                  character: 98
-                                                token_type:
-                                                  type: Symbol
-                                                  symbol: "->"
-                                              trailing_trivia:
-                                                - start_position:
-                                                    bytes: 703
-                                                    line: 28
-                                                    character: 98
-                                                  end_position:
-                                                    bytes: 704
-                                                    line: 28
-                                                    character: 99
-                                                  token_type:
-                                                    type: Whitespace
-                                                    characters: " "
-                                            return_type:
-                                              Basic:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 704
-                                                    line: 28
-                                                    character: 99
-                                                  end_position:
-                                                    bytes: 711
-                                                    line: 28
-                                                    character: 106
-                                                  token_type:
-                                                    type: Identifier
-                                                    identifier: boolean
-                                                trailing_trivia: []
+                                                          type: Identifier
+                                                          identifier: boolean
+                                                      trailing_trivia: []
                           question_mark:
                             leading_trivia: []
                             token:
@@ -4240,4 +4251,3 @@ stmts:
                             type: Whitespace
                             characters: "\n"
     - ~
-

--- a/full-moon/tests/roblox_cases/pass/types_variadic/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_variadic/ast.snap
@@ -1,6 +1,7 @@
 ---
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/types_variadic
 ---
 stmts:
   - - TypeDeclaration:
@@ -1062,77 +1063,79 @@ stmts:
                           trailing_trivia: []
                         type_info:
                           Union:
-                            left:
-                              String:
-                                leading_trivia: []
-                                token:
-                                  start_position:
-                                    bytes: 149
-                                    line: 5
-                                    character: 17
-                                  end_position:
-                                    bytes: 154
-                                    line: 5
-                                    character: 22
-                                  token_type:
-                                    type: StringLiteral
-                                    literal: hit
-                                    quote_type: Double
-                                trailing_trivia:
-                                  - start_position:
-                                      bytes: 154
-                                      line: 5
-                                      character: 22
-                                    end_position:
-                                      bytes: 155
-                                      line: 5
-                                      character: 23
-                                    token_type:
-                                      type: Whitespace
-                                      characters: " "
-                            pipe:
-                              leading_trivia: []
-                              token:
-                                start_position:
-                                  bytes: 155
-                                  line: 5
-                                  character: 23
-                                end_position:
-                                  bytes: 156
-                                  line: 5
-                                  character: 24
-                                token_type:
-                                  type: Symbol
-                                  symbol: "|"
-                              trailing_trivia:
-                                - start_position:
-                                    bytes: 156
-                                    line: 5
-                                    character: 24
-                                  end_position:
-                                    bytes: 157
-                                    line: 5
-                                    character: 25
-                                  token_type:
-                                    type: Whitespace
-                                    characters: " "
-                            right:
-                              String:
-                                leading_trivia: []
-                                token:
-                                  start_position:
-                                    bytes: 157
-                                    line: 5
-                                    character: 25
-                                  end_position:
-                                    bytes: 163
-                                    line: 5
-                                    character: 31
-                                  token_type:
-                                    type: StringLiteral
-                                    literal: miss
-                                    quote_type: Double
-                                trailing_trivia: []
+                            leading: ~
+                            types:
+                              pairs:
+                                - Punctuated:
+                                    - String:
+                                        leading_trivia: []
+                                        token:
+                                          start_position:
+                                            bytes: 149
+                                            line: 5
+                                            character: 17
+                                          end_position:
+                                            bytes: 154
+                                            line: 5
+                                            character: 22
+                                          token_type:
+                                            type: StringLiteral
+                                            literal: hit
+                                            quote_type: Double
+                                        trailing_trivia:
+                                          - start_position:
+                                              bytes: 154
+                                              line: 5
+                                              character: 22
+                                            end_position:
+                                              bytes: 155
+                                              line: 5
+                                              character: 23
+                                            token_type:
+                                              type: Whitespace
+                                              characters: " "
+                                    - leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 155
+                                          line: 5
+                                          character: 23
+                                        end_position:
+                                          bytes: 156
+                                          line: 5
+                                          character: 24
+                                        token_type:
+                                          type: Symbol
+                                          symbol: "|"
+                                      trailing_trivia:
+                                        - start_position:
+                                            bytes: 156
+                                            line: 5
+                                            character: 24
+                                          end_position:
+                                            bytes: 157
+                                            line: 5
+                                            character: 25
+                                          token_type:
+                                            type: Whitespace
+                                            characters: " "
+                                - End:
+                                    String:
+                                      leading_trivia: []
+                                      token:
+                                        start_position:
+                                          bytes: 157
+                                          line: 5
+                                          character: 25
+                                        end_position:
+                                          bytes: 163
+                                          line: 5
+                                          character: 31
+                                        token_type:
+                                          type: StringLiteral
+                                          literal: miss
+                                          quote_type: Double
+                                      trailing_trivia: []
             arrow:
               leading_trivia: []
               token:
@@ -1303,133 +1306,132 @@ stmts:
                                   pairs:
                                     - End:
                                         Union:
-                                          left:
-                                            Union:
-                                              left:
-                                                String:
-                                                  leading_trivia: []
-                                                  token:
-                                                    start_position:
-                                                      bytes: 181
-                                                      line: 5
-                                                      character: 49
-                                                    end_position:
-                                                      bytes: 191
-                                                      line: 5
-                                                      character: 59
-                                                    token_type:
-                                                      type: StringLiteral
-                                                      literal: critical
-                                                      quote_type: Double
-                                                  trailing_trivia:
-                                                    - start_position:
-                                                        bytes: 191
-                                                        line: 5
-                                                        character: 59
-                                                      end_position:
+                                          leading: ~
+                                          types:
+                                            pairs:
+                                              - Punctuated:
+                                                  - String:
+                                                      leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 181
+                                                          line: 5
+                                                          character: 49
+                                                        end_position:
+                                                          bytes: 191
+                                                          line: 5
+                                                          character: 59
+                                                        token_type:
+                                                          type: StringLiteral
+                                                          literal: critical
+                                                          quote_type: Double
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 191
+                                                            line: 5
+                                                            character: 59
+                                                          end_position:
+                                                            bytes: 192
+                                                            line: 5
+                                                            character: 60
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                  - leading_trivia: []
+                                                    token:
+                                                      start_position:
                                                         bytes: 192
                                                         line: 5
                                                         character: 60
-                                                      token_type:
-                                                        type: Whitespace
-                                                        characters: " "
-                                              pipe:
-                                                leading_trivia: []
-                                                token:
-                                                  start_position:
-                                                    bytes: 192
-                                                    line: 5
-                                                    character: 60
-                                                  end_position:
-                                                    bytes: 193
-                                                    line: 5
-                                                    character: 61
-                                                  token_type:
-                                                    type: Symbol
-                                                    symbol: "|"
-                                                trailing_trivia:
-                                                  - start_position:
-                                                      bytes: 193
-                                                      line: 5
-                                                      character: 61
-                                                    end_position:
-                                                      bytes: 194
-                                                      line: 5
-                                                      character: 62
-                                                    token_type:
-                                                      type: Whitespace
-                                                      characters: " "
-                                              right:
-                                                String:
-                                                  leading_trivia: []
-                                                  token:
-                                                    start_position:
-                                                      bytes: 194
-                                                      line: 5
-                                                      character: 62
-                                                    end_position:
-                                                      bytes: 200
-                                                      line: 5
-                                                      character: 68
-                                                    token_type:
-                                                      type: StringLiteral
-                                                      literal: weak
-                                                      quote_type: Double
-                                                  trailing_trivia:
-                                                    - start_position:
-                                                        bytes: 200
-                                                        line: 5
-                                                        character: 68
                                                       end_position:
+                                                        bytes: 193
+                                                        line: 5
+                                                        character: 61
+                                                      token_type:
+                                                        type: Symbol
+                                                        symbol: "|"
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 193
+                                                          line: 5
+                                                          character: 61
+                                                        end_position:
+                                                          bytes: 194
+                                                          line: 5
+                                                          character: 62
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                              - Punctuated:
+                                                  - String:
+                                                      leading_trivia: []
+                                                      token:
+                                                        start_position:
+                                                          bytes: 194
+                                                          line: 5
+                                                          character: 62
+                                                        end_position:
+                                                          bytes: 200
+                                                          line: 5
+                                                          character: 68
+                                                        token_type:
+                                                          type: StringLiteral
+                                                          literal: weak
+                                                          quote_type: Double
+                                                      trailing_trivia:
+                                                        - start_position:
+                                                            bytes: 200
+                                                            line: 5
+                                                            character: 68
+                                                          end_position:
+                                                            bytes: 201
+                                                            line: 5
+                                                            character: 69
+                                                          token_type:
+                                                            type: Whitespace
+                                                            characters: " "
+                                                  - leading_trivia: []
+                                                    token:
+                                                      start_position:
                                                         bytes: 201
                                                         line: 5
                                                         character: 69
+                                                      end_position:
+                                                        bytes: 202
+                                                        line: 5
+                                                        character: 70
                                                       token_type:
-                                                        type: Whitespace
-                                                        characters: " "
-                                          pipe:
-                                            leading_trivia: []
-                                            token:
-                                              start_position:
-                                                bytes: 201
-                                                line: 5
-                                                character: 69
-                                              end_position:
-                                                bytes: 202
-                                                line: 5
-                                                character: 70
-                                              token_type:
-                                                type: Symbol
-                                                symbol: "|"
-                                            trailing_trivia:
-                                              - start_position:
-                                                  bytes: 202
-                                                  line: 5
-                                                  character: 70
-                                                end_position:
-                                                  bytes: 203
-                                                  line: 5
-                                                  character: 71
-                                                token_type:
-                                                  type: Whitespace
-                                                  characters: " "
-                                          right:
-                                            String:
-                                              leading_trivia: []
-                                              token:
-                                                start_position:
-                                                  bytes: 203
-                                                  line: 5
-                                                  character: 71
-                                                end_position:
-                                                  bytes: 211
-                                                  line: 5
-                                                  character: 79
-                                                token_type:
-                                                  type: StringLiteral
-                                                  literal: normal
-                                                  quote_type: Double
-                                              trailing_trivia: []
+                                                        type: Symbol
+                                                        symbol: "|"
+                                                    trailing_trivia:
+                                                      - start_position:
+                                                          bytes: 202
+                                                          line: 5
+                                                          character: 70
+                                                        end_position:
+                                                          bytes: 203
+                                                          line: 5
+                                                          character: 71
+                                                        token_type:
+                                                          type: Whitespace
+                                                          characters: " "
+                                              - End:
+                                                  String:
+                                                    leading_trivia: []
+                                                    token:
+                                                      start_position:
+                                                        bytes: 203
+                                                        line: 5
+                                                        character: 71
+                                                      end_position:
+                                                        bytes: 211
+                                                        line: 5
+                                                        character: 79
+                                                      token_type:
+                                                        type: StringLiteral
+                                                        literal: normal
+                                                        quote_type: Double
+                                                    trailing_trivia: []
                 arrow:
                   leading_trivia: []
                   token:
@@ -1520,77 +1522,79 @@ stmts:
                           pairs:
                             - End:
                                 Union:
-                                  left:
-                                    String:
-                                      leading_trivia: []
-                                      token:
-                                        start_position:
-                                          bytes: 221
-                                          line: 5
-                                          character: 89
-                                        end_position:
-                                          bytes: 227
-                                          line: 5
-                                          character: 95
-                                        token_type:
-                                          type: StringLiteral
-                                          literal: dead
-                                          quote_type: Double
-                                      trailing_trivia:
-                                        - start_position:
-                                            bytes: 227
-                                            line: 5
-                                            character: 95
-                                          end_position:
-                                            bytes: 228
-                                            line: 5
-                                            character: 96
-                                          token_type:
-                                            type: Whitespace
-                                            characters: " "
-                                  pipe:
-                                    leading_trivia: []
-                                    token:
-                                      start_position:
-                                        bytes: 228
-                                        line: 5
-                                        character: 96
-                                      end_position:
-                                        bytes: 229
-                                        line: 5
-                                        character: 97
-                                      token_type:
-                                        type: Symbol
-                                        symbol: "|"
-                                    trailing_trivia:
-                                      - start_position:
-                                          bytes: 229
-                                          line: 5
-                                          character: 97
-                                        end_position:
-                                          bytes: 230
-                                          line: 5
-                                          character: 98
-                                        token_type:
-                                          type: Whitespace
-                                          characters: " "
-                                  right:
-                                    String:
-                                      leading_trivia: []
-                                      token:
-                                        start_position:
-                                          bytes: 230
-                                          line: 5
-                                          character: 98
-                                        end_position:
-                                          bytes: 237
-                                          line: 5
-                                          character: 105
-                                        token_type:
-                                          type: StringLiteral
-                                          literal: alive
-                                          quote_type: Double
-                                      trailing_trivia: []
+                                  leading: ~
+                                  types:
+                                    pairs:
+                                      - Punctuated:
+                                          - String:
+                                              leading_trivia: []
+                                              token:
+                                                start_position:
+                                                  bytes: 221
+                                                  line: 5
+                                                  character: 89
+                                                end_position:
+                                                  bytes: 227
+                                                  line: 5
+                                                  character: 95
+                                                token_type:
+                                                  type: StringLiteral
+                                                  literal: dead
+                                                  quote_type: Double
+                                              trailing_trivia:
+                                                - start_position:
+                                                    bytes: 227
+                                                    line: 5
+                                                    character: 95
+                                                  end_position:
+                                                    bytes: 228
+                                                    line: 5
+                                                    character: 96
+                                                  token_type:
+                                                    type: Whitespace
+                                                    characters: " "
+                                          - leading_trivia: []
+                                            token:
+                                              start_position:
+                                                bytes: 228
+                                                line: 5
+                                                character: 96
+                                              end_position:
+                                                bytes: 229
+                                                line: 5
+                                                character: 97
+                                              token_type:
+                                                type: Symbol
+                                                symbol: "|"
+                                            trailing_trivia:
+                                              - start_position:
+                                                  bytes: 229
+                                                  line: 5
+                                                  character: 97
+                                                end_position:
+                                                  bytes: 230
+                                                  line: 5
+                                                  character: 98
+                                                token_type:
+                                                  type: Whitespace
+                                                  characters: " "
+                                      - End:
+                                          String:
+                                            leading_trivia: []
+                                            token:
+                                              start_position:
+                                                bytes: 230
+                                                line: 5
+                                                character: 98
+                                              end_position:
+                                                bytes: 237
+                                                line: 5
+                                                character: 105
+                                              token_type:
+                                                type: StringLiteral
+                                                literal: alive
+                                                quote_type: Double
+                                            trailing_trivia: []
     - ~
   - - FunctionDeclaration:
         function_token:
@@ -1788,86 +1792,88 @@ stmts:
                   trailing_trivia: []
                 type_info:
                   Union:
-                    left:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 271
-                            line: 7
-                            character: 32
-                          end_position:
-                            bytes: 277
-                            line: 7
-                            character: 38
-                          token_type:
-                            type: Identifier
-                            identifier: number
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 277
-                              line: 7
-                              character: 38
-                            end_position:
-                              bytes: 278
-                              line: 7
-                              character: 39
-                            token_type:
-                              type: Whitespace
-                              characters: " "
-                    pipe:
-                      leading_trivia: []
-                      token:
-                        start_position:
-                          bytes: 278
-                          line: 7
-                          character: 39
-                        end_position:
-                          bytes: 279
-                          line: 7
-                          character: 40
-                        token_type:
-                          type: Symbol
-                          symbol: "|"
-                      trailing_trivia:
-                        - start_position:
-                            bytes: 279
-                            line: 7
-                            character: 40
-                          end_position:
-                            bytes: 280
-                            line: 7
-                            character: 41
-                          token_type:
-                            type: Whitespace
-                            characters: " "
-                    right:
-                      Basic:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 280
-                            line: 7
-                            character: 41
-                          end_position:
-                            bytes: 286
-                            line: 7
-                            character: 47
-                          token_type:
-                            type: Identifier
-                            identifier: string
-                        trailing_trivia:
-                          - start_position:
-                              bytes: 286
-                              line: 7
-                              character: 47
-                            end_position:
-                              bytes: 287
-                              line: 7
-                              character: 48
-                            token_type:
-                              type: Whitespace
-                              characters: " "
+                    leading: ~
+                    types:
+                      pairs:
+                        - Punctuated:
+                            - Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 271
+                                    line: 7
+                                    character: 32
+                                  end_position:
+                                    bytes: 277
+                                    line: 7
+                                    character: 38
+                                  token_type:
+                                    type: Identifier
+                                    identifier: number
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 277
+                                      line: 7
+                                      character: 38
+                                    end_position:
+                                      bytes: 278
+                                      line: 7
+                                      character: 39
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                            - leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 278
+                                  line: 7
+                                  character: 39
+                                end_position:
+                                  bytes: 279
+                                  line: 7
+                                  character: 40
+                                token_type:
+                                  type: Symbol
+                                  symbol: "|"
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 279
+                                    line: 7
+                                    character: 40
+                                  end_position:
+                                    bytes: 280
+                                    line: 7
+                                    character: 41
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                        - End:
+                            Basic:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 280
+                                  line: 7
+                                  character: 41
+                                end_position:
+                                  bytes: 286
+                                  line: 7
+                                  character: 47
+                                token_type:
+                                  type: Identifier
+                                  identifier: string
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 286
+                                    line: 7
+                                    character: 47
+                                  end_position:
+                                    bytes: 287
+                                    line: 7
+                                    character: 48
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
           block:
             stmts: []
           end_token:
@@ -4023,4 +4029,3 @@ stmts:
                               quote_type: Single
                           trailing_trivia: []
     - ~
-


### PR DESCRIPTION
This PR changes `TypeInfo::Union` and `TypeInfo::Intersection` to both use a separate struct: `TypeUnion` and `TypeIntersection`. It also changes the structure of these types from being linked lists into `Vec`s (using `Punctuated`). This also results in some new visitor methods: `visit_type_union`, `visit_type_union_end`, `visit_type_intersection`, and `visit_type_intersection_end`.

This PR also adds the ability to parse leading `|` and `&` in types, such as:
```luau
type T = | "A" | "B" | "C"
```
This involved adding a `leading` field to the `TypeUnion` and `TypeIntersection` structs, which contains an optional `TokenReference`.

Tests were updated to accommodate the changes, and leading `|` and `&` was added to the `types` test.