### PR TITLE
Fix leading | and & in generic type params and function return types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Luau: fixed leading `|` and `&` not parsing in generic type arguments, e.g. `Box<| string | number>` (#350)
+- Luau: fixed leading `|` and `&` not parsing in function type return types, e.g. `() -> | string | number`
+
 ## [2.1.1] - 2026-01-22
 ### Fixed
 - Fixed docs not compiling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
-- Luau: fixed leading `|` and `&` not parsing in generic type arguments, e.g. `Box<| string | number>` (#350)
-- Luau: fixed leading `|` and `&` not parsing in function type return types, e.g. `() -> | string | number`
+- Luau: fixed leading `|` and `&` not parsing in generic type arguments and function type return types, e.g. `Box<| string | number>` (#350)
 
 ## [2.1.1] - 2026-01-22
 ### Fixed

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2574,6 +2574,16 @@ fn parse_type(state: &mut ParserState) -> ParserResult<ast::TypeInfo> {
 
 #[cfg(feature = "luau")]
 fn parse_type_or_pack(state: &mut ParserState) -> ParserResult<ast::TypeInfo> {
+    // A leading | or & can only start a union/intersection type, never a type pack
+    if let Ok(current_token) = state.current() {
+        if let TokenType::Symbol {
+            symbol: Symbol::Pipe | Symbol::Ampersand,
+        } = current_token.token_type()
+        {
+            return parse_type_suffix(state, None);
+        }
+    }
+
     let ParserResult::Value(simple_type) = parse_simple_type(state, SimpleTypeStyle::AllowPack)
     else {
         return ParserResult::LexerMoved;

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -2574,14 +2574,14 @@ fn parse_type(state: &mut ParserState) -> ParserResult<ast::TypeInfo> {
 
 #[cfg(feature = "luau")]
 fn parse_type_or_pack(state: &mut ParserState) -> ParserResult<ast::TypeInfo> {
-    // A leading | or & can only start a union/intersection type, never a type pack
-    if let Ok(current_token) = state.current() {
-        if let TokenType::Symbol {
-            symbol: Symbol::Pipe | Symbol::Ampersand,
-        } = current_token.token_type()
-        {
-            return parse_type_suffix(state, None);
-        }
+    if matches!(
+        state.current(),
+        Ok(token) if matches!(
+            token.token_type(),
+            TokenType::Symbol { symbol: Symbol::Pipe | Symbol::Ampersand }
+        )
+    ) {
+        return parse_type_suffix(state, None);
     }
 
     let ParserResult::Value(simple_type) = parse_simple_type(state, SimpleTypeStyle::AllowPack)

--- a/full-moon/tests/roblox_cases/pass/types_leading_union_generic/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_leading_union_generic/ast.snap
@@ -1,0 +1,1250 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/types_leading_union_generic
+---
+stmts:
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 0
+                line: 1
+                character: 1
+              end_position:
+                bytes: 50
+                line: 1
+                character: 51
+              token_type:
+                type: SingleLineComment
+                comment: " Issue #350: leading | in generic type arguments"
+            - start_position:
+                bytes: 50
+                line: 1
+                character: 51
+              end_position:
+                bytes: 51
+                line: 1
+                character: 51
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 51
+              line: 2
+              character: 1
+            end_position:
+              bytes: 55
+              line: 2
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 55
+                line: 2
+                character: 5
+              end_position:
+                bytes: 56
+                line: 2
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 56
+              line: 2
+              character: 6
+            end_position:
+              bytes: 60
+              line: 2
+              character: 10
+            token_type:
+              type: Identifier
+              identifier: Test
+          trailing_trivia:
+            - start_position:
+                bytes: 60
+                line: 2
+                character: 10
+              end_position:
+                bytes: 61
+                line: 2
+                character: 11
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 61
+              line: 2
+              character: 11
+            end_position:
+              bytes: 62
+              line: 2
+              character: 12
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 62
+                line: 2
+                character: 12
+              end_position:
+                bytes: 63
+                line: 2
+                character: 13
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Generic:
+            base:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 63
+                  line: 2
+                  character: 13
+                end_position:
+                  bytes: 66
+                  line: 2
+                  character: 16
+                token_type:
+                  type: Identifier
+                  identifier: Box
+              trailing_trivia: []
+            arrows:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 66
+                      line: 2
+                      character: 16
+                    end_position:
+                      bytes: 67
+                      line: 2
+                      character: 17
+                    token_type:
+                      type: Symbol
+                      symbol: "<"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 67
+                        line: 2
+                        character: 17
+                      end_position:
+                        bytes: 68
+                        line: 2
+                        character: 17
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 94
+                      line: 5
+                      character: 1
+                    end_position:
+                      bytes: 95
+                      line: 5
+                      character: 2
+                    token_type:
+                      type: Symbol
+                      symbol: ">"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 95
+                        line: 5
+                        character: 2
+                      end_position:
+                        bytes: 96
+                        line: 5
+                        character: 2
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+            generics:
+              pairs:
+                - End:
+                    Union:
+                      leading:
+                        leading_trivia:
+                          - start_position:
+                              bytes: 68
+                              line: 3
+                              character: 1
+                            end_position:
+                              bytes: 72
+                              line: 3
+                              character: 5
+                            token_type:
+                              type: Whitespace
+                              characters: "    "
+                        token:
+                          start_position:
+                            bytes: 72
+                            line: 3
+                            character: 5
+                          end_position:
+                            bytes: 73
+                            line: 3
+                            character: 6
+                          token_type:
+                            type: Symbol
+                            symbol: "|"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 73
+                              line: 3
+                              character: 6
+                            end_position:
+                              bytes: 74
+                              line: 3
+                              character: 7
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      types:
+                        pairs:
+                          - Punctuated:
+                              - Basic:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 74
+                                      line: 3
+                                      character: 7
+                                    end_position:
+                                      bytes: 80
+                                      line: 3
+                                      character: 13
+                                    token_type:
+                                      type: Identifier
+                                      identifier: string
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 80
+                                        line: 3
+                                        character: 13
+                                      end_position:
+                                        bytes: 81
+                                        line: 3
+                                        character: 13
+                                      token_type:
+                                        type: Whitespace
+                                        characters: "\n"
+                              - leading_trivia:
+                                  - start_position:
+                                      bytes: 81
+                                      line: 4
+                                      character: 1
+                                    end_position:
+                                      bytes: 85
+                                      line: 4
+                                      character: 5
+                                    token_type:
+                                      type: Whitespace
+                                      characters: "    "
+                                token:
+                                  start_position:
+                                    bytes: 85
+                                    line: 4
+                                    character: 5
+                                  end_position:
+                                    bytes: 86
+                                    line: 4
+                                    character: 6
+                                  token_type:
+                                    type: Symbol
+                                    symbol: "|"
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 86
+                                      line: 4
+                                      character: 6
+                                    end_position:
+                                      bytes: 87
+                                      line: 4
+                                      character: 7
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                          - End:
+                              Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 87
+                                    line: 4
+                                    character: 7
+                                  end_position:
+                                    bytes: 93
+                                    line: 4
+                                    character: 13
+                                  token_type:
+                                    type: Identifier
+                                    identifier: number
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 93
+                                      line: 4
+                                      character: 13
+                                    end_position:
+                                      bytes: 94
+                                      line: 4
+                                      character: 13
+                                    token_type:
+                                      type: Whitespace
+                                      characters: "\n"
+    - ~
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 96
+                line: 6
+                character: 1
+              end_position:
+                bytes: 97
+                line: 6
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 97
+              line: 7
+              character: 1
+            end_position:
+              bytes: 101
+              line: 7
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 101
+                line: 7
+                character: 5
+              end_position:
+                bytes: 102
+                line: 7
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 102
+              line: 7
+              character: 6
+            end_position:
+              bytes: 107
+              line: 7
+              character: 11
+            token_type:
+              type: Identifier
+              identifier: Test2
+          trailing_trivia:
+            - start_position:
+                bytes: 107
+                line: 7
+                character: 11
+              end_position:
+                bytes: 108
+                line: 7
+                character: 12
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 108
+              line: 7
+              character: 12
+            end_position:
+              bytes: 109
+              line: 7
+              character: 13
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 109
+                line: 7
+                character: 13
+              end_position:
+                bytes: 110
+                line: 7
+                character: 14
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Generic:
+            base:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 110
+                  line: 7
+                  character: 14
+                end_position:
+                  bytes: 113
+                  line: 7
+                  character: 17
+                token_type:
+                  type: Identifier
+                  identifier: Box
+              trailing_trivia: []
+            arrows:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 113
+                      line: 7
+                      character: 17
+                    end_position:
+                      bytes: 114
+                      line: 7
+                      character: 18
+                    token_type:
+                      type: Symbol
+                      symbol: "<"
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 131
+                      line: 7
+                      character: 35
+                    end_position:
+                      bytes: 132
+                      line: 7
+                      character: 36
+                    token_type:
+                      type: Symbol
+                      symbol: ">"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 132
+                        line: 7
+                        character: 36
+                      end_position:
+                        bytes: 133
+                        line: 7
+                        character: 36
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+            generics:
+              pairs:
+                - End:
+                    Union:
+                      leading:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 114
+                            line: 7
+                            character: 18
+                          end_position:
+                            bytes: 115
+                            line: 7
+                            character: 19
+                          token_type:
+                            type: Symbol
+                            symbol: "|"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 115
+                              line: 7
+                              character: 19
+                            end_position:
+                              bytes: 116
+                              line: 7
+                              character: 20
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      types:
+                        pairs:
+                          - Punctuated:
+                              - Basic:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 116
+                                      line: 7
+                                      character: 20
+                                    end_position:
+                                      bytes: 122
+                                      line: 7
+                                      character: 26
+                                    token_type:
+                                      type: Identifier
+                                      identifier: string
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 122
+                                        line: 7
+                                        character: 26
+                                      end_position:
+                                        bytes: 123
+                                        line: 7
+                                        character: 27
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 123
+                                    line: 7
+                                    character: 27
+                                  end_position:
+                                    bytes: 124
+                                    line: 7
+                                    character: 28
+                                  token_type:
+                                    type: Symbol
+                                    symbol: "|"
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 124
+                                      line: 7
+                                      character: 28
+                                    end_position:
+                                      bytes: 125
+                                      line: 7
+                                      character: 29
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                          - End:
+                              Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 125
+                                    line: 7
+                                    character: 29
+                                  end_position:
+                                    bytes: 131
+                                    line: 7
+                                    character: 35
+                                  token_type:
+                                    type: Identifier
+                                    identifier: number
+                                trailing_trivia: []
+    - ~
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 133
+                line: 8
+                character: 1
+              end_position:
+                bytes: 134
+                line: 8
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+            - start_position:
+                bytes: 134
+                line: 9
+                character: 1
+              end_position:
+                bytes: 192
+                line: 9
+                character: 59
+              token_type:
+                type: SingleLineComment
+                comment: " Issue #311 comment: leading & in generic type arguments"
+            - start_position:
+                bytes: 192
+                line: 9
+                character: 59
+              end_position:
+                bytes: 193
+                line: 9
+                character: 59
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 193
+              line: 10
+              character: 1
+            end_position:
+              bytes: 197
+              line: 10
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 197
+                line: 10
+                character: 5
+              end_position:
+                bytes: 198
+                line: 10
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 198
+              line: 10
+              character: 6
+            end_position:
+              bytes: 203
+              line: 10
+              character: 11
+            token_type:
+              type: Identifier
+              identifier: Test3
+          trailing_trivia:
+            - start_position:
+                bytes: 203
+                line: 10
+                character: 11
+              end_position:
+                bytes: 204
+                line: 10
+                character: 12
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 204
+              line: 10
+              character: 12
+            end_position:
+              bytes: 205
+              line: 10
+              character: 13
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 205
+                line: 10
+                character: 13
+              end_position:
+                bytes: 206
+                line: 10
+                character: 14
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Generic:
+            base:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 206
+                  line: 10
+                  character: 14
+                end_position:
+                  bytes: 213
+                  line: 10
+                  character: 21
+                token_type:
+                  type: Identifier
+                  identifier: Generic
+              trailing_trivia: []
+            arrows:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 213
+                      line: 10
+                      character: 21
+                    end_position:
+                      bytes: 214
+                      line: 10
+                      character: 22
+                    token_type:
+                      type: Symbol
+                      symbol: "<"
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 232
+                      line: 10
+                      character: 40
+                    end_position:
+                      bytes: 233
+                      line: 10
+                      character: 41
+                    token_type:
+                      type: Symbol
+                      symbol: ">"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 233
+                        line: 10
+                        character: 41
+                      end_position:
+                        bytes: 234
+                        line: 10
+                        character: 41
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+            generics:
+              pairs:
+                - End:
+                    Intersection:
+                      leading:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 214
+                            line: 10
+                            character: 22
+                          end_position:
+                            bytes: 215
+                            line: 10
+                            character: 23
+                          token_type:
+                            type: Symbol
+                            symbol: "&"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 215
+                              line: 10
+                              character: 23
+                            end_position:
+                              bytes: 216
+                              line: 10
+                              character: 24
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      types:
+                        pairs:
+                          - Punctuated:
+                              - Basic:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 216
+                                      line: 10
+                                      character: 24
+                                    end_position:
+                                      bytes: 223
+                                      line: 10
+                                      character: 31
+                                    token_type:
+                                      type: Identifier
+                                      identifier: boolean
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 223
+                                        line: 10
+                                        character: 31
+                                      end_position:
+                                        bytes: 224
+                                        line: 10
+                                        character: 32
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 224
+                                    line: 10
+                                    character: 32
+                                  end_position:
+                                    bytes: 225
+                                    line: 10
+                                    character: 33
+                                  token_type:
+                                    type: Symbol
+                                    symbol: "&"
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 225
+                                      line: 10
+                                      character: 33
+                                    end_position:
+                                      bytes: 226
+                                      line: 10
+                                      character: 34
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                          - End:
+                              Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 226
+                                    line: 10
+                                    character: 34
+                                  end_position:
+                                    bytes: 232
+                                    line: 10
+                                    character: 40
+                                  token_type:
+                                    type: Identifier
+                                    identifier: string
+                                trailing_trivia: []
+    - ~
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 234
+                line: 11
+                character: 1
+              end_position:
+                bytes: 235
+                line: 11
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 235
+              line: 12
+              character: 1
+            end_position:
+              bytes: 239
+              line: 12
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 239
+                line: 12
+                character: 5
+              end_position:
+                bytes: 240
+                line: 12
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 240
+              line: 12
+              character: 6
+            end_position:
+              bytes: 245
+              line: 12
+              character: 11
+            token_type:
+              type: Identifier
+              identifier: Test4
+          trailing_trivia:
+            - start_position:
+                bytes: 245
+                line: 12
+                character: 11
+              end_position:
+                bytes: 246
+                line: 12
+                character: 12
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 246
+              line: 12
+              character: 12
+            end_position:
+              bytes: 247
+              line: 12
+              character: 13
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 247
+                line: 12
+                character: 13
+              end_position:
+                bytes: 248
+                line: 12
+                character: 14
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Generic:
+            base:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 248
+                  line: 12
+                  character: 14
+                end_position:
+                  bytes: 251
+                  line: 12
+                  character: 17
+                token_type:
+                  type: Identifier
+                  identifier: Map
+              trailing_trivia: []
+            arrows:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 251
+                      line: 12
+                      character: 17
+                    end_position:
+                      bytes: 252
+                      line: 12
+                      character: 18
+                    token_type:
+                      type: Symbol
+                      symbol: "<"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 252
+                        line: 12
+                        character: 18
+                      end_position:
+                        bytes: 253
+                        line: 12
+                        character: 18
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 296
+                      line: 15
+                      character: 1
+                    end_position:
+                      bytes: 297
+                      line: 15
+                      character: 2
+                    token_type:
+                      type: Symbol
+                      symbol: ">"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 297
+                        line: 15
+                        character: 2
+                      end_position:
+                        bytes: 298
+                        line: 15
+                        character: 2
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+            generics:
+              pairs:
+                - Punctuated:
+                    - Intersection:
+                        leading:
+                          leading_trivia:
+                            - start_position:
+                                bytes: 253
+                                line: 13
+                                character: 1
+                              end_position:
+                                bytes: 257
+                                line: 13
+                                character: 5
+                              token_type:
+                                type: Whitespace
+                                characters: "    "
+                          token:
+                            start_position:
+                              bytes: 257
+                              line: 13
+                              character: 5
+                            end_position:
+                              bytes: 258
+                              line: 13
+                              character: 6
+                            token_type:
+                              type: Symbol
+                              symbol: "&"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 258
+                                line: 13
+                                character: 6
+                              end_position:
+                                bytes: 259
+                                line: 13
+                                character: 7
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                        types:
+                          pairs:
+                            - Punctuated:
+                                - Basic:
+                                    leading_trivia: []
+                                    token:
+                                      start_position:
+                                        bytes: 259
+                                        line: 13
+                                        character: 7
+                                      end_position:
+                                        bytes: 265
+                                        line: 13
+                                        character: 13
+                                      token_type:
+                                        type: Identifier
+                                        identifier: string
+                                    trailing_trivia:
+                                      - start_position:
+                                          bytes: 265
+                                          line: 13
+                                          character: 13
+                                        end_position:
+                                          bytes: 266
+                                          line: 13
+                                          character: 14
+                                        token_type:
+                                          type: Whitespace
+                                          characters: " "
+                                - leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 266
+                                      line: 13
+                                      character: 14
+                                    end_position:
+                                      bytes: 267
+                                      line: 13
+                                      character: 15
+                                    token_type:
+                                      type: Symbol
+                                      symbol: "&"
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 267
+                                        line: 13
+                                        character: 15
+                                      end_position:
+                                        bytes: 268
+                                        line: 13
+                                        character: 16
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                            - End:
+                                Basic:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 268
+                                      line: 13
+                                      character: 16
+                                    end_position:
+                                      bytes: 274
+                                      line: 13
+                                      character: 22
+                                    token_type:
+                                      type: Identifier
+                                      identifier: number
+                                  trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 274
+                          line: 13
+                          character: 22
+                        end_position:
+                          bytes: 275
+                          line: 13
+                          character: 23
+                        token_type:
+                          type: Symbol
+                          symbol: ","
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 275
+                            line: 13
+                            character: 23
+                          end_position:
+                            bytes: 276
+                            line: 13
+                            character: 23
+                          token_type:
+                            type: Whitespace
+                            characters: "\n"
+                - End:
+                    Union:
+                      leading:
+                        leading_trivia:
+                          - start_position:
+                              bytes: 276
+                              line: 14
+                              character: 1
+                            end_position:
+                              bytes: 280
+                              line: 14
+                              character: 5
+                            token_type:
+                              type: Whitespace
+                              characters: "    "
+                        token:
+                          start_position:
+                            bytes: 280
+                            line: 14
+                            character: 5
+                          end_position:
+                            bytes: 281
+                            line: 14
+                            character: 6
+                          token_type:
+                            type: Symbol
+                            symbol: "|"
+                        trailing_trivia:
+                          - start_position:
+                              bytes: 281
+                              line: 14
+                              character: 6
+                            end_position:
+                              bytes: 282
+                              line: 14
+                              character: 7
+                            token_type:
+                              type: Whitespace
+                              characters: " "
+                      types:
+                        pairs:
+                          - Punctuated:
+                              - Basic:
+                                  leading_trivia: []
+                                  token:
+                                    start_position:
+                                      bytes: 282
+                                      line: 14
+                                      character: 7
+                                    end_position:
+                                      bytes: 289
+                                      line: 14
+                                      character: 14
+                                    token_type:
+                                      type: Identifier
+                                      identifier: boolean
+                                  trailing_trivia:
+                                    - start_position:
+                                        bytes: 289
+                                        line: 14
+                                        character: 14
+                                      end_position:
+                                        bytes: 290
+                                        line: 14
+                                        character: 15
+                                      token_type:
+                                        type: Whitespace
+                                        characters: " "
+                              - leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 290
+                                    line: 14
+                                    character: 15
+                                  end_position:
+                                    bytes: 291
+                                    line: 14
+                                    character: 16
+                                  token_type:
+                                    type: Symbol
+                                    symbol: "|"
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 291
+                                      line: 14
+                                      character: 16
+                                    end_position:
+                                      bytes: 292
+                                      line: 14
+                                      character: 17
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                          - End:
+                              Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 292
+                                    line: 14
+                                    character: 17
+                                  end_position:
+                                    bytes: 295
+                                    line: 14
+                                    character: 20
+                                  token_type:
+                                    type: Symbol
+                                    symbol: nil
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 295
+                                      line: 14
+                                      character: 20
+                                    end_position:
+                                      bytes: 296
+                                      line: 14
+                                      character: 20
+                                    token_type:
+                                      type: Whitespace
+                                      characters: "\n"
+    - ~

--- a/full-moon/tests/roblox_cases/pass/types_leading_union_generic/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_leading_union_generic/source.lua
@@ -1,0 +1,15 @@
+-- Issue #350: leading | in generic type arguments
+type Test = Box<
+    | string
+    | number
+>
+
+type Test2 = Box<| string | number>
+
+-- Issue #311 comment: leading & in generic type arguments
+type Test3 = Generic<& boolean & string>
+
+type Test4 = Map<
+    & string & number,
+    | boolean | nil
+>

--- a/full-moon/tests/roblox_cases/pass/types_leading_union_generic/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_leading_union_generic/tokens.snap
@@ -1,0 +1,1027 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+input_file: full-moon/tests/roblox_cases/pass/types_leading_union_generic
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 50
+    line: 1
+    character: 51
+  token_type:
+    type: SingleLineComment
+    comment: " Issue #350: leading | in generic type arguments"
+- start_position:
+    bytes: 50
+    line: 1
+    character: 51
+  end_position:
+    bytes: 51
+    line: 1
+    character: 51
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 51
+    line: 2
+    character: 1
+  end_position:
+    bytes: 55
+    line: 2
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 55
+    line: 2
+    character: 5
+  end_position:
+    bytes: 56
+    line: 2
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 56
+    line: 2
+    character: 6
+  end_position:
+    bytes: 60
+    line: 2
+    character: 10
+  token_type:
+    type: Identifier
+    identifier: Test
+- start_position:
+    bytes: 60
+    line: 2
+    character: 10
+  end_position:
+    bytes: 61
+    line: 2
+    character: 11
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 61
+    line: 2
+    character: 11
+  end_position:
+    bytes: 62
+    line: 2
+    character: 12
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 62
+    line: 2
+    character: 12
+  end_position:
+    bytes: 63
+    line: 2
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 63
+    line: 2
+    character: 13
+  end_position:
+    bytes: 66
+    line: 2
+    character: 16
+  token_type:
+    type: Identifier
+    identifier: Box
+- start_position:
+    bytes: 66
+    line: 2
+    character: 16
+  end_position:
+    bytes: 67
+    line: 2
+    character: 17
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 67
+    line: 2
+    character: 17
+  end_position:
+    bytes: 68
+    line: 2
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 68
+    line: 3
+    character: 1
+  end_position:
+    bytes: 72
+    line: 3
+    character: 5
+  token_type:
+    type: Whitespace
+    characters: "    "
+- start_position:
+    bytes: 72
+    line: 3
+    character: 5
+  end_position:
+    bytes: 73
+    line: 3
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 73
+    line: 3
+    character: 6
+  end_position:
+    bytes: 74
+    line: 3
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 74
+    line: 3
+    character: 7
+  end_position:
+    bytes: 80
+    line: 3
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 80
+    line: 3
+    character: 13
+  end_position:
+    bytes: 81
+    line: 3
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 81
+    line: 4
+    character: 1
+  end_position:
+    bytes: 85
+    line: 4
+    character: 5
+  token_type:
+    type: Whitespace
+    characters: "    "
+- start_position:
+    bytes: 85
+    line: 4
+    character: 5
+  end_position:
+    bytes: 86
+    line: 4
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 86
+    line: 4
+    character: 6
+  end_position:
+    bytes: 87
+    line: 4
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 87
+    line: 4
+    character: 7
+  end_position:
+    bytes: 93
+    line: 4
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 93
+    line: 4
+    character: 13
+  end_position:
+    bytes: 94
+    line: 4
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 94
+    line: 5
+    character: 1
+  end_position:
+    bytes: 95
+    line: 5
+    character: 2
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 95
+    line: 5
+    character: 2
+  end_position:
+    bytes: 96
+    line: 5
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 96
+    line: 6
+    character: 1
+  end_position:
+    bytes: 97
+    line: 6
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 97
+    line: 7
+    character: 1
+  end_position:
+    bytes: 101
+    line: 7
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 101
+    line: 7
+    character: 5
+  end_position:
+    bytes: 102
+    line: 7
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 102
+    line: 7
+    character: 6
+  end_position:
+    bytes: 107
+    line: 7
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: Test2
+- start_position:
+    bytes: 107
+    line: 7
+    character: 11
+  end_position:
+    bytes: 108
+    line: 7
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 108
+    line: 7
+    character: 12
+  end_position:
+    bytes: 109
+    line: 7
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 109
+    line: 7
+    character: 13
+  end_position:
+    bytes: 110
+    line: 7
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 110
+    line: 7
+    character: 14
+  end_position:
+    bytes: 113
+    line: 7
+    character: 17
+  token_type:
+    type: Identifier
+    identifier: Box
+- start_position:
+    bytes: 113
+    line: 7
+    character: 17
+  end_position:
+    bytes: 114
+    line: 7
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 114
+    line: 7
+    character: 18
+  end_position:
+    bytes: 115
+    line: 7
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 115
+    line: 7
+    character: 19
+  end_position:
+    bytes: 116
+    line: 7
+    character: 20
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 116
+    line: 7
+    character: 20
+  end_position:
+    bytes: 122
+    line: 7
+    character: 26
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 122
+    line: 7
+    character: 26
+  end_position:
+    bytes: 123
+    line: 7
+    character: 27
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 123
+    line: 7
+    character: 27
+  end_position:
+    bytes: 124
+    line: 7
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 124
+    line: 7
+    character: 28
+  end_position:
+    bytes: 125
+    line: 7
+    character: 29
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 125
+    line: 7
+    character: 29
+  end_position:
+    bytes: 131
+    line: 7
+    character: 35
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 131
+    line: 7
+    character: 35
+  end_position:
+    bytes: 132
+    line: 7
+    character: 36
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 132
+    line: 7
+    character: 36
+  end_position:
+    bytes: 133
+    line: 7
+    character: 36
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 133
+    line: 8
+    character: 1
+  end_position:
+    bytes: 134
+    line: 8
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 134
+    line: 9
+    character: 1
+  end_position:
+    bytes: 192
+    line: 9
+    character: 59
+  token_type:
+    type: SingleLineComment
+    comment: " Issue #311 comment: leading & in generic type arguments"
+- start_position:
+    bytes: 192
+    line: 9
+    character: 59
+  end_position:
+    bytes: 193
+    line: 9
+    character: 59
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 193
+    line: 10
+    character: 1
+  end_position:
+    bytes: 197
+    line: 10
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 197
+    line: 10
+    character: 5
+  end_position:
+    bytes: 198
+    line: 10
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 198
+    line: 10
+    character: 6
+  end_position:
+    bytes: 203
+    line: 10
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: Test3
+- start_position:
+    bytes: 203
+    line: 10
+    character: 11
+  end_position:
+    bytes: 204
+    line: 10
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 204
+    line: 10
+    character: 12
+  end_position:
+    bytes: 205
+    line: 10
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 205
+    line: 10
+    character: 13
+  end_position:
+    bytes: 206
+    line: 10
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 206
+    line: 10
+    character: 14
+  end_position:
+    bytes: 213
+    line: 10
+    character: 21
+  token_type:
+    type: Identifier
+    identifier: Generic
+- start_position:
+    bytes: 213
+    line: 10
+    character: 21
+  end_position:
+    bytes: 214
+    line: 10
+    character: 22
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 214
+    line: 10
+    character: 22
+  end_position:
+    bytes: 215
+    line: 10
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 215
+    line: 10
+    character: 23
+  end_position:
+    bytes: 216
+    line: 10
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 216
+    line: 10
+    character: 24
+  end_position:
+    bytes: 223
+    line: 10
+    character: 31
+  token_type:
+    type: Identifier
+    identifier: boolean
+- start_position:
+    bytes: 223
+    line: 10
+    character: 31
+  end_position:
+    bytes: 224
+    line: 10
+    character: 32
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 224
+    line: 10
+    character: 32
+  end_position:
+    bytes: 225
+    line: 10
+    character: 33
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 225
+    line: 10
+    character: 33
+  end_position:
+    bytes: 226
+    line: 10
+    character: 34
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 226
+    line: 10
+    character: 34
+  end_position:
+    bytes: 232
+    line: 10
+    character: 40
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 232
+    line: 10
+    character: 40
+  end_position:
+    bytes: 233
+    line: 10
+    character: 41
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 233
+    line: 10
+    character: 41
+  end_position:
+    bytes: 234
+    line: 10
+    character: 41
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 234
+    line: 11
+    character: 1
+  end_position:
+    bytes: 235
+    line: 11
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 235
+    line: 12
+    character: 1
+  end_position:
+    bytes: 239
+    line: 12
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 239
+    line: 12
+    character: 5
+  end_position:
+    bytes: 240
+    line: 12
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 240
+    line: 12
+    character: 6
+  end_position:
+    bytes: 245
+    line: 12
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: Test4
+- start_position:
+    bytes: 245
+    line: 12
+    character: 11
+  end_position:
+    bytes: 246
+    line: 12
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 246
+    line: 12
+    character: 12
+  end_position:
+    bytes: 247
+    line: 12
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 247
+    line: 12
+    character: 13
+  end_position:
+    bytes: 248
+    line: 12
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 248
+    line: 12
+    character: 14
+  end_position:
+    bytes: 251
+    line: 12
+    character: 17
+  token_type:
+    type: Identifier
+    identifier: Map
+- start_position:
+    bytes: 251
+    line: 12
+    character: 17
+  end_position:
+    bytes: 252
+    line: 12
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: "<"
+- start_position:
+    bytes: 252
+    line: 12
+    character: 18
+  end_position:
+    bytes: 253
+    line: 12
+    character: 18
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 253
+    line: 13
+    character: 1
+  end_position:
+    bytes: 257
+    line: 13
+    character: 5
+  token_type:
+    type: Whitespace
+    characters: "    "
+- start_position:
+    bytes: 257
+    line: 13
+    character: 5
+  end_position:
+    bytes: 258
+    line: 13
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 258
+    line: 13
+    character: 6
+  end_position:
+    bytes: 259
+    line: 13
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 259
+    line: 13
+    character: 7
+  end_position:
+    bytes: 265
+    line: 13
+    character: 13
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 265
+    line: 13
+    character: 13
+  end_position:
+    bytes: 266
+    line: 13
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 266
+    line: 13
+    character: 14
+  end_position:
+    bytes: 267
+    line: 13
+    character: 15
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 267
+    line: 13
+    character: 15
+  end_position:
+    bytes: 268
+    line: 13
+    character: 16
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 268
+    line: 13
+    character: 16
+  end_position:
+    bytes: 274
+    line: 13
+    character: 22
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 274
+    line: 13
+    character: 22
+  end_position:
+    bytes: 275
+    line: 13
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: ","
+- start_position:
+    bytes: 275
+    line: 13
+    character: 23
+  end_position:
+    bytes: 276
+    line: 13
+    character: 23
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 276
+    line: 14
+    character: 1
+  end_position:
+    bytes: 280
+    line: 14
+    character: 5
+  token_type:
+    type: Whitespace
+    characters: "    "
+- start_position:
+    bytes: 280
+    line: 14
+    character: 5
+  end_position:
+    bytes: 281
+    line: 14
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 281
+    line: 14
+    character: 6
+  end_position:
+    bytes: 282
+    line: 14
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 282
+    line: 14
+    character: 7
+  end_position:
+    bytes: 289
+    line: 14
+    character: 14
+  token_type:
+    type: Identifier
+    identifier: boolean
+- start_position:
+    bytes: 289
+    line: 14
+    character: 14
+  end_position:
+    bytes: 290
+    line: 14
+    character: 15
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 290
+    line: 14
+    character: 15
+  end_position:
+    bytes: 291
+    line: 14
+    character: 16
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 291
+    line: 14
+    character: 16
+  end_position:
+    bytes: 292
+    line: 14
+    character: 17
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 292
+    line: 14
+    character: 17
+  end_position:
+    bytes: 295
+    line: 14
+    character: 20
+  token_type:
+    type: Symbol
+    symbol: nil
+- start_position:
+    bytes: 295
+    line: 14
+    character: 20
+  end_position:
+    bytes: 296
+    line: 14
+    character: 20
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 296
+    line: 15
+    character: 1
+  end_position:
+    bytes: 297
+    line: 15
+    character: 2
+  token_type:
+    type: Symbol
+    symbol: ">"
+- start_position:
+    bytes: 297
+    line: 15
+    character: 2
+  end_position:
+    bytes: 298
+    line: 15
+    character: 2
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 298
+    line: 16
+    character: 1
+  end_position:
+    bytes: 298
+    line: 16
+    character: 1
+  token_type:
+    type: Eof

--- a/full-moon/tests/roblox_cases/pass/types_leading_union_return/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/types_leading_union_return/ast.snap
@@ -1,0 +1,1521 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: ast.nodes()
+input_file: full-moon/tests/roblox_cases/pass/types_leading_union_return
+---
+stmts:
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 0
+                line: 1
+                character: 1
+              end_position:
+                bytes: 63
+                line: 1
+                character: 64
+              token_type:
+                type: SingleLineComment
+                comment: " Issue #311 comment: leading | and & in function return types"
+            - start_position:
+                bytes: 63
+                line: 1
+                character: 64
+              end_position:
+                bytes: 64
+                line: 1
+                character: 64
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 64
+              line: 2
+              character: 1
+            end_position:
+              bytes: 68
+              line: 2
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 68
+                line: 2
+                character: 5
+              end_position:
+                bytes: 69
+                line: 2
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 69
+              line: 2
+              character: 6
+            end_position:
+              bytes: 80
+              line: 2
+              character: 17
+            token_type:
+              type: Identifier
+              identifier: UnionReturn
+          trailing_trivia:
+            - start_position:
+                bytes: 80
+                line: 2
+                character: 17
+              end_position:
+                bytes: 81
+                line: 2
+                character: 18
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 81
+              line: 2
+              character: 18
+            end_position:
+              bytes: 82
+              line: 2
+              character: 19
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 82
+                line: 2
+                character: 19
+              end_position:
+                bytes: 83
+                line: 2
+                character: 20
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Callback:
+            generics: ~
+            parentheses:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 83
+                      line: 2
+                      character: 20
+                    end_position:
+                      bytes: 84
+                      line: 2
+                      character: 21
+                    token_type:
+                      type: Symbol
+                      symbol: (
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 84
+                      line: 2
+                      character: 21
+                    end_position:
+                      bytes: 85
+                      line: 2
+                      character: 22
+                    token_type:
+                      type: Symbol
+                      symbol: )
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 85
+                        line: 2
+                        character: 22
+                      end_position:
+                        bytes: 86
+                        line: 2
+                        character: 23
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+            arguments:
+              pairs: []
+            arrow:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 86
+                  line: 2
+                  character: 23
+                end_position:
+                  bytes: 88
+                  line: 2
+                  character: 25
+                token_type:
+                  type: Symbol
+                  symbol: "->"
+              trailing_trivia:
+                - start_position:
+                    bytes: 88
+                    line: 2
+                    character: 25
+                  end_position:
+                    bytes: 89
+                    line: 2
+                    character: 26
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            return_type:
+              Union:
+                leading:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 89
+                      line: 2
+                      character: 26
+                    end_position:
+                      bytes: 90
+                      line: 2
+                      character: 27
+                    token_type:
+                      type: Symbol
+                      symbol: "|"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 90
+                        line: 2
+                        character: 27
+                      end_position:
+                        bytes: 91
+                        line: 2
+                        character: 28
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 91
+                                line: 2
+                                character: 28
+                              end_position:
+                                bytes: 97
+                                line: 2
+                                character: 34
+                              token_type:
+                                type: Identifier
+                                identifier: string
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 97
+                                  line: 2
+                                  character: 34
+                                end_position:
+                                  bytes: 98
+                                  line: 2
+                                  character: 35
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 98
+                              line: 2
+                              character: 35
+                            end_position:
+                              bytes: 99
+                              line: 2
+                              character: 36
+                            token_type:
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 99
+                                line: 2
+                                character: 36
+                              end_position:
+                                bytes: 100
+                                line: 2
+                                character: 37
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 100
+                              line: 2
+                              character: 37
+                            end_position:
+                              bytes: 106
+                              line: 2
+                              character: 43
+                            token_type:
+                              type: Identifier
+                              identifier: number
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 106
+                                line: 2
+                                character: 43
+                              end_position:
+                                bytes: 107
+                                line: 2
+                                character: 43
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
+    - ~
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 107
+                line: 3
+                character: 1
+              end_position:
+                bytes: 108
+                line: 3
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 108
+              line: 4
+              character: 1
+            end_position:
+              bytes: 112
+              line: 4
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 112
+                line: 4
+                character: 5
+              end_position:
+                bytes: 113
+                line: 4
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 113
+              line: 4
+              character: 6
+            end_position:
+              bytes: 131
+              line: 4
+              character: 24
+            token_type:
+              type: Identifier
+              identifier: IntersectionReturn
+          trailing_trivia:
+            - start_position:
+                bytes: 131
+                line: 4
+                character: 24
+              end_position:
+                bytes: 132
+                line: 4
+                character: 25
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 132
+              line: 4
+              character: 25
+            end_position:
+              bytes: 133
+              line: 4
+              character: 26
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 133
+                line: 4
+                character: 26
+              end_position:
+                bytes: 134
+                line: 4
+                character: 27
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Callback:
+            generics: ~
+            parentheses:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 134
+                      line: 4
+                      character: 27
+                    end_position:
+                      bytes: 135
+                      line: 4
+                      character: 28
+                    token_type:
+                      type: Symbol
+                      symbol: (
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 135
+                      line: 4
+                      character: 28
+                    end_position:
+                      bytes: 136
+                      line: 4
+                      character: 29
+                    token_type:
+                      type: Symbol
+                      symbol: )
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 136
+                        line: 4
+                        character: 29
+                      end_position:
+                        bytes: 137
+                        line: 4
+                        character: 30
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+            arguments:
+              pairs: []
+            arrow:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 137
+                  line: 4
+                  character: 30
+                end_position:
+                  bytes: 139
+                  line: 4
+                  character: 32
+                token_type:
+                  type: Symbol
+                  symbol: "->"
+              trailing_trivia:
+                - start_position:
+                    bytes: 139
+                    line: 4
+                    character: 32
+                  end_position:
+                    bytes: 140
+                    line: 4
+                    character: 33
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            return_type:
+              Intersection:
+                leading:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 140
+                      line: 4
+                      character: 33
+                    end_position:
+                      bytes: 141
+                      line: 4
+                      character: 34
+                    token_type:
+                      type: Symbol
+                      symbol: "&"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 141
+                        line: 4
+                        character: 34
+                      end_position:
+                        bytes: 142
+                        line: 4
+                        character: 35
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 142
+                                line: 4
+                                character: 35
+                              end_position:
+                                bytes: 148
+                                line: 4
+                                character: 41
+                              token_type:
+                                type: Identifier
+                                identifier: string
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 148
+                                  line: 4
+                                  character: 41
+                                end_position:
+                                  bytes: 149
+                                  line: 4
+                                  character: 42
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 149
+                              line: 4
+                              character: 42
+                            end_position:
+                              bytes: 150
+                              line: 4
+                              character: 43
+                            token_type:
+                              type: Symbol
+                              symbol: "&"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 150
+                                line: 4
+                                character: 43
+                              end_position:
+                                bytes: 151
+                                line: 4
+                                character: 44
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 151
+                              line: 4
+                              character: 44
+                            end_position:
+                              bytes: 157
+                              line: 4
+                              character: 50
+                            token_type:
+                              type: Identifier
+                              identifier: number
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 157
+                                line: 4
+                                character: 50
+                              end_position:
+                                bytes: 158
+                                line: 4
+                                character: 50
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
+    - ~
+  - - TypeDeclaration:
+        type_token:
+          leading_trivia:
+            - start_position:
+                bytes: 158
+                line: 5
+                character: 1
+              end_position:
+                bytes: 159
+                line: 5
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 159
+              line: 6
+              character: 1
+            end_position:
+              bytes: 163
+              line: 6
+              character: 5
+            token_type:
+              type: Identifier
+              identifier: type
+          trailing_trivia:
+            - start_position:
+                bytes: 163
+                line: 6
+                character: 5
+              end_position:
+                bytes: 164
+                line: 6
+                character: 6
+              token_type:
+                type: Whitespace
+                characters: " "
+        base:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 164
+              line: 6
+              character: 6
+            end_position:
+              bytes: 176
+              line: 6
+              character: 18
+            token_type:
+              type: Identifier
+              identifier: NestedReturn
+          trailing_trivia:
+            - start_position:
+                bytes: 176
+                line: 6
+                character: 18
+              end_position:
+                bytes: 177
+                line: 6
+                character: 19
+              token_type:
+                type: Whitespace
+                characters: " "
+        generics: ~
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 177
+              line: 6
+              character: 19
+            end_position:
+              bytes: 178
+              line: 6
+              character: 20
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 178
+                line: 6
+                character: 20
+              end_position:
+                bytes: 179
+                line: 6
+                character: 21
+              token_type:
+                type: Whitespace
+                characters: " "
+        declare_as:
+          Callback:
+            generics: ~
+            parentheses:
+              tokens:
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 179
+                      line: 6
+                      character: 21
+                    end_position:
+                      bytes: 180
+                      line: 6
+                      character: 22
+                    token_type:
+                      type: Symbol
+                      symbol: (
+                  trailing_trivia: []
+                - leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 186
+                      line: 6
+                      character: 28
+                    end_position:
+                      bytes: 187
+                      line: 6
+                      character: 29
+                    token_type:
+                      type: Symbol
+                      symbol: )
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 187
+                        line: 6
+                        character: 29
+                      end_position:
+                        bytes: 188
+                        line: 6
+                        character: 30
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+            arguments:
+              pairs:
+                - End:
+                    name: ~
+                    type_info:
+                      Basic:
+                        leading_trivia: []
+                        token:
+                          start_position:
+                            bytes: 180
+                            line: 6
+                            character: 22
+                          end_position:
+                            bytes: 186
+                            line: 6
+                            character: 28
+                          token_type:
+                            type: Identifier
+                            identifier: string
+                        trailing_trivia: []
+            arrow:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 188
+                  line: 6
+                  character: 30
+                end_position:
+                  bytes: 190
+                  line: 6
+                  character: 32
+                token_type:
+                  type: Symbol
+                  symbol: "->"
+              trailing_trivia:
+                - start_position:
+                    bytes: 190
+                    line: 6
+                    character: 32
+                  end_position:
+                    bytes: 191
+                    line: 6
+                    character: 33
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            return_type:
+              Union:
+                leading:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 191
+                      line: 6
+                      character: 33
+                    end_position:
+                      bytes: 192
+                      line: 6
+                      character: 34
+                    token_type:
+                      type: Symbol
+                      symbol: "|"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 192
+                        line: 6
+                        character: 34
+                      end_position:
+                        bytes: 193
+                        line: 6
+                        character: 35
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                types:
+                  pairs:
+                    - Punctuated:
+                        - Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 193
+                                line: 6
+                                character: 35
+                              end_position:
+                                bytes: 200
+                                line: 6
+                                character: 42
+                              token_type:
+                                type: Identifier
+                                identifier: boolean
+                            trailing_trivia:
+                              - start_position:
+                                  bytes: 200
+                                  line: 6
+                                  character: 42
+                                end_position:
+                                  bytes: 201
+                                  line: 6
+                                  character: 43
+                                token_type:
+                                  type: Whitespace
+                                  characters: " "
+                        - leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 201
+                              line: 6
+                              character: 43
+                            end_position:
+                              bytes: 202
+                              line: 6
+                              character: 44
+                            token_type:
+                              type: Symbol
+                              symbol: "|"
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 202
+                                line: 6
+                                character: 44
+                              end_position:
+                                bytes: 203
+                                line: 6
+                                character: 45
+                              token_type:
+                                type: Whitespace
+                                characters: " "
+                    - End:
+                        Basic:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 203
+                              line: 6
+                              character: 45
+                            end_position:
+                              bytes: 206
+                              line: 6
+                              character: 48
+                            token_type:
+                              type: Symbol
+                              symbol: nil
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 206
+                                line: 6
+                                character: 48
+                              end_position:
+                                bytes: 207
+                                line: 6
+                                character: 48
+                              token_type:
+                                type: Whitespace
+                                characters: "\n"
+    - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia:
+            - start_position:
+                bytes: 207
+                line: 7
+                character: 1
+              end_position:
+                bytes: 208
+                line: 7
+                character: 1
+              token_type:
+                type: Whitespace
+                characters: "\n"
+            - start_position:
+                bytes: 208
+                line: 8
+                character: 1
+              end_position:
+                bytes: 250
+                line: 8
+                character: 43
+              token_type:
+                type: SingleLineComment
+                comment: " Also valid in function type annotations"
+            - start_position:
+                bytes: 250
+                line: 8
+                character: 43
+              end_position:
+                bytes: 251
+                line: 8
+                character: 43
+              token_type:
+                type: Whitespace
+                characters: "\n"
+          token:
+            start_position:
+              bytes: 251
+              line: 9
+              character: 1
+            end_position:
+              bytes: 256
+              line: 9
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 256
+                line: 9
+                character: 6
+              end_position:
+                bytes: 257
+                line: 9
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        type_specifiers:
+          - punctuation:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 258
+                  line: 9
+                  character: 8
+                end_position:
+                  bytes: 259
+                  line: 9
+                  character: 9
+                token_type:
+                  type: Symbol
+                  symbol: ":"
+              trailing_trivia:
+                - start_position:
+                    bytes: 259
+                    line: 9
+                    character: 9
+                  end_position:
+                    bytes: 260
+                    line: 9
+                    character: 10
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            type_info:
+              Callback:
+                generics: ~
+                parentheses:
+                  tokens:
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 260
+                          line: 9
+                          character: 10
+                        end_position:
+                          bytes: 261
+                          line: 9
+                          character: 11
+                        token_type:
+                          type: Symbol
+                          symbol: (
+                      trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 261
+                          line: 9
+                          character: 11
+                        end_position:
+                          bytes: 262
+                          line: 9
+                          character: 12
+                        token_type:
+                          type: Symbol
+                          symbol: )
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 262
+                            line: 9
+                            character: 12
+                          end_position:
+                            bytes: 263
+                            line: 9
+                            character: 13
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                arguments:
+                  pairs: []
+                arrow:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 263
+                      line: 9
+                      character: 13
+                    end_position:
+                      bytes: 265
+                      line: 9
+                      character: 15
+                    token_type:
+                      type: Symbol
+                      symbol: "->"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 265
+                        line: 9
+                        character: 15
+                      end_position:
+                        bytes: 266
+                        line: 9
+                        character: 16
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                return_type:
+                  Union:
+                    leading:
+                      leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 266
+                          line: 9
+                          character: 16
+                        end_position:
+                          bytes: 267
+                          line: 9
+                          character: 17
+                        token_type:
+                          type: Symbol
+                          symbol: "|"
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 267
+                            line: 9
+                            character: 17
+                          end_position:
+                            bytes: 268
+                            line: 9
+                            character: 18
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                    types:
+                      pairs:
+                        - Punctuated:
+                            - Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 268
+                                    line: 9
+                                    character: 18
+                                  end_position:
+                                    bytes: 274
+                                    line: 9
+                                    character: 24
+                                  token_type:
+                                    type: Identifier
+                                    identifier: string
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 274
+                                      line: 9
+                                      character: 24
+                                    end_position:
+                                      bytes: 275
+                                      line: 9
+                                      character: 25
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                            - leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 275
+                                  line: 9
+                                  character: 25
+                                end_position:
+                                  bytes: 276
+                                  line: 9
+                                  character: 26
+                                token_type:
+                                  type: Symbol
+                                  symbol: "|"
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 276
+                                    line: 9
+                                    character: 26
+                                  end_position:
+                                    bytes: 277
+                                    line: 9
+                                    character: 27
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                        - End:
+                            Basic:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 277
+                                  line: 9
+                                  character: 27
+                                end_position:
+                                  bytes: 283
+                                  line: 9
+                                  character: 33
+                                token_type:
+                                  type: Identifier
+                                  identifier: number
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 283
+                                    line: 9
+                                    character: 33
+                                  end_position:
+                                    bytes: 284
+                                    line: 9
+                                    character: 34
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 257
+                    line: 9
+                    character: 7
+                  end_position:
+                    bytes: 258
+                    line: 9
+                    character: 8
+                  token_type:
+                    type: Identifier
+                    identifier: f
+                trailing_trivia: []
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 284
+              line: 9
+              character: 34
+            end_position:
+              bytes: 285
+              line: 9
+              character: 35
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 285
+                line: 9
+                character: 35
+              end_position:
+                bytes: 286
+                line: 9
+                character: 36
+              token_type:
+                type: Whitespace
+                characters: " "
+        expr_list:
+          pairs:
+            - End:
+                Symbol:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 286
+                      line: 9
+                      character: 36
+                    end_position:
+                      bytes: 289
+                      line: 9
+                      character: 39
+                    token_type:
+                      type: Symbol
+                      symbol: nil
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 289
+                        line: 9
+                        character: 39
+                      end_position:
+                        bytes: 290
+                        line: 9
+                        character: 39
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+    - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 290
+              line: 10
+              character: 1
+            end_position:
+              bytes: 295
+              line: 10
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 295
+                line: 10
+                character: 6
+              end_position:
+                bytes: 296
+                line: 10
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        type_specifiers:
+          - punctuation:
+              leading_trivia: []
+              token:
+                start_position:
+                  bytes: 297
+                  line: 10
+                  character: 8
+                end_position:
+                  bytes: 298
+                  line: 10
+                  character: 9
+                token_type:
+                  type: Symbol
+                  symbol: ":"
+              trailing_trivia:
+                - start_position:
+                    bytes: 298
+                    line: 10
+                    character: 9
+                  end_position:
+                    bytes: 299
+                    line: 10
+                    character: 10
+                  token_type:
+                    type: Whitespace
+                    characters: " "
+            type_info:
+              Callback:
+                generics: ~
+                parentheses:
+                  tokens:
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 299
+                          line: 10
+                          character: 10
+                        end_position:
+                          bytes: 300
+                          line: 10
+                          character: 11
+                        token_type:
+                          type: Symbol
+                          symbol: (
+                      trailing_trivia: []
+                    - leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 306
+                          line: 10
+                          character: 17
+                        end_position:
+                          bytes: 307
+                          line: 10
+                          character: 18
+                        token_type:
+                          type: Symbol
+                          symbol: )
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 307
+                            line: 10
+                            character: 18
+                          end_position:
+                            bytes: 308
+                            line: 10
+                            character: 19
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                arguments:
+                  pairs:
+                    - End:
+                        name: ~
+                        type_info:
+                          Basic:
+                            leading_trivia: []
+                            token:
+                              start_position:
+                                bytes: 300
+                                line: 10
+                                character: 11
+                              end_position:
+                                bytes: 306
+                                line: 10
+                                character: 17
+                              token_type:
+                                type: Identifier
+                                identifier: number
+                            trailing_trivia: []
+                arrow:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 308
+                      line: 10
+                      character: 19
+                    end_position:
+                      bytes: 310
+                      line: 10
+                      character: 21
+                    token_type:
+                      type: Symbol
+                      symbol: "->"
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 310
+                        line: 10
+                        character: 21
+                      end_position:
+                        bytes: 311
+                        line: 10
+                        character: 22
+                      token_type:
+                        type: Whitespace
+                        characters: " "
+                return_type:
+                  Intersection:
+                    leading:
+                      leading_trivia: []
+                      token:
+                        start_position:
+                          bytes: 311
+                          line: 10
+                          character: 22
+                        end_position:
+                          bytes: 312
+                          line: 10
+                          character: 23
+                        token_type:
+                          type: Symbol
+                          symbol: "&"
+                      trailing_trivia:
+                        - start_position:
+                            bytes: 312
+                            line: 10
+                            character: 23
+                          end_position:
+                            bytes: 313
+                            line: 10
+                            character: 24
+                          token_type:
+                            type: Whitespace
+                            characters: " "
+                    types:
+                      pairs:
+                        - Punctuated:
+                            - Basic:
+                                leading_trivia: []
+                                token:
+                                  start_position:
+                                    bytes: 313
+                                    line: 10
+                                    character: 24
+                                  end_position:
+                                    bytes: 319
+                                    line: 10
+                                    character: 30
+                                  token_type:
+                                    type: Identifier
+                                    identifier: string
+                                trailing_trivia:
+                                  - start_position:
+                                      bytes: 319
+                                      line: 10
+                                      character: 30
+                                    end_position:
+                                      bytes: 320
+                                      line: 10
+                                      character: 31
+                                    token_type:
+                                      type: Whitespace
+                                      characters: " "
+                            - leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 320
+                                  line: 10
+                                  character: 31
+                                end_position:
+                                  bytes: 321
+                                  line: 10
+                                  character: 32
+                                token_type:
+                                  type: Symbol
+                                  symbol: "&"
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 321
+                                    line: 10
+                                    character: 32
+                                  end_position:
+                                    bytes: 322
+                                    line: 10
+                                    character: 33
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+                        - End:
+                            Basic:
+                              leading_trivia: []
+                              token:
+                                start_position:
+                                  bytes: 322
+                                  line: 10
+                                  character: 33
+                                end_position:
+                                  bytes: 328
+                                  line: 10
+                                  character: 39
+                                token_type:
+                                  type: Identifier
+                                  identifier: number
+                              trailing_trivia:
+                                - start_position:
+                                    bytes: 328
+                                    line: 10
+                                    character: 39
+                                  end_position:
+                                    bytes: 329
+                                    line: 10
+                                    character: 40
+                                  token_type:
+                                    type: Whitespace
+                                    characters: " "
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 296
+                    line: 10
+                    character: 7
+                  end_position:
+                    bytes: 297
+                    line: 10
+                    character: 8
+                  token_type:
+                    type: Identifier
+                    identifier: g
+                trailing_trivia: []
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 329
+              line: 10
+              character: 40
+            end_position:
+              bytes: 330
+              line: 10
+              character: 41
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 330
+                line: 10
+                character: 41
+              end_position:
+                bytes: 331
+                line: 10
+                character: 42
+              token_type:
+                type: Whitespace
+                characters: " "
+        expr_list:
+          pairs:
+            - End:
+                Symbol:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 331
+                      line: 10
+                      character: 42
+                    end_position:
+                      bytes: 334
+                      line: 10
+                      character: 45
+                    token_type:
+                      type: Symbol
+                      symbol: nil
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 334
+                        line: 10
+                        character: 45
+                      end_position:
+                        bytes: 335
+                        line: 10
+                        character: 45
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+    - ~

--- a/full-moon/tests/roblox_cases/pass/types_leading_union_return/source.lua
+++ b/full-moon/tests/roblox_cases/pass/types_leading_union_return/source.lua
@@ -1,0 +1,10 @@
+-- Issue #311 comment: leading | and & in function return types
+type UnionReturn = () -> | string | number
+
+type IntersectionReturn = () -> & string & number
+
+type NestedReturn = (string) -> | boolean | nil
+
+-- Also valid in function type annotations
+local f: () -> | string | number = nil
+local g: (number) -> & string & number = nil

--- a/full-moon/tests/roblox_cases/pass/types_leading_union_return/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/types_leading_union_return/tokens.snap
@@ -1,0 +1,1225 @@
+---
+source: full-moon/tests/pass_cases.rs
+expression: tokens
+input_file: full-moon/tests/roblox_cases/pass/types_leading_union_return
+---
+- start_position:
+    bytes: 0
+    line: 1
+    character: 1
+  end_position:
+    bytes: 63
+    line: 1
+    character: 64
+  token_type:
+    type: SingleLineComment
+    comment: " Issue #311 comment: leading | and & in function return types"
+- start_position:
+    bytes: 63
+    line: 1
+    character: 64
+  end_position:
+    bytes: 64
+    line: 1
+    character: 64
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 64
+    line: 2
+    character: 1
+  end_position:
+    bytes: 68
+    line: 2
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 68
+    line: 2
+    character: 5
+  end_position:
+    bytes: 69
+    line: 2
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 69
+    line: 2
+    character: 6
+  end_position:
+    bytes: 80
+    line: 2
+    character: 17
+  token_type:
+    type: Identifier
+    identifier: UnionReturn
+- start_position:
+    bytes: 80
+    line: 2
+    character: 17
+  end_position:
+    bytes: 81
+    line: 2
+    character: 18
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 81
+    line: 2
+    character: 18
+  end_position:
+    bytes: 82
+    line: 2
+    character: 19
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 82
+    line: 2
+    character: 19
+  end_position:
+    bytes: 83
+    line: 2
+    character: 20
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 83
+    line: 2
+    character: 20
+  end_position:
+    bytes: 84
+    line: 2
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 84
+    line: 2
+    character: 21
+  end_position:
+    bytes: 85
+    line: 2
+    character: 22
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 85
+    line: 2
+    character: 22
+  end_position:
+    bytes: 86
+    line: 2
+    character: 23
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 86
+    line: 2
+    character: 23
+  end_position:
+    bytes: 88
+    line: 2
+    character: 25
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 88
+    line: 2
+    character: 25
+  end_position:
+    bytes: 89
+    line: 2
+    character: 26
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 89
+    line: 2
+    character: 26
+  end_position:
+    bytes: 90
+    line: 2
+    character: 27
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 90
+    line: 2
+    character: 27
+  end_position:
+    bytes: 91
+    line: 2
+    character: 28
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 91
+    line: 2
+    character: 28
+  end_position:
+    bytes: 97
+    line: 2
+    character: 34
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 97
+    line: 2
+    character: 34
+  end_position:
+    bytes: 98
+    line: 2
+    character: 35
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 98
+    line: 2
+    character: 35
+  end_position:
+    bytes: 99
+    line: 2
+    character: 36
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 99
+    line: 2
+    character: 36
+  end_position:
+    bytes: 100
+    line: 2
+    character: 37
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 100
+    line: 2
+    character: 37
+  end_position:
+    bytes: 106
+    line: 2
+    character: 43
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 106
+    line: 2
+    character: 43
+  end_position:
+    bytes: 107
+    line: 2
+    character: 43
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 107
+    line: 3
+    character: 1
+  end_position:
+    bytes: 108
+    line: 3
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 108
+    line: 4
+    character: 1
+  end_position:
+    bytes: 112
+    line: 4
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 112
+    line: 4
+    character: 5
+  end_position:
+    bytes: 113
+    line: 4
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 113
+    line: 4
+    character: 6
+  end_position:
+    bytes: 131
+    line: 4
+    character: 24
+  token_type:
+    type: Identifier
+    identifier: IntersectionReturn
+- start_position:
+    bytes: 131
+    line: 4
+    character: 24
+  end_position:
+    bytes: 132
+    line: 4
+    character: 25
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 132
+    line: 4
+    character: 25
+  end_position:
+    bytes: 133
+    line: 4
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 133
+    line: 4
+    character: 26
+  end_position:
+    bytes: 134
+    line: 4
+    character: 27
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 134
+    line: 4
+    character: 27
+  end_position:
+    bytes: 135
+    line: 4
+    character: 28
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 135
+    line: 4
+    character: 28
+  end_position:
+    bytes: 136
+    line: 4
+    character: 29
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 136
+    line: 4
+    character: 29
+  end_position:
+    bytes: 137
+    line: 4
+    character: 30
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 137
+    line: 4
+    character: 30
+  end_position:
+    bytes: 139
+    line: 4
+    character: 32
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 139
+    line: 4
+    character: 32
+  end_position:
+    bytes: 140
+    line: 4
+    character: 33
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 140
+    line: 4
+    character: 33
+  end_position:
+    bytes: 141
+    line: 4
+    character: 34
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 141
+    line: 4
+    character: 34
+  end_position:
+    bytes: 142
+    line: 4
+    character: 35
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 142
+    line: 4
+    character: 35
+  end_position:
+    bytes: 148
+    line: 4
+    character: 41
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 148
+    line: 4
+    character: 41
+  end_position:
+    bytes: 149
+    line: 4
+    character: 42
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 149
+    line: 4
+    character: 42
+  end_position:
+    bytes: 150
+    line: 4
+    character: 43
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 150
+    line: 4
+    character: 43
+  end_position:
+    bytes: 151
+    line: 4
+    character: 44
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 151
+    line: 4
+    character: 44
+  end_position:
+    bytes: 157
+    line: 4
+    character: 50
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 157
+    line: 4
+    character: 50
+  end_position:
+    bytes: 158
+    line: 4
+    character: 50
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 158
+    line: 5
+    character: 1
+  end_position:
+    bytes: 159
+    line: 5
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 159
+    line: 6
+    character: 1
+  end_position:
+    bytes: 163
+    line: 6
+    character: 5
+  token_type:
+    type: Identifier
+    identifier: type
+- start_position:
+    bytes: 163
+    line: 6
+    character: 5
+  end_position:
+    bytes: 164
+    line: 6
+    character: 6
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 164
+    line: 6
+    character: 6
+  end_position:
+    bytes: 176
+    line: 6
+    character: 18
+  token_type:
+    type: Identifier
+    identifier: NestedReturn
+- start_position:
+    bytes: 176
+    line: 6
+    character: 18
+  end_position:
+    bytes: 177
+    line: 6
+    character: 19
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 177
+    line: 6
+    character: 19
+  end_position:
+    bytes: 178
+    line: 6
+    character: 20
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 178
+    line: 6
+    character: 20
+  end_position:
+    bytes: 179
+    line: 6
+    character: 21
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 179
+    line: 6
+    character: 21
+  end_position:
+    bytes: 180
+    line: 6
+    character: 22
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 180
+    line: 6
+    character: 22
+  end_position:
+    bytes: 186
+    line: 6
+    character: 28
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 186
+    line: 6
+    character: 28
+  end_position:
+    bytes: 187
+    line: 6
+    character: 29
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 187
+    line: 6
+    character: 29
+  end_position:
+    bytes: 188
+    line: 6
+    character: 30
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 188
+    line: 6
+    character: 30
+  end_position:
+    bytes: 190
+    line: 6
+    character: 32
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 190
+    line: 6
+    character: 32
+  end_position:
+    bytes: 191
+    line: 6
+    character: 33
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 191
+    line: 6
+    character: 33
+  end_position:
+    bytes: 192
+    line: 6
+    character: 34
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 192
+    line: 6
+    character: 34
+  end_position:
+    bytes: 193
+    line: 6
+    character: 35
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 193
+    line: 6
+    character: 35
+  end_position:
+    bytes: 200
+    line: 6
+    character: 42
+  token_type:
+    type: Identifier
+    identifier: boolean
+- start_position:
+    bytes: 200
+    line: 6
+    character: 42
+  end_position:
+    bytes: 201
+    line: 6
+    character: 43
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 201
+    line: 6
+    character: 43
+  end_position:
+    bytes: 202
+    line: 6
+    character: 44
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 202
+    line: 6
+    character: 44
+  end_position:
+    bytes: 203
+    line: 6
+    character: 45
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 203
+    line: 6
+    character: 45
+  end_position:
+    bytes: 206
+    line: 6
+    character: 48
+  token_type:
+    type: Symbol
+    symbol: nil
+- start_position:
+    bytes: 206
+    line: 6
+    character: 48
+  end_position:
+    bytes: 207
+    line: 6
+    character: 48
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 207
+    line: 7
+    character: 1
+  end_position:
+    bytes: 208
+    line: 7
+    character: 1
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 208
+    line: 8
+    character: 1
+  end_position:
+    bytes: 250
+    line: 8
+    character: 43
+  token_type:
+    type: SingleLineComment
+    comment: " Also valid in function type annotations"
+- start_position:
+    bytes: 250
+    line: 8
+    character: 43
+  end_position:
+    bytes: 251
+    line: 8
+    character: 43
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 251
+    line: 9
+    character: 1
+  end_position:
+    bytes: 256
+    line: 9
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 256
+    line: 9
+    character: 6
+  end_position:
+    bytes: 257
+    line: 9
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 257
+    line: 9
+    character: 7
+  end_position:
+    bytes: 258
+    line: 9
+    character: 8
+  token_type:
+    type: Identifier
+    identifier: f
+- start_position:
+    bytes: 258
+    line: 9
+    character: 8
+  end_position:
+    bytes: 259
+    line: 9
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 259
+    line: 9
+    character: 9
+  end_position:
+    bytes: 260
+    line: 9
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 260
+    line: 9
+    character: 10
+  end_position:
+    bytes: 261
+    line: 9
+    character: 11
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 261
+    line: 9
+    character: 11
+  end_position:
+    bytes: 262
+    line: 9
+    character: 12
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 262
+    line: 9
+    character: 12
+  end_position:
+    bytes: 263
+    line: 9
+    character: 13
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 263
+    line: 9
+    character: 13
+  end_position:
+    bytes: 265
+    line: 9
+    character: 15
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 265
+    line: 9
+    character: 15
+  end_position:
+    bytes: 266
+    line: 9
+    character: 16
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 266
+    line: 9
+    character: 16
+  end_position:
+    bytes: 267
+    line: 9
+    character: 17
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 267
+    line: 9
+    character: 17
+  end_position:
+    bytes: 268
+    line: 9
+    character: 18
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 268
+    line: 9
+    character: 18
+  end_position:
+    bytes: 274
+    line: 9
+    character: 24
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 274
+    line: 9
+    character: 24
+  end_position:
+    bytes: 275
+    line: 9
+    character: 25
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 275
+    line: 9
+    character: 25
+  end_position:
+    bytes: 276
+    line: 9
+    character: 26
+  token_type:
+    type: Symbol
+    symbol: "|"
+- start_position:
+    bytes: 276
+    line: 9
+    character: 26
+  end_position:
+    bytes: 277
+    line: 9
+    character: 27
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 277
+    line: 9
+    character: 27
+  end_position:
+    bytes: 283
+    line: 9
+    character: 33
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 283
+    line: 9
+    character: 33
+  end_position:
+    bytes: 284
+    line: 9
+    character: 34
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 284
+    line: 9
+    character: 34
+  end_position:
+    bytes: 285
+    line: 9
+    character: 35
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 285
+    line: 9
+    character: 35
+  end_position:
+    bytes: 286
+    line: 9
+    character: 36
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 286
+    line: 9
+    character: 36
+  end_position:
+    bytes: 289
+    line: 9
+    character: 39
+  token_type:
+    type: Symbol
+    symbol: nil
+- start_position:
+    bytes: 289
+    line: 9
+    character: 39
+  end_position:
+    bytes: 290
+    line: 9
+    character: 39
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 290
+    line: 10
+    character: 1
+  end_position:
+    bytes: 295
+    line: 10
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 295
+    line: 10
+    character: 6
+  end_position:
+    bytes: 296
+    line: 10
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 296
+    line: 10
+    character: 7
+  end_position:
+    bytes: 297
+    line: 10
+    character: 8
+  token_type:
+    type: Identifier
+    identifier: g
+- start_position:
+    bytes: 297
+    line: 10
+    character: 8
+  end_position:
+    bytes: 298
+    line: 10
+    character: 9
+  token_type:
+    type: Symbol
+    symbol: ":"
+- start_position:
+    bytes: 298
+    line: 10
+    character: 9
+  end_position:
+    bytes: 299
+    line: 10
+    character: 10
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 299
+    line: 10
+    character: 10
+  end_position:
+    bytes: 300
+    line: 10
+    character: 11
+  token_type:
+    type: Symbol
+    symbol: (
+- start_position:
+    bytes: 300
+    line: 10
+    character: 11
+  end_position:
+    bytes: 306
+    line: 10
+    character: 17
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 306
+    line: 10
+    character: 17
+  end_position:
+    bytes: 307
+    line: 10
+    character: 18
+  token_type:
+    type: Symbol
+    symbol: )
+- start_position:
+    bytes: 307
+    line: 10
+    character: 18
+  end_position:
+    bytes: 308
+    line: 10
+    character: 19
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 308
+    line: 10
+    character: 19
+  end_position:
+    bytes: 310
+    line: 10
+    character: 21
+  token_type:
+    type: Symbol
+    symbol: "->"
+- start_position:
+    bytes: 310
+    line: 10
+    character: 21
+  end_position:
+    bytes: 311
+    line: 10
+    character: 22
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 311
+    line: 10
+    character: 22
+  end_position:
+    bytes: 312
+    line: 10
+    character: 23
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 312
+    line: 10
+    character: 23
+  end_position:
+    bytes: 313
+    line: 10
+    character: 24
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 313
+    line: 10
+    character: 24
+  end_position:
+    bytes: 319
+    line: 10
+    character: 30
+  token_type:
+    type: Identifier
+    identifier: string
+- start_position:
+    bytes: 319
+    line: 10
+    character: 30
+  end_position:
+    bytes: 320
+    line: 10
+    character: 31
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 320
+    line: 10
+    character: 31
+  end_position:
+    bytes: 321
+    line: 10
+    character: 32
+  token_type:
+    type: Symbol
+    symbol: "&"
+- start_position:
+    bytes: 321
+    line: 10
+    character: 32
+  end_position:
+    bytes: 322
+    line: 10
+    character: 33
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 322
+    line: 10
+    character: 33
+  end_position:
+    bytes: 328
+    line: 10
+    character: 39
+  token_type:
+    type: Identifier
+    identifier: number
+- start_position:
+    bytes: 328
+    line: 10
+    character: 39
+  end_position:
+    bytes: 329
+    line: 10
+    character: 40
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 329
+    line: 10
+    character: 40
+  end_position:
+    bytes: 330
+    line: 10
+    character: 41
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 330
+    line: 10
+    character: 41
+  end_position:
+    bytes: 331
+    line: 10
+    character: 42
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 331
+    line: 10
+    character: 42
+  end_position:
+    bytes: 334
+    line: 10
+    character: 45
+  token_type:
+    type: Symbol
+    symbol: nil
+- start_position:
+    bytes: 334
+    line: 10
+    character: 45
+  end_position:
+    bytes: 335
+    line: 10
+    character: 45
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 335
+    line: 11
+    character: 1
+  end_position:
+    bytes: 335
+    line: 11
+    character: 1
+  token_type:
+    type: Eof


### PR DESCRIPTION
- parse_type_or_pack now handles leading | and & tokens by delegating
  to parse_type_suffix, fixing Luau union/intersection types that begin
  with a pipe or ampersand in generic type arguments (fixes #350) and
  in function return type annotations (fixes #311).
- Add test cases for both scenarios.