### PR TITLE
Fix clippy warnings

### DIFF
--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -1271,6 +1271,12 @@ pub struct TypeInstantiation {
     pub(crate) types: Punctuated<TypeInfo>,
 }
 
+impl Default for TypeInstantiation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TypeInstantiation {
     /// Creates an empty TypeInstantiation
     pub fn new() -> Self {

--- a/full-moon/src/ast/punctuated.rs
+++ b/full-moon/src/ast/punctuated.rs
@@ -224,7 +224,7 @@ impl<T: Node> Node for Punctuated<T> {
             .similar(&other.into_iter().collect::<Vec<_>>())
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         self.pairs.tokens()
     }
 }
@@ -457,7 +457,7 @@ impl<T: Node> Node for Pair<T> {
         self.value().similar(other.value())
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         match self {
             Pair::Punctuated(node, separator) => {
                 let mut items = node.tokens().items;

--- a/full-moon/src/ast/span.rs
+++ b/full-moon/src/ast/span.rs
@@ -51,7 +51,7 @@ impl Node for ContainedSpan {
         self.tokens.0.similar(&other.tokens.0) && self.tokens.1.similar(&other.tokens.1)
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         self.tokens.tokens()
     }
 }

--- a/full-moon/src/node.rs
+++ b/full-moon/src/node.rs
@@ -21,7 +21,7 @@ pub trait Node: private::Sealed {
         Self: Sized;
 
     /// The token references that comprise a node
-    fn tokens(&self) -> Tokens;
+    fn tokens(&self) -> Tokens<'_>;
 
     /// The full range of a node, if it has both start and end positions
     fn range(&self) -> Option<(Position, Position)> {
@@ -122,7 +122,7 @@ impl Node for Ast {
         self.nodes().similar(other.nodes())
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         self.nodes().tokens()
     }
 }
@@ -140,7 +140,7 @@ impl<T: Node> Node for Box<T> {
         (**self).similar(other)
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         (**self).tokens()
     }
 }
@@ -158,7 +158,7 @@ impl<T: Node> Node for &T {
         (**self).similar(other)
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         (**self).tokens()
     }
 }
@@ -176,7 +176,7 @@ impl<T: Node> Node for &mut T {
         (**self).similar(other)
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         (**self).tokens()
     }
 }
@@ -194,7 +194,7 @@ impl Node for TokenReference {
         *self.token_type() == *other.token_type()
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         Tokens {
             items: vec![TokenItem::TokenReference(self)],
         }
@@ -218,7 +218,7 @@ impl<T: Node> Node for Option<T> {
         }
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         match self {
             Some(node) => node.tokens(),
             None => Tokens::default(),
@@ -243,7 +243,7 @@ impl<T: Node> Node for Vec<T> {
         }
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         Tokens {
             items: self.iter().flat_map(|node| node.tokens().items).collect(),
         }
@@ -273,7 +273,7 @@ impl<A: Node, B: Node> Node for (A, B) {
         self.0.similar(&other.0) && self.1.similar(&other.1)
     }
 
-    fn tokens(&self) -> Tokens {
+    fn tokens(&self) -> Tokens<'_> {
         let mut items = self.0.tokens().items;
         items.append(&mut self.1.tokens().items);
 


### PR DESCRIPTION
Add explicit `'_` lifetime to all `fn tokens(&self) -> Tokens<'_>` signatures to resolve the `mismatched_lifetime_syntaxes` warning introduced in newer Rust.

Add Default impl for TypeInstantiation