### PR TITLE
Fix typo in `Expression::Function`

### DIFF
--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -305,7 +305,7 @@ pub enum Expression {
         expression: Box<Expression>,
     },
 
-    /// An anonymous function, such as `function() end)`
+    /// An anonymous function, such as `function() end`
     #[display(fmt = "{}{}", "_0.0", "_0.1")]
     Function(Box<(TokenReference, FunctionBody)>),
 


### PR DESCRIPTION
Fixes a minor typo in `Expression::Function` doc comment.