### PR TITLE
Fix including trivia in check for typeof identifier

### DIFF
--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2345,7 +2345,7 @@ fn parse_simple_type(
         TokenType::Identifier { .. } => {
             let name = state.consume().unwrap();
 
-            if name.to_string() == "typeof" {
+            if name.token.to_string() == "typeof" {
                 let left_parenthesis =
                     match state.require(Symbol::LeftParen, "expected `(` after `typeof`") {
                         Some(token) => token,

--- a/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/ast.snap
@@ -1,0 +1,190 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/multiline_typeof_regression
+---
+stmts:
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 0
+              line: 1
+              character: 1
+            end_position:
+              bytes: 4
+              line: 1
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 4
+                line: 1
+                character: 5
+              end_position:
+                bytes: 5
+                line: 1
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 5
+              line: 1
+              character: 6
+            end_position:
+              bytes: 11
+              line: 1
+              character: 12
+            token_type:
+              type: Identifier
+              identifier: TypeOf
+          trailing_trivia:
+            - start_position:
+                bytes: 11
+                line: 1
+                character: 12
+              end_position:
+                bytes: 12
+                line: 1
+                character: 13
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 12
+              line: 1
+              character: 13
+            end_position:
+              bytes: 13
+              line: 1
+              character: 14
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 13
+                line: 1
+                character: 14
+              end_position:
+                bytes: 15
+                line: 1
+                character: 15
+              token_type:
+                type: Whitespace
+                characters: "\r\n"
+        declare_as:
+          Typeof:
+            typeof_token:
+              leading_trivia:
+                - start_position:
+                    bytes: 15
+                    line: 2
+                    character: 1
+                  end_position:
+                    bytes: 19
+                    line: 2
+                    character: 5
+                  token_type:
+                    type: Whitespace
+                    characters: "    "
+              token:
+                start_position:
+                  bytes: 19
+                  line: 2
+                  character: 5
+                end_position:
+                  bytes: 25
+                  line: 2
+                  character: 11
+                token_type:
+                  type: Identifier
+                  identifier: typeof
+              trailing_trivia: []
+            parentheses:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 25
+                      line: 2
+                      character: 11
+                    end_position:
+                      bytes: 26
+                      line: 2
+                      character: 12
+                    token_type:
+                      type: Symbol
+                      symbol: (
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 28
+                      line: 2
+                      character: 14
+                    end_position:
+                      bytes: 29
+                      line: 2
+                      character: 15
+                    token_type:
+                      type: Symbol
+                      symbol: )
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 29
+                        line: 2
+                        character: 15
+                      end_position:
+                        bytes: 31
+                        line: 2
+                        character: 16
+                      token_type:
+                        type: Whitespace
+                        characters: "\r\n"
+            inner:
+              TableConstructor:
+                braces:
+                  tokens:
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 26
+                          line: 2
+                          character: 12
+                        end_position:
+                          bytes: 27
+                          line: 2
+                          character: 13
+                        token_type:
+                          type: Symbol
+                          symbol: "{"
+                      trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 27
+                          line: 2
+                          character: 13
+                        end_position:
+                          bytes: 28
+                          line: 2
+                          character: 14
+                        token_type:
+                          type: Symbol
+                          symbol: "}"
+                      trailing_trivia: []
+                fields:
+                  pairs: []
+    - ~

--- a/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/ast.snap
@@ -78,22 +78,22 @@ stmts:
                 line: 1
                 character: 14
               end_position:
-                bytes: 15
+                bytes: 14
                 line: 1
-                character: 15
+                character: 14
               token_type:
                 type: Whitespace
-                characters: "\r\n"
+                characters: "\n"
         declare_as:
           Typeof:
             typeof_token:
               leading_trivia:
                 - start_position:
-                    bytes: 15
+                    bytes: 14
                     line: 2
                     character: 1
                   end_position:
-                    bytes: 19
+                    bytes: 18
                     line: 2
                     character: 5
                   token_type:
@@ -101,11 +101,11 @@ stmts:
                     characters: "    "
               token:
                 start_position:
-                  bytes: 19
+                  bytes: 18
                   line: 2
                   character: 5
                 end_position:
-                  bytes: 25
+                  bytes: 24
                   line: 2
                   character: 11
                 token_type:
@@ -117,11 +117,11 @@ stmts:
                 - leading_trivia: []
                   token:
                     start_position:
-                      bytes: 25
+                      bytes: 24
                       line: 2
                       character: 11
                     end_position:
-                      bytes: 26
+                      bytes: 25
                       line: 2
                       character: 12
                     token_type:
@@ -131,11 +131,11 @@ stmts:
                 - leading_trivia: []
                   token:
                     start_position:
-                      bytes: 28
+                      bytes: 27
                       line: 2
                       character: 14
                     end_position:
-                      bytes: 29
+                      bytes: 28
                       line: 2
                       character: 15
                     token_type:
@@ -143,16 +143,16 @@ stmts:
                       symbol: )
                   trailing_trivia:
                     - start_position:
-                        bytes: 29
+                        bytes: 28
                         line: 2
                         character: 15
                       end_position:
-                        bytes: 31
+                        bytes: 29
                         line: 2
-                        character: 16
+                        character: 15
                       token_type:
                         type: Whitespace
-                        characters: "\r\n"
+                        characters: "\n"
             inner:
               TableConstructor:
                 braces:
@@ -160,11 +160,11 @@ stmts:
                     - leading_trivia: []
                       token:
                         start_position:
-                          bytes: 26
+                          bytes: 25
                           line: 2
                           character: 12
                         end_position:
-                          bytes: 27
+                          bytes: 26
                           line: 2
                           character: 13
                         token_type:
@@ -174,11 +174,11 @@ stmts:
                     - leading_trivia: []
                       token:
                         start_position:
-                          bytes: 27
+                          bytes: 26
                           line: 2
                           character: 13
                         end_position:
-                          bytes: 28
+                          bytes: 27
                           line: 2
                           character: 14
                         token_type:

--- a/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/source.lua
+++ b/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/source.lua
@@ -1,0 +1,2 @@
+type TypeOf =
+    typeof({})

--- a/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/tokens.snap
@@ -63,95 +63,95 @@ input_file: full-moon/tests/roblox_cases/pass/multiline_typeof_regression
     line: 1
     character: 14
   end_position:
-    bytes: 15
+    bytes: 14
     line: 1
-    character: 15
+    character: 14
   token_type:
     type: Whitespace
-    characters: "\r\n"
+    characters: "\n"
 - start_position:
-    bytes: 15
+    bytes: 14
     line: 2
     character: 1
   end_position:
-    bytes: 19
+    bytes: 18
     line: 2
     character: 5
   token_type:
     type: Whitespace
     characters: "    "
 - start_position:
-    bytes: 19
+    bytes: 18
     line: 2
     character: 5
   end_position:
-    bytes: 25
+    bytes: 24
     line: 2
     character: 11
   token_type:
     type: Identifier
     identifier: typeof
 - start_position:
-    bytes: 25
+    bytes: 24
     line: 2
     character: 11
   end_position:
-    bytes: 26
+    bytes: 25
     line: 2
     character: 12
   token_type:
     type: Symbol
     symbol: (
 - start_position:
-    bytes: 26
+    bytes: 25
     line: 2
     character: 12
   end_position:
-    bytes: 27
+    bytes: 26
     line: 2
     character: 13
   token_type:
     type: Symbol
     symbol: "{"
 - start_position:
-    bytes: 27
+    bytes: 26
     line: 2
     character: 13
   end_position:
-    bytes: 28
+    bytes: 27
     line: 2
     character: 14
   token_type:
     type: Symbol
     symbol: "}"
 - start_position:
-    bytes: 28
+    bytes: 27
     line: 2
     character: 14
   end_position:
-    bytes: 29
+    bytes: 28
     line: 2
     character: 15
   token_type:
     type: Symbol
     symbol: )
 - start_position:
-    bytes: 29
+    bytes: 28
     line: 2
     character: 15
   end_position:
-    bytes: 31
+    bytes: 29
     line: 2
-    character: 16
+    character: 15
   token_type:
     type: Whitespace
-    characters: "\r\n"
+    characters: "\n"
 - start_position:
-    bytes: 31
+    bytes: 29
     line: 3
     character: 1
   end_position:
-    bytes: 31
+    bytes: 29
     line: 3
     character: 1
   token_type:

--- a/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/multiline_typeof_regression/tokens.snap
@@ -1,0 +1,158 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+input_file: full-moon/tests/roblox_cases/pass/multiline_typeof_regression
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 4
+    line: 1
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 4
+    line: 1
+    character: 5
+  end_position:
+    bytes: 5
+    line: 1
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 5
+    line: 1
+    character: 6
+  end_position:
+    bytes: 11
+    line: 1
+    character: 12
+  token_type:
+    type: Identifier
+    identifier: TypeOf
+- start_position:
+    bytes: 11
+    line: 1
+    character: 12
+  end_position:
+    bytes: 12
+    line: 1
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 12
+    line: 1
+    character: 13
+  end_position:
+    bytes: 13
+    line: 1
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 13
+    line: 1
+    character: 14
+  end_position:
+    bytes: 15
+    line: 1
+    character: 15
+  token_type:
+    type: Whitespace
+    characters: "\r\n"
+- start_position:
+    bytes: 15
+    line: 2
+    character: 1
+  end_position:
+    bytes: 19
+    line: 2
+    character: 5
+  token_type:
+    type: Whitespace
+    characters: "    "
+- start_position:
+    bytes: 19
+    line: 2
+    character: 5
+  end_position:
+    bytes: 25
+    line: 2
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: typeof
+- start_position:
+    bytes: 25
+    line: 2
+    character: 11
+  end_position:
+    bytes: 26
+    line: 2
+    character: 12
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 26
+    line: 2
+    character: 12
+  end_position:
+    bytes: 27
+    line: 2
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "{"
+- start_position:
+    bytes: 27
+    line: 2
+    character: 13
+  end_position:
+    bytes: 28
+    line: 2
+    character: 14
+  token_type:
+    type: Symbol
+    symbol: "}"
+- start_position:
+    bytes: 28
+    line: 2
+    character: 14
+  end_position:
+    bytes: 29
+    line: 2
+    character: 15
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 29
+    line: 2
+    character: 15
+  end_position:
+    bytes: 31
+    line: 2
+    character: 16
+  token_type:
+    type: Whitespace
+    characters: "\r\n"
+- start_position:
+    bytes: 31
+    line: 3
+    character: 1
+  end_position:
+    bytes: 31
+    line: 3
+    character: 1
+  token_type:
+    type: Eof


### PR DESCRIPTION
Fixes #314

The following case will fail to parse correctly because the check at [this line](https://github.com/Kampfkarren/full-moon/blob/674154d21df9a367fed8b179167d9bd2ce811780/full-moon/src/ast/parsers.rs#L2348C13-L2348C46) includes all trivia. When including the trivia, we end up with a check that looks like ``"    typeof" = "typeof"``, which of course fails.
```lua
type T =
    typeof({})
```

This PR turns the token into a string instead of the token reference in the check, as the token does not contain trivia.