### PR TITLE
The `print()` function didn't print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0-rc.5] - 2024-07-06
 ### Changed
 - **[BREAKING CHANGE]** The `types` module is now named `luau`.
+- **[BREAKING CHANGE]** The `print()` function has been removed, use `ast.to_string()` instead.
 
 ## [1.0.0-rc.4] - 2024-07-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Added
-- Added structs `TypeUnion` and `TypeIntersection` which both contain a field for a leading `TokenReference` (`|` or `&`), and a field which contains a `Punctuated<TypeInfo>`.
-- Added support for parsing leading `|` and `&` in types.
 
 ### Changed
-- **[BREAKING CHANGE]** Changed `TypeInfo::Union` and `TypeInfo::Intersection` to hold structs `TypeUnion` and `TypeIntersection` respectively.
-
+- **[BREAKING CHANGE]** The `print()` function has been removed, use `ast.to_string()` instead.
 
 ## [1.0.0-rc.5] - 2024-07-06
 ### Changed
 - **[BREAKING CHANGE]** The `types` module is now named `luau`.
-- **[BREAKING CHANGE]** The `print()` function has been removed, use `ast.to_string()` instead.
 
 ## [1.0.0-rc.4] - 2024-07-06
 ### Fixed

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt::{Display, Formatter};
+use std::fmt::Formatter;
 use std::{borrow::Cow, fmt};
 
 use derive_more::Display;
@@ -2291,7 +2291,7 @@ impl Ast {
     }
 }
 
-impl Display for Ast {
+impl fmt::Display for Ast {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.nodes())?;
         write!(f, "{}", self.eof())

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1,5 +1,5 @@
-use std::{borrow::Cow, fmt};
 use std::fmt::{Display, Formatter};
+use std::{borrow::Cow, fmt};
 
 use derive_more::Display;
 #[cfg(feature = "serde")]
@@ -31,11 +31,11 @@ pub mod span;
 mod update_positions;
 mod visitors;
 
-mod versions;
 #[cfg(feature = "luau")]
 pub mod luau;
 #[cfg(feature = "luau")]
 mod luau_visitors;
+mod versions;
 
 #[cfg(any(feature = "lua52", feature = "luajit"))]
 pub mod lua52;

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -1,3 +1,27 @@
+use std::{borrow::Cow, fmt};
+use std::fmt::{Display, Formatter};
+
+use derive_more::Display;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use full_moon_derive::{Node, Visit};
+#[cfg(any(feature = "lua52", feature = "luajit"))]
+use lua52::*;
+#[cfg(feature = "lua54")]
+use lua54::*;
+#[cfg(feature = "luau")]
+use luau::*;
+pub use parser_structs::AstResult;
+use punctuated::{Pair, Punctuated};
+use span::ContainedSpan;
+pub use versions::*;
+
+use crate::{
+    tokenizer::{Position, Symbol, Token, TokenReference, TokenType},
+    util::*,
+};
+
 mod parser_structs;
 #[macro_use]
 mod parser_util;
@@ -7,43 +31,16 @@ pub mod span;
 mod update_positions;
 mod visitors;
 
-use crate::{
-    tokenizer::{Position, Symbol, Token, TokenReference, TokenType},
-    util::*,
-};
-use derive_more::Display;
-use full_moon_derive::{Node, Visit};
-
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, fmt};
-
-use punctuated::{Pair, Punctuated};
-use span::ContainedSpan;
-
-pub use parser_structs::AstResult;
-
 mod versions;
-pub use versions::*;
-
 #[cfg(feature = "luau")]
 pub mod luau;
-#[cfg(feature = "luau")]
-use luau::*;
-
 #[cfg(feature = "luau")]
 mod luau_visitors;
 
 #[cfg(any(feature = "lua52", feature = "luajit"))]
 pub mod lua52;
-#[cfg(any(feature = "lua52", feature = "luajit"))]
-use lua52::*;
-
 #[cfg(feature = "lua54")]
 pub mod lua54;
-#[cfg(feature = "lua54")]
-use lua54::*;
-
 /// A block of statements, such as in if/do/etc block
 #[derive(Clone, Debug, Default, Display, PartialEq, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
@@ -2307,10 +2304,18 @@ impl Ast {
     }
 }
 
+impl Display for Ast {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.nodes())?;
+        write!(f, "{}", self.eof())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::{parse, visitors::VisitorMut};
+
     use super::*;
-    use crate::{parse, print, visitors::VisitorMut};
 
     #[test]
     fn test_with_eof_safety() {
@@ -2320,7 +2325,7 @@ mod tests {
             ast.with_eof(eof)
         };
 
-        print(&new_ast);
+        assert_eq!("local foo = 1", new_ast.to_string());
     }
 
     #[test]
@@ -2331,7 +2336,7 @@ mod tests {
             ast.with_nodes(nodes)
         };
 
-        print(&new_ast);
+        assert_eq!(new_ast.to_string(), "local foo = 1");
     }
 
     #[test]
@@ -2349,7 +2354,7 @@ mod tests {
             SyntaxRewriter.visit_ast(ast)
         };
 
-        print(&new_ast);
+        assert_eq!(new_ast.to_string(), "local foo = 1");
     }
 
     // Tests AST nodes with new methods that call unwrap
@@ -2417,6 +2422,6 @@ mod tests {
         )]);
 
         let ast = parse("").unwrap().with_nodes(block);
-        assert_eq!(print(&ast), "local variable = 1");
+        assert_eq!(ast.to_string(), "local variable = 1");
     }
 }

--- a/full-moon/src/lib.rs
+++ b/full-moon/src/lib.rs
@@ -108,8 +108,3 @@ pub fn parse(code: &str) -> Result<ast::Ast, Vec<Error>> {
 pub fn parse_fallible(code: &str, lua_version: LuaVersion) -> ast::AstResult {
     ast::AstResult::parse_fallible(code, lua_version)
 }
-
-/// Prints back Lua code from an [`Ast`](ast::Ast)
-pub fn print(ast: &ast::Ast) -> String {
-    format!("{}{}", ast.nodes(), ast.eof())
-}

--- a/full-moon/tests/cases/fail/parser/assignment-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/assignment-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/assignment-1
 ---
 x =

--- a/full-moon/tests/cases/fail/parser/assignment-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/assignment-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/assignment-2
 ---
 "x = "

--- a/full-moon/tests/cases/fail/parser/assignment-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/assignment-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/assignment-3
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/bin-op-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/bin-op-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/bin-op-1
 ---
 "return 1 "

--- a/full-moon/tests/cases/fail/parser/bin-op-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/bin-op-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/bin-op-2
 ---
 "return 1 "

--- a/full-moon/tests/cases/fail/parser/call-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/call-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/call-1
 ---
 call()

--- a/full-moon/tests/cases/fail/parser/call-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/call-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/call-2
 ---
 "call(\"hello\")"

--- a/full-moon/tests/cases/fail/parser/call-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/call-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/call-3
 ---
 "call(\"hello\", \"world\")"

--- a/full-moon/tests/cases/fail/parser/call-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/call-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/call-4
 ---
 call()

--- a/full-moon/tests/cases/fail/parser/do-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/do-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/do-1
 ---
 "do\n\tcall()end"

--- a/full-moon/tests/cases/fail/parser/do-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/do-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/do-2
 ---
 do end

--- a/full-moon/tests/cases/fail/parser/function-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-1
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/function-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-2
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/function-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-3
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/function-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-4
 ---
 function x()end

--- a/full-moon/tests/cases/fail/parser/function-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-5
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/function-6/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-6/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-6
 ---
 function x()end

--- a/full-moon/tests/cases/fail/parser/function-7/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-7/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-7
 ---
 function x(...)end

--- a/full-moon/tests/cases/fail/parser/function-8/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/function-8/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/function-8
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/generic-for-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/generic-for-1
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/generic-for-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/generic-for-2
 ---
 for x in pairs(y)doend

--- a/full-moon/tests/cases/fail/parser/generic-for-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/generic-for-3
 ---
 for x in pairs(y) doend

--- a/full-moon/tests/cases/fail/parser/generic-for-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/generic-for-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/generic-for-4
 ---
 pairs(list) do end

--- a/full-moon/tests/cases/fail/parser/if-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/if-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/if-1
 ---
 if x thenend

--- a/full-moon/tests/cases/fail/parser/if-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/if-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/if-2
 ---
 "if x then\nelse\n\tcall()end"

--- a/full-moon/tests/cases/fail/parser/if-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/if-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/if-3
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/if-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/if-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/if-4
 ---
 "if x then\nelseif y thenend"

--- a/full-moon/tests/cases/fail/parser/if-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/if-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/if-5
 ---
 "if x then\n\tcall1()\nelse\n\tcall2()\nend\tcall3()\n"

--- a/full-moon/tests/cases/fail/parser/if-6/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/if-6/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/if-6
 ---
 "if x then\nelse end\tcall()\n"

--- a/full-moon/tests/cases/fail/parser/if-7/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/if-7/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/if-7
 ---
 "if x then do\nendend"

--- a/full-moon/tests/cases/fail/parser/index-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/index-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/index-1
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/index-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/index-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/index-2
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/index-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/index-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/index-3
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/index-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/index-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/index-4
 ---
 local y = x

--- a/full-moon/tests/cases/fail/parser/index-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/index-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/index-5
 ---
 return name

--- a/full-moon/tests/cases/fail/parser/last-stmt-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/last-stmt-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/last-stmt-1
 ---
 "local function x()\n\treturn 1\nend\treturn 2\n"

--- a/full-moon/tests/cases/fail/parser/last-stmt-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/last-stmt-2/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "local a = pcall(function()\n\treturn\nend)\treturn\n"
 

--- a/full-moon/tests/cases/fail/parser/local-assignment-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-assignment-1
 ---
 "local x "

--- a/full-moon/tests/cases/fail/parser/local-assignment-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-assignment-2
 ---
 local x =

--- a/full-moon/tests/cases/fail/parser/local-assignment-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-assignment-3
 ---
 local x = 1

--- a/full-moon/tests/cases/fail/parser/local-assignment-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-assignment-4
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/local-assignment-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-assignment-5
 ---
 "local x = "

--- a/full-moon/tests/cases/fail/parser/local-assignment-6/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-assignment-6/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 19
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-assignment-6
 ---
 "local x =\nlocal y = 2\n"

--- a/full-moon/tests/cases/fail/parser/local-function-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-function-1
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/local-function-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-function-2
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/local-function-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-function-3
 ---
 local function x()end

--- a/full-moon/tests/cases/fail/parser/local-function-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-function-4
 ---
 "local function x()\n\tcall()end"

--- a/full-moon/tests/cases/fail/parser/local-function-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-function-5
 ---
 "\tcall()\n"

--- a/full-moon/tests/cases/fail/parser/local-function-6/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-6/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-function-6
 ---
 local function x()end

--- a/full-moon/tests/cases/fail/parser/local-function-7/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/local-function-7/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 19
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/local-function-7
 ---
 "local function foo(x, y)\n\tprint(x, y)\nend\n"

--- a/full-moon/tests/cases/fail/parser/method-call-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/method-call-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/method-call-1
 ---
 return name

--- a/full-moon/tests/cases/fail/parser/method-call-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/method-call-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/method-call-2
 ---
 "return name:method()"

--- a/full-moon/tests/cases/fail/parser/method-call-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/method-call-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/method-call-3
 ---
 "return name:method()"

--- a/full-moon/tests/cases/fail/parser/numeric-for-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/numeric-for-1
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/numeric-for-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/numeric-for-2
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/numeric-for-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/numeric-for-3
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/numeric-for-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/numeric-for-4
 ---
 "for x = 1, 10 doend"

--- a/full-moon/tests/cases/fail/parser/numeric-for-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/numeric-for-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/numeric-for-5
 ---
 do end

--- a/full-moon/tests/cases/fail/parser/paren-expression-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/paren-expression-1
 ---
 "return "

--- a/full-moon/tests/cases/fail/parser/paren-expression-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/paren-expression-2
 ---
 "return (3), 4"

--- a/full-moon/tests/cases/fail/parser/paren-expression-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/paren-expression-3
 ---
 "return (3), 4"

--- a/full-moon/tests/cases/fail/parser/paren-expression-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/paren-expression-4
 ---
 "return "

--- a/full-moon/tests/cases/fail/parser/paren-expression-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/paren-expression-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/paren-expression-5
 ---
 "return "

--- a/full-moon/tests/cases/fail/parser/repeat-until-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/repeat-until-1
 ---
 "do\n\nend"

--- a/full-moon/tests/cases/fail/parser/repeat-until-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/repeat-until-2
 ---
 "do\n\tcall()\nend"

--- a/full-moon/tests/cases/fail/parser/repeat-until-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/repeat-until-3
 ---
 "do\n\tcall()\n\nend"

--- a/full-moon/tests/cases/fail/parser/repeat-until-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/repeat-until-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/repeat-until-4
 ---
 "do\n\tcall()\n\nend"

--- a/full-moon/tests/cases/fail/parser/stmt-after-break-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/stmt-after-break-1/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "print(\"1\")\nprint(\"2\")\nbreak -- this can be replaced with break/return\n"
 

--- a/full-moon/tests/cases/fail/parser/stmt-after-return-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/stmt-after-return-1/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "print(\"1\")\nprint(\"2\")\nreturn;\n"
 

--- a/full-moon/tests/cases/fail/parser/table-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-1
 ---
 "return {}"

--- a/full-moon/tests/cases/fail/parser/table-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-2
 ---
 "return {\n\ta = 1,}"

--- a/full-moon/tests/cases/fail/parser/table-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-3
 ---
 "return {\n}"

--- a/full-moon/tests/cases/fail/parser/table-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-4
 ---
 "return { }"

--- a/full-moon/tests/cases/fail/parser/table-5/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-5/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-5
 ---
 "return {\n}"

--- a/full-moon/tests/cases/fail/parser/table-6/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-6/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-6
 ---
 "return {\n}"

--- a/full-moon/tests/cases/fail/parser/table-7/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-7/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-7
 ---
 "return {\n}"

--- a/full-moon/tests/cases/fail/parser/table-8/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-8/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-8
 ---
 "return {\n}"

--- a/full-moon/tests/cases/fail/parser/table-9/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/table-9/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/table-9
 ---
 "local x = {\n}"

--- a/full-moon/tests/cases/fail/parser/un-op-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/un-op-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/un-op-1
 ---
 "return "

--- a/full-moon/tests/cases/fail/parser/un-op-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/un-op-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/un-op-2
 ---
 "return "

--- a/full-moon/tests/cases/fail/parser/while-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/while-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/while-1
 ---
 ""

--- a/full-moon/tests/cases/fail/parser/while-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/while-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/while-2
 ---
 do end

--- a/full-moon/tests/cases/fail/parser/while-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/while-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/while-3
 ---
 "while true do\n\tcall()end"

--- a/full-moon/tests/cases/fail/parser/while-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/parser/while-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 30
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/parser/while-4
 ---
 "while true\n do\nend\n\tcall()\n"

--- a/full-moon/tests/cases/fail/tokenizer/bad-numbers-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/bad-numbers-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 22
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/bad-numbers-1
 ---
 _ = 1edoge

--- a/full-moon/tests/cases/fail/tokenizer/unclosed-comment-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unclosed-comment-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 22
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/unclosed-comment-1
 ---
 "--[[]]"

--- a/full-moon/tests/cases/fail/tokenizer/unclosed-string-1/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unclosed-string-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 22
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/unclosed-string-1
 ---
 "local x = \"hello\""

--- a/full-moon/tests/cases/fail/tokenizer/unclosed-string-2/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unclosed-string-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 22
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/unclosed-string-2
 ---
 "local x = 'hello'"

--- a/full-moon/tests/cases/fail/tokenizer/unclosed-string-3/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unclosed-string-3/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 22
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/unclosed-string-3
 ---
 "local x = [[hello\nworld]]"

--- a/full-moon/tests/cases/fail/tokenizer/unclosed-string-4/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unclosed-string-4/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 19
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/unclosed-string-4
 ---
 "local x = 1\n"

--- a/full-moon/tests/cases/fail/tokenizer/unexpected-character/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/unexpected-character/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 22
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/unexpected-character
 ---
 "local x = "

--- a/full-moon/tests/cases/fail/tokenizer/wrong-place-shebang/ast_to_string.snap
+++ b/full-moon/tests/cases/fail/tokenizer/wrong-place-shebang/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 22
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/cases/fail/tokenizer/wrong-place-shebang
 ---
 "\nprint(\"hello\");\n"

--- a/full-moon/tests/fail_cases.rs
+++ b/full-moon/tests/fail_cases.rs
@@ -25,7 +25,7 @@ fn process_fail_case(path: &Path, source: &str, lua_version: LuaVersion) {
     process_codespan_display(source, &result);
 
     let ast = result.into_ast().update_positions();
-    assert_yaml_snapshot!("ast_to_string", full_moon::print(&ast));
+    assert_yaml_snapshot!("ast_to_string", ast.to_string());
 }
 
 fn process_codespan_display(source: &str, result: &AstResult) {

--- a/full-moon/tests/lua52_cases/fail/parser/goto-1/ast_to_string.snap
+++ b/full-moon/tests/lua52_cases/fail/parser/goto-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/lua52_cases/fail/parser/goto-1
 ---
 ""

--- a/full-moon/tests/lua52_cases/fail/parser/goto-as-identifier/ast_to_string.snap
+++ b/full-moon/tests/lua52_cases/fail/parser/goto-as-identifier/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/lua52_cases/fail/parser/goto-as-identifier
 ---
 ""

--- a/full-moon/tests/lua52_cases/fail/parser/label-1/ast_to_string.snap
+++ b/full-moon/tests/lua52_cases/fail/parser/label-1/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/lua52_cases/fail/parser/label-1
 ---
 "::label::"

--- a/full-moon/tests/lua52_cases/fail/parser/label-2/ast_to_string.snap
+++ b/full-moon/tests/lua52_cases/fail/parser/label-2/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/lua52_cases/fail/parser/label-2
 ---
 ""

--- a/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/ast_to_string.snap
+++ b/full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/lua53_cases/fail/parser/double-greater-than-binop
 ---
 "-- We shouldn't parse this as >> since it has a space in between\nlocal x = 1 "

--- a/full-moon/tests/lua54_cases/fail/parser/unclosed-attribute-1/ast_to_string.snap
+++ b/full-moon/tests/lua54_cases/fail/parser/unclosed-attribute-1/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/lua54_cases/fail/parser/unclosed-attribute-1
 ---
 local name <const>

--- a/full-moon/tests/lua54_cases/fail/parser/unclosed-attribute-2/ast_to_string.snap
+++ b/full-moon/tests/lua54_cases/fail/parser/unclosed-attribute-2/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/lua54_cases/fail/parser/unclosed-attribute-2
 ---
 local name <const >= 10

--- a/full-moon/tests/pass_cases.rs
+++ b/full-moon/tests/pass_cases.rs
@@ -1,7 +1,6 @@
 use full_moon::{
     ast::LuaVersion,
     node::Node,
-    print,
     tokenizer::{self, Token, TokenReference},
 };
 use insta::assert_yaml_snapshot;
@@ -46,7 +45,7 @@ fn test_pass_case(path: &Path, lua_version: LuaVersion) {
     let old_positions: Vec<_> = ast.tokens().flat_map(unpack_token_reference).collect();
 
     assert_yaml_snapshot!("ast", ast.nodes());
-    assert_eq!(PrettyString(&print(&ast)), PrettyString(&source));
+    assert_eq!(PrettyString(&ast.to_string()), PrettyString(&source));
 
     let ast = ast.update_positions();
     assert_eq!(

--- a/full-moon/tests/roblox_cases/fail/parser/function_return_type_thin_arrow/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/function_return_type_thin_arrow/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "function foo() -> string\n\treturn \"\"\nend"
 

--- a/full-moon/tests/roblox_cases/fail/parser/generic_declare_no_parameters/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/generic_declare_no_parameters/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 type Foo<%error-id%> = () -> ()
 

--- a/full-moon/tests/roblox_cases/fail/parser/generic_declare_packs_last/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/generic_declare_packs_last/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "type Bar<T..., U...> = nil"
 

--- a/full-moon/tests/roblox_cases/fail/parser/generic_default_not_a_type_pack/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/generic_default_not_a_type_pack/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "type Foo<T... = string> = nil\n"
 

--- a/full-moon/tests/roblox_cases/fail/parser/generic_must_declare_default/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/generic_must_declare_default/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "type Foo<X, Y, Z = string, P> = nil"
 

--- a/full-moon/tests/roblox_cases/fail/parser/generic_nil/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/generic_nil/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 type Foo = nil
 

--- a/full-moon/tests/roblox_cases/fail/parser/generic_string/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/generic_string/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "type Foo = \"bar\""
 

--- a/full-moon/tests/roblox_cases/fail/parser/missing_else_in_if_expression/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/missing_else_in_if_expression/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "local endIndex = \nprint(\"testing\")"
 

--- a/full-moon/tests/roblox_cases/fail/parser/named_function_arg_types/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/named_function_arg_types/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 ""
 

--- a/full-moon/tests/roblox_cases/fail/parser/nil_dot/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/nil_dot/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 type Foo = nil
 

--- a/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_tuple_types/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "function foo(test)\nend"
 

--- a/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/param_variadic_types/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 function bar(test)end
 

--- a/full-moon/tests/roblox_cases/fail/parser/parentheses_variadic_types/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/parentheses_variadic_types/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 ""
 

--- a/full-moon/tests/roblox_cases/fail/parser/stmt_after_continue/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/stmt_after_continue/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "print(\"1\")\nprint(\"2\")\ncontinue -- this can be replaced with break/return\n"
 

--- a/full-moon/tests/roblox_cases/fail/parser/string-interpolation-double-brace-recovery/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/string-interpolation-double-brace-recovery/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/roblox_cases/fail/parser/string-interpolation-double-brace-recovery
 ---
 "local _ = `2 + 2 = {2 + 2}`\n"

--- a/full-moon/tests/roblox_cases/fail/parser/string-interpolation-double-brace/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/string-interpolation-double-brace/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/roblox_cases/fail/parser/string-interpolation-double-brace
 ---
 "_ = `{"

--- a/full-moon/tests/roblox_cases/fail/parser/type_table_no_right_brace/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/parser/type_table_no_right_brace/ast_to_string.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/fail_cases.rs
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 ---
 "type Foo = { x: string, y: string\n}\nlocal x = 1"
 

--- a/full-moon/tests/roblox_cases/fail/tokenizer/unfinished-string-interpolation-with-new-line/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/tokenizer/unfinished-string-interpolation-with-new-line/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/roblox_cases/fail/tokenizer/unfinished-string-interpolation-with-new-line
 ---
 "local x = `ab`\nprint(1)\n"

--- a/full-moon/tests/roblox_cases/fail/tokenizer/unfinished-string-interpolation/ast_to_string.snap
+++ b/full-moon/tests/roblox_cases/fail/tokenizer/unfinished-string-interpolation/ast_to_string.snap
@@ -1,7 +1,7 @@
 ---
 source: full-moon/tests/fail_cases.rs
 assertion_line: 28
-expression: "full_moon::print(&ast)"
+expression: "ast.to_string()"
 input_file: full-moon/tests/roblox_cases/fail/tokenizer/unfinished-string-interpolation
 ---
 "local _ = `asdf`"

--- a/full-moon/tests/visitors.rs
+++ b/full-moon/tests/visitors.rs
@@ -1,5 +1,5 @@
 use full_moon::{
-    ast, parse, print,
+    ast, parse,
     tokenizer::*,
     visitors::{Visitor, VisitorMut},
 };
@@ -57,7 +57,7 @@ fn test_visitor_mut() {
 
     let code = parse("local dogs, snakes = 1").unwrap();
     let code = SnakeNamer.visit_ast(code);
-    assert_eq!(print(&code), "local dogsss, sssnakesss = 1");
+    assert_eq!(code.to_string(), "local dogsss, sssnakesss = 1");
 
     struct PositionValidator;
 


### PR DESCRIPTION
The `print(ast`) function didn't print anything, it merely formatted the `Ast` as a string. This was confusing.

To make it more clear the function has been replaced by an implementation of `Display` for `Ast` that has the same formatting behavior.