### PR TITLE
Shrink AST nodes to fix recursive-parse stack overflows (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.0.0] - YYYY-MM-DD
+### Changed
+- **[BREAKING CHANGE]**: shrunk `Stmt`, `Expression`, and other AST nodes by boxing heavy enum variants and struct fields, fixing recursive-parse stack overflows on small-stack threads (#346). `Stmt` is now ~14x smaller (4784 → 352 bytes); `Expression` is ~3x smaller (880 → 280 bytes). The `#346` repro now parses comfortably in a 96 KiB release-mode stack (was ~384 KiB).
+  - Code that destructures variants by value will need `Box::new(...)` at construction sites and `*`/auto-deref at binding sites. Code that uses accessor methods or matches by reference is unaffected, since `Box<T>: Deref<Target = T>`.
+  - `serde` representation is unchanged; `Box<T>` serializes transparently and all existing snapshot files are byte-identical.
+  - Affected `Stmt` variants: `Do`, `If`, `While`, `Repeat`, `NumericFor`, `GenericFor`, `FunctionDeclaration`, `LocalFunction`, `CompoundAssignment`, plus the Luau-only `ConstFunction`, `TypeDeclaration`, `TypeFunction`, `ExportedTypeDeclaration`, `ExportedTypeFunction`.
+  - Affected `Expression` variants: `IfExpression`, `InterpolatedString`, `TableConstructor`, `TypeAssertion`.
+  - Affected `Suffix`/`Call` variants: `Suffix::TypeInstantiation`, `Call::MethodCall`.
+  - Affected struct fields: `body` on every function-bearing struct (`AnonymousFunction`, `LocalFunction`, `FunctionDeclaration`, `ConstFunction`, `TypeFunction`); `condition`/`until`/`start`/`end`/`step` on loop and branch structs; `expression` on `Index::Brackets`; `key`/`value` on `Field::ExpressionKey` and `value` on `Field::NameKey`; `TableConstructor` on `FunctionArgs::TableConstructor`; `type_instantiation` on `MethodCall`; `return_type`/`generics` on `FunctionBody`; `type_specifier` on `NumericFor`; the `TypeInfo`-bearing fields on `TypeField`, `TypeFieldKey::IndexSignature`, `TypeArgument`, `TypeSpecifier`, `TypeAssertion`, and `GenericDeclarationParameter`.
+
 ## [2.2.0] - 2026-04-15
 ### Added
 - Luau: added support for the `const` keyword (rfc: https://github.com/luau-lang/rfcs/blob/master/docs/const-keyword.md)

--- a/full-moon/Cargo.toml
+++ b/full-moon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "full_moon"
-version = "2.2.0"
+version = "3.0.0"
 authors = ["Kampfkarren <kampfkarren@gmail.com>"]
 description = "A lossless Lua parser"
 license = "MPL-2.0"

--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -287,7 +287,7 @@ pub struct TypeField {
     pub(crate) access: Option<TokenReference>,
     pub(crate) key: TypeFieldKey,
     pub(crate) colon: TokenReference,
-    pub(crate) value: TypeInfo,
+    pub(crate) value: Box<TypeInfo>,
 }
 
 impl TypeField {
@@ -297,7 +297,7 @@ impl TypeField {
             access: None,
             key,
             colon: TokenReference::symbol(": ").unwrap(),
-            value,
+            value: Box::new(value),
         }
     }
 
@@ -341,7 +341,10 @@ impl TypeField {
 
     /// Returns a new TypeField with the `:` token
     pub fn with_value(self, value: TypeInfo) -> Self {
-        Self { value, ..self }
+        Self {
+            value: Box::new(value),
+            ..self
+        }
     }
 }
 
@@ -361,7 +364,7 @@ pub enum TypeFieldKey {
         brackets: ContainedSpan,
 
         /// The type for the index signature, `number` in `[number]`.
-        inner: TypeInfo,
+        inner: Box<TypeInfo>,
     },
 }
 
@@ -371,7 +374,7 @@ pub enum TypeFieldKey {
 #[display("{assertion_op}{cast_to}")]
 pub struct TypeAssertion {
     pub(crate) assertion_op: TokenReference,
-    pub(crate) cast_to: TypeInfo,
+    pub(crate) cast_to: Box<TypeInfo>,
 }
 
 impl TypeAssertion {
@@ -379,7 +382,7 @@ impl TypeAssertion {
     pub fn new(cast_to: TypeInfo) -> Self {
         Self {
             assertion_op: TokenReference::symbol("::").unwrap(),
-            cast_to,
+            cast_to: Box::new(cast_to),
         }
     }
 
@@ -403,7 +406,10 @@ impl TypeAssertion {
 
     /// Returns a new TypeAssertion with the given TypeInfo to cast to
     pub fn with_cast_to(self, cast_to: TypeInfo) -> Self {
-        Self { cast_to, ..self }
+        Self {
+            cast_to: Box::new(cast_to),
+            ..self
+        }
     }
 }
 
@@ -533,7 +539,7 @@ pub enum GenericParameterInfo {
 )]
 pub struct GenericDeclarationParameter {
     pub(crate) parameter: GenericParameterInfo,
-    pub(crate) default: Option<(TokenReference, TypeInfo)>,
+    pub(crate) default: Option<(TokenReference, Box<TypeInfo>)>,
 }
 
 impl GenericDeclarationParameter {
@@ -557,7 +563,9 @@ impl GenericDeclarationParameter {
 
     /// The default type, if present
     pub fn default_type(&self) -> Option<&TypeInfo> {
-        self.default.as_ref().map(|(_, default_type)| default_type)
+        self.default
+            .as_ref()
+            .map(|(_, default_type)| default_type.as_ref())
     }
 
     /// Returns a new GenericDeclarationParameter with the given parameter info
@@ -567,7 +575,10 @@ impl GenericDeclarationParameter {
 
     /// Returns a new GenericDeclarationParameter with the given default type
     pub fn with_default(self, default: Option<(TokenReference, TypeInfo)>) -> Self {
-        Self { default, ..self }
+        Self {
+            default: default.map(|(token, ty)| (token, Box::new(ty))),
+            ..self
+        }
     }
 }
 
@@ -626,7 +637,7 @@ impl Default for GenericDeclaration {
 #[display("{punctuation}{type_info}")]
 pub struct TypeSpecifier {
     pub(crate) punctuation: TokenReference,
-    pub(crate) type_info: TypeInfo,
+    pub(crate) type_info: Box<TypeInfo>,
 }
 
 impl TypeSpecifier {
@@ -634,7 +645,7 @@ impl TypeSpecifier {
     pub fn new(type_info: TypeInfo) -> Self {
         Self {
             punctuation: TokenReference::symbol(": ").unwrap(),
-            type_info,
+            type_info: Box::new(type_info),
         }
     }
 
@@ -659,7 +670,10 @@ impl TypeSpecifier {
 
     /// Returns a new TypeSpecifier with the given type being specified
     pub fn with_type_info(self, type_info: TypeInfo) -> Self {
-        Self { type_info, ..self }
+        Self {
+            type_info: Box::new(type_info),
+            ..self
+        }
     }
 }
 
@@ -668,7 +682,7 @@ impl TypeSpecifier {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TypeArgument {
     pub(crate) name: Option<(TokenReference, TokenReference)>,
-    pub(crate) type_info: TypeInfo,
+    pub(crate) type_info: Box<TypeInfo>,
 }
 
 impl TypeArgument {
@@ -676,7 +690,7 @@ impl TypeArgument {
     pub fn new(type_info: TypeInfo) -> Self {
         Self {
             name: None,
-            type_info,
+            type_info: Box::new(type_info),
         }
     }
 
@@ -697,7 +711,10 @@ impl TypeArgument {
 
     /// Returns a new TypeArgument with the given type info
     pub fn with_type_info(self, type_info: TypeInfo) -> Self {
-        Self { type_info, ..self }
+        Self {
+            type_info: Box::new(type_info),
+            ..self
+        }
     }
 }
 
@@ -772,12 +789,13 @@ pub struct TypeFunction {
     pub(crate) type_token: TokenReference,
     pub(crate) function_token: TokenReference,
     pub(crate) function_name: TokenReference,
-    pub(crate) function_body: FunctionBody,
+    pub(crate) function_body: Box<FunctionBody>,
 }
 
 impl TypeFunction {
     /// Creates a new TypeFunction from the given function name and body
     pub fn new(function_name: TokenReference, function_body: FunctionBody) -> Self {
+        let function_body = Box::new(function_body);
         Self {
             type_token: TokenReference::new(
                 Vec::new(),
@@ -836,7 +854,7 @@ impl TypeFunction {
     /// Returns a new TypeFunction with the given function body
     pub fn with_function_body(self, function_body: FunctionBody) -> Self {
         Self {
-            function_body,
+            function_body: Box::new(function_body),
             ..self
         }
     }
@@ -1019,7 +1037,7 @@ pub struct ConstFunction {
     pub(crate) const_token: TokenReference,
     pub(crate) function_token: TokenReference,
     pub(crate) name: TokenReference,
-    pub(crate) body: FunctionBody,
+    pub(crate) body: Box<FunctionBody>,
 }
 
 impl ConstFunction {
@@ -1036,7 +1054,7 @@ impl ConstFunction {
             ),
             function_token: TokenReference::basic_symbol("function "),
             name,
-            body: FunctionBody::new(),
+            body: Box::new(FunctionBody::new()),
         }
     }
 
@@ -1093,7 +1111,10 @@ impl ConstFunction {
 
     /// Returns a new ConstFunction with the given function body
     pub fn with_body(self, body: FunctionBody) -> Self {
-        Self { body, ..self }
+        Self {
+            body: Box::new(body),
+            ..self
+        }
     }
 }
 
@@ -1244,9 +1265,9 @@ impl IfExpression {
 #[display("{else_if_token}{condition}{then_token}{expression}")]
 pub struct ElseIfExpression {
     pub(crate) else_if_token: TokenReference,
-    pub(crate) condition: Expression,
+    pub(crate) condition: Box<Expression>,
     pub(crate) then_token: TokenReference,
-    pub(crate) expression: Expression,
+    pub(crate) expression: Box<Expression>,
 }
 
 impl ElseIfExpression {
@@ -1254,9 +1275,9 @@ impl ElseIfExpression {
     pub fn new(condition: Expression, expression: Expression) -> Self {
         Self {
             else_if_token: TokenReference::symbol(" elseif ").unwrap(),
-            condition,
+            condition: Box::new(condition),
             then_token: TokenReference::symbol(" then ").unwrap(),
-            expression,
+            expression: Box::new(expression),
         }
     }
 
@@ -1290,7 +1311,10 @@ impl ElseIfExpression {
 
     /// Returns a new ElseIfExpression with the given condition
     pub fn with_condition(self, condition: Expression) -> Self {
-        Self { condition, ..self }
+        Self {
+            condition: Box::new(condition),
+            ..self
+        }
     }
 
     /// Returns a new ElseIfExpression with the given `then` token
@@ -1300,7 +1324,10 @@ impl ElseIfExpression {
 
     /// Returns a new ElseIfExpression with the given expression
     pub fn with_block(self, expression: Expression) -> Self {
-        Self { expression, ..self }
+        Self {
+            expression: Box::new(expression),
+            ..self
+        }
     }
 }
 

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -195,11 +195,11 @@ pub enum Field {
         /// The `[...]` part of `[expression] = value`
         brackets: ContainedSpan,
         /// The `expression` part of `[expression] = value`
-        key: Expression,
+        key: Box<Expression>,
         /// The `=` part of `[expression] = value`
         equal: TokenReference,
         /// The `value` part of `[expression] = value`
-        value: Expression,
+        value: Box<Expression>,
     },
 
     /// A key in the format of `name = value`
@@ -210,7 +210,7 @@ pub enum Field {
         /// The `=` part of `name = value`
         equal: TokenReference,
         /// The `value` part of `name = value`
-        value: Expression,
+        value: Box<Expression>,
     },
 
     /// A set constructor field, such as .a inside { .a } which is equivalent to { a = true }
@@ -291,7 +291,7 @@ pub struct AnonymousFunction {
     #[cfg(feature = "luau")]
     attributes: Vec<LuauAttribute>,
     function_token: TokenReference,
-    body: FunctionBody,
+    body: Box<FunctionBody>,
 }
 
 impl AnonymousFunction {
@@ -301,7 +301,7 @@ impl AnonymousFunction {
             #[cfg(feature = "luau")]
             attributes: Vec::new(),
             function_token: TokenReference::basic_symbol("function"),
-            body: FunctionBody::new(),
+            body: Box::new(FunctionBody::new()),
         }
     }
 
@@ -337,7 +337,10 @@ impl AnonymousFunction {
 
     /// Returns a new AnonymousFunction with the given function body
     pub fn with_body(self, body: FunctionBody) -> Self {
-        Self { body, ..self }
+        Self {
+            body: Box::new(body),
+            ..self
+        }
     }
 }
 
@@ -394,17 +397,17 @@ pub enum Expression {
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
     #[display("{_0}")]
-    IfExpression(IfExpression),
+    IfExpression(Box<IfExpression>),
 
     /// An interpolated string, such as `` `hello {"world"}` ``
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
     #[display("{_0}")]
-    InterpolatedString(InterpolatedString),
+    InterpolatedString(Box<InterpolatedString>),
 
     /// A table constructor, such as `{ 1, 2, 3 }`
     #[display("{_0}")]
-    TableConstructor(TableConstructor),
+    TableConstructor(Box<TableConstructor>),
 
     /// A number token, such as `3.3`
     #[display("{_0}")]
@@ -427,7 +430,7 @@ pub enum Expression {
         expression: Box<Expression>,
 
         /// The type assertion
-        type_assertion: TypeAssertion,
+        type_assertion: Box<TypeAssertion>,
     },
 
     /// A more complex value, such as `call().x`
@@ -445,40 +448,40 @@ pub enum Stmt {
     Assignment(Assignment),
     /// A do block, `do end`
     #[display("{_0}")]
-    Do(Do),
+    Do(Box<Do>),
     /// A function call on its own, such as `call()`
     #[display("{_0}")]
     FunctionCall(FunctionCall),
     /// A function declaration, such as `function x() end`
     #[display("{_0}")]
-    FunctionDeclaration(FunctionDeclaration),
+    FunctionDeclaration(Box<FunctionDeclaration>),
     /// A generic for loop, such as `for index, value in pairs(list) do end`
     #[display("{_0}")]
-    GenericFor(GenericFor),
+    GenericFor(Box<GenericFor>),
     /// An if statement
     #[display("{_0}")]
-    If(If),
+    If(Box<If>),
     /// A local assignment, such as `local x = 1`
     #[display("{_0}")]
     LocalAssignment(LocalAssignment),
     /// A local function declaration, such as `local function x() end`
     #[display("{_0}")]
-    LocalFunction(LocalFunction),
+    LocalFunction(Box<LocalFunction>),
     /// A numeric for loop, such as `for index = 1, 10 do end`
     #[display("{_0}")]
-    NumericFor(NumericFor),
+    NumericFor(Box<NumericFor>),
     /// A repeat loop
     #[display("{_0}")]
-    Repeat(Repeat),
+    Repeat(Box<Repeat>),
     /// A while loop
     #[display("{_0}")]
-    While(While),
+    While(Box<While>),
 
     /// A compound assignment, such as `+=`
     /// Only available when the "luau" feature flag is enabled
     #[cfg(any(feature = "luau", feature = "cfxlua"))]
     #[display("{_0}")]
-    CompoundAssignment(CompoundAssignment),
+    CompoundAssignment(Box<CompoundAssignment>),
     /// A const variable assignment, such as `const x = 1`
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
@@ -488,23 +491,23 @@ pub enum Stmt {
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
     #[display("{_0}")]
-    ConstFunction(ConstFunction),
+    ConstFunction(Box<ConstFunction>),
     /// An exported type declaration, such as `export type Meters = number`
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
-    ExportedTypeDeclaration(ExportedTypeDeclaration),
+    ExportedTypeDeclaration(Box<ExportedTypeDeclaration>),
     /// A type declaration, such as `type Meters = number`
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
-    TypeDeclaration(TypeDeclaration),
+    TypeDeclaration(Box<TypeDeclaration>),
     /// An exported type function, such as `export type function Pairs(...) end`
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
-    ExportedTypeFunction(ExportedTypeFunction),
+    ExportedTypeFunction(Box<ExportedTypeFunction>),
     /// A type function, such as `type function Pairs(...) end`
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
-    TypeFunction(TypeFunction),
+    TypeFunction(Box<TypeFunction>),
 
     /// A goto statement, such as `goto label`
     /// Only available when the "lua52" or "luajit" feature flag is enabled.
@@ -542,7 +545,7 @@ pub enum Index {
         /// The `[...]` part of `["y"]`
         brackets: ContainedSpan,
         /// The `"y"` part of `["y"]`
-        expression: Expression,
+        expression: Box<Expression>,
     },
 
     /// Indexing in the form of `x.y`
@@ -579,7 +582,7 @@ pub enum FunctionArgs {
     String(TokenReference),
     /// Used when a function is called in the form of `call { 1, 2, 3 }`
     #[display("{_0}")]
-    TableConstructor(TableConstructor),
+    TableConstructor(Box<TableConstructor>),
 }
 
 impl FunctionArgs {
@@ -602,17 +605,17 @@ pub struct NumericFor {
     for_token: TokenReference,
     index_variable: TokenReference,
     equal_token: TokenReference,
-    start: Expression,
+    start: Box<Expression>,
     start_end_comma: TokenReference,
-    end: Expression,
+    end: Box<Expression>,
     end_step_comma: Option<TokenReference>,
-    step: Option<Expression>,
+    step: Option<Box<Expression>>,
     do_token: TokenReference,
     block: Block,
     end_token: TokenReference,
     #[cfg(feature = "luau")]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    type_specifier: Option<TypeSpecifier>,
+    type_specifier: Option<Box<TypeSpecifier>>,
 }
 
 impl NumericFor {
@@ -622,9 +625,9 @@ impl NumericFor {
             for_token: TokenReference::basic_symbol("for "),
             index_variable,
             equal_token: TokenReference::basic_symbol(" = "),
-            start,
+            start: Box::new(start),
             start_end_comma: TokenReference::basic_symbol(", "),
-            end,
+            end: Box::new(end),
             end_step_comma: None,
             step: None,
             do_token: TokenReference::basic_symbol(" do\n"),
@@ -655,6 +658,7 @@ impl NumericFor {
         &self.start
     }
 
+
     /// The comma in between the starting point and end point
     /// for _ = 1, 10 do
     ///          ^
@@ -667,6 +671,7 @@ impl NumericFor {
         &self.end
     }
 
+
     /// The comma in between the ending point and limit, if one exists
     /// for _ = 0, 10, 2 do
     ///              ^
@@ -676,7 +681,7 @@ impl NumericFor {
 
     /// The step if one exists, `2` in `for index = 0, 10, 2 do end`
     pub fn step(&self) -> Option<&Expression> {
-        self.step.as_ref()
+        self.step.as_deref()
     }
 
     /// The `do` token
@@ -700,7 +705,7 @@ impl NumericFor {
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
     pub fn type_specifier(&self) -> Option<&TypeSpecifier> {
-        self.type_specifier.as_ref()
+        self.type_specifier.as_deref()
     }
 
     /// Returns a new NumericFor with the given for token
@@ -726,7 +731,10 @@ impl NumericFor {
 
     /// Returns a new NumericFor with the given start expression
     pub fn with_start(self, start: Expression) -> Self {
-        Self { start, ..self }
+        Self {
+            start: Box::new(start),
+            ..self
+        }
     }
 
     /// Returns a new NumericFor with the given comma between the start and end expressions
@@ -739,7 +747,10 @@ impl NumericFor {
 
     /// Returns a new NumericFor with the given end expression
     pub fn with_end(self, end: Expression) -> Self {
-        Self { end, ..self }
+        Self {
+            end: Box::new(end),
+            ..self
+        }
     }
 
     /// Returns a new NumericFor with the given comma between the end and the step expressions
@@ -752,7 +763,10 @@ impl NumericFor {
 
     /// Returns a new NumericFor with the given step expression
     pub fn with_step(self, step: Option<Expression>) -> Self {
-        Self { step, ..self }
+        Self {
+            step: step.map(Box::new),
+            ..self
+        }
     }
 
     /// Returns a new NumericFor with the given `do` token
@@ -775,7 +789,7 @@ impl NumericFor {
     #[cfg(feature = "luau")]
     pub fn with_type_specifier(self, type_specifier: Option<TypeSpecifier>) -> Self {
         Self {
-            type_specifier,
+            type_specifier: type_specifier.map(Box::new),
             ..self
         }
     }
@@ -997,7 +1011,7 @@ impl fmt::Display for GenericFor {
 )]
 pub struct If {
     if_token: TokenReference,
-    condition: Expression,
+    condition: Box<Expression>,
     then_token: TokenReference,
     block: Block,
     else_if: Option<Vec<ElseIf>>,
@@ -1012,7 +1026,7 @@ impl If {
     pub fn new(condition: Expression) -> Self {
         Self {
             if_token: TokenReference::basic_symbol("if "),
-            condition,
+            condition: Box::new(condition),
             then_token: TokenReference::basic_symbol(" then"),
             block: Block::new(),
             else_if: None,
@@ -1071,7 +1085,10 @@ impl If {
 
     /// Returns a new If with the given condition
     pub fn with_condition(self, condition: Expression) -> Self {
-        Self { condition, ..self }
+        Self {
+            condition: Box::new(condition),
+            ..self
+        }
     }
 
     /// Returns a new If with the given `then` token
@@ -1177,7 +1194,7 @@ impl ElseIf {
 #[display("{while_token}{condition}{do_token}{block}{end_token}")]
 pub struct While {
     while_token: TokenReference,
-    condition: Expression,
+    condition: Box<Expression>,
     do_token: TokenReference,
     block: Block,
     end_token: TokenReference,
@@ -1188,7 +1205,7 @@ impl While {
     pub fn new(condition: Expression) -> Self {
         Self {
             while_token: TokenReference::basic_symbol("while "),
-            condition,
+            condition: Box::new(condition),
             do_token: TokenReference::basic_symbol(" do\n"),
             block: Block::new(),
             end_token: TokenReference::basic_symbol("end\n"),
@@ -1230,7 +1247,10 @@ impl While {
 
     /// Returns a new While with the given condition
     pub fn with_condition(self, condition: Expression) -> Self {
-        Self { condition, ..self }
+        Self {
+            condition: Box::new(condition),
+            ..self
+        }
     }
 
     /// Returns a new While with the given `do` token
@@ -1257,7 +1277,7 @@ pub struct Repeat {
     repeat_token: TokenReference,
     block: Block,
     until_token: TokenReference,
-    until: Expression,
+    until: Box<Expression>,
 }
 
 impl Repeat {
@@ -1267,7 +1287,7 @@ impl Repeat {
             repeat_token: TokenReference::basic_symbol("repeat\n"),
             block: Block::new(),
             until_token: TokenReference::basic_symbol("\nuntil "),
-            until,
+            until: Box::new(until),
         }
     }
 
@@ -1314,7 +1334,10 @@ impl Repeat {
 
     /// Returns a new Repeat with the given `until` block
     pub fn with_until(self, until: Expression) -> Self {
-        Self { until, ..self }
+        Self {
+            until: Box::new(until),
+            ..self
+        }
     }
 }
 
@@ -1327,9 +1350,9 @@ pub struct MethodCall {
 
     #[cfg(feature = "luau")]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    type_instantiation: Option<TypeInstantiation>,
+    type_instantiation: Option<Box<TypeInstantiation>>,
 
-    args: FunctionArgs,
+    args: Box<FunctionArgs>,
 }
 
 impl MethodCall {
@@ -1338,7 +1361,7 @@ impl MethodCall {
         Self {
             colon_token: TokenReference::basic_symbol(":"),
             name,
-            args,
+            args: Box::new(args),
             #[cfg(feature = "luau")]
             type_instantiation: None,
         }
@@ -1364,7 +1387,7 @@ impl MethodCall {
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
     pub fn type_instantiation(&self) -> Option<&TypeInstantiation> {
-        self.type_instantiation.as_ref()
+        self.type_instantiation.as_deref()
     }
 
     /// Returns a new MethodCall with the given `:` token
@@ -1382,14 +1405,17 @@ impl MethodCall {
 
     /// Returns a new MethodCall with the given args
     pub fn with_args(self, args: FunctionArgs) -> Self {
-        Self { args, ..self }
+        Self {
+            args: Box::new(args),
+            ..self
+        }
     }
 
     /// Returns a new MethodCall with the given type instantiation.
     #[cfg(feature = "luau")]
     pub fn with_type_instanation(self, type_instantiation: Option<TypeInstantiation>) -> Self {
         Self {
-            type_instantiation,
+            type_instantiation: type_instantiation.map(Box::new),
             ..self
         }
     }
@@ -1417,10 +1443,10 @@ impl fmt::Display for MethodCall {
 pub enum Call {
     #[display("{_0}")]
     /// A function being called directly, such as `x(1)`
-    AnonymousCall(FunctionArgs),
+    AnonymousCall(Box<FunctionArgs>),
     #[display("{_0}")]
     /// A method call, such as `x:y()`
-    MethodCall(MethodCall),
+    MethodCall(Box<MethodCall>),
 }
 
 /// A function body, everything except `function x` in `function x(a, b, c) call() end`
@@ -1428,7 +1454,7 @@ pub enum Call {
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct FunctionBody {
     #[cfg(feature = "luau")]
-    generics: Option<GenericDeclaration>,
+    generics: Option<Box<GenericDeclaration>>,
 
     parameters_parentheses: ContainedSpan,
     parameters: Punctuated<Parameter>,
@@ -1438,7 +1464,7 @@ pub struct FunctionBody {
 
     #[cfg(feature = "luau")]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    return_type: Option<TypeSpecifier>,
+    return_type: Option<Box<TypeSpecifier>>,
 
     block: Block,
     end_token: TokenReference,
@@ -1493,7 +1519,7 @@ impl FunctionBody {
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
     pub fn generics(&self) -> Option<&GenericDeclaration> {
-        self.generics.as_ref()
+        self.generics.as_deref()
     }
 
     /// The type specifiers of the variables, in the order that they were assigned.
@@ -1509,7 +1535,7 @@ impl FunctionBody {
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]
     pub fn return_type(&self) -> Option<&TypeSpecifier> {
-        self.return_type.as_ref()
+        self.return_type.as_deref()
     }
 
     /// Returns a new FunctionBody with the given parentheses for the parameters
@@ -1528,7 +1554,10 @@ impl FunctionBody {
     /// Returns a new FunctionBody with the given generics declaration
     #[cfg(feature = "luau")]
     pub fn with_generics(self, generics: Option<GenericDeclaration>) -> Self {
-        Self { generics, ..self }
+        Self {
+            generics: generics.map(Box::new),
+            ..self
+        }
     }
 
     /// Returns a new FunctionBody with the given type specifiers
@@ -1544,7 +1573,7 @@ impl FunctionBody {
     #[cfg(feature = "luau")]
     pub fn with_return_type(self, return_type: Option<TypeSpecifier>) -> Self {
         Self {
-            return_type,
+            return_type: return_type.map(Box::new),
             ..self
         }
     }
@@ -1624,7 +1653,7 @@ pub enum Suffix {
     #[display("{_0}")]
     #[cfg(feature = "luau")]
     /// A type instantiation, such as `a<<T>>`
-    TypeInstantiation(TypeInstantiation),
+    TypeInstantiation(Box<TypeInstantiation>),
 }
 
 /// A complex expression used by [`Var`], consisting of both a prefix and suffixes
@@ -1759,7 +1788,7 @@ pub struct LocalFunction {
     local_token: TokenReference,
     function_token: TokenReference,
     name: TokenReference,
-    body: FunctionBody,
+    body: Box<FunctionBody>,
 }
 
 impl LocalFunction {
@@ -1771,7 +1800,7 @@ impl LocalFunction {
             local_token: TokenReference::basic_symbol("local "),
             function_token: TokenReference::basic_symbol("function "),
             name,
-            body: FunctionBody::new(),
+            body: Box::new(FunctionBody::new()),
         }
     }
 
@@ -1830,7 +1859,10 @@ impl LocalFunction {
 
     /// Returns a new LocalFunction with the given function body
     pub fn with_body(self, body: FunctionBody) -> Self {
-        Self { body, ..self }
+        Self {
+            body: Box::new(body),
+            ..self
+        }
     }
 }
 
@@ -2048,7 +2080,7 @@ impl FunctionCall {
     pub fn new(prefix: Prefix) -> Self {
         FunctionCall {
             prefix,
-            suffixes: vec![Suffix::Call(Call::AnonymousCall(
+            suffixes: vec![Suffix::Call(Call::AnonymousCall(Box::new(
                 FunctionArgs::Parentheses {
                     arguments: Punctuated::new(),
                     parentheses: ContainedSpan::new(
@@ -2056,7 +2088,7 @@ impl FunctionCall {
                         TokenReference::basic_symbol(")"),
                     ),
                 },
-            ))],
+            )))],
         }
     }
 
@@ -2149,7 +2181,7 @@ pub struct FunctionDeclaration {
     attributes: Vec<LuauAttribute>,
     function_token: TokenReference,
     name: FunctionName,
-    body: FunctionBody,
+    body: Box<FunctionBody>,
 }
 
 impl FunctionDeclaration {
@@ -2160,7 +2192,7 @@ impl FunctionDeclaration {
             attributes: Vec::new(),
             function_token: TokenReference::basic_symbol("function "),
             name,
-            body: FunctionBody::new(),
+            body: Box::new(FunctionBody::new()),
         }
     }
 
@@ -2206,7 +2238,10 @@ impl FunctionDeclaration {
 
     /// Returns a new FunctionDeclaration with the given function body
     pub fn with_body(self, body: FunctionBody) -> Self {
-        Self { body, ..self }
+        Self {
+            body: Box::new(body),
+            ..self
+        }
     }
 }
 

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -128,11 +128,11 @@ fn parse_compound_assignment(state: &mut ParserState, var: Var) -> ParserResult<
     };
 
     ParserResult::Value(StmtVariant::Stmt(ast::Stmt::CompoundAssignment(
-        ast::CompoundAssignment {
+        Box::new(ast::CompoundAssignment {
             lhs: var,
             compound_operator: ast::CompoundOp::from_token(compound_operator),
             rhs: expr,
-        },
+        }),
     )))
 }
 
@@ -171,7 +171,9 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                             Err(()) => return ParserResult::LexerMoved,
                         };
 
-                    ParserResult::Value(StmtVariant::Stmt(ast::Stmt::LocalFunction(local_function)))
+                    ParserResult::Value(StmtVariant::Stmt(ast::Stmt::LocalFunction(
+                        Box::new(local_function),
+                    )))
                 }
 
                 _ => {
@@ -203,22 +205,22 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                 Err(()) => return ParserResult::LexerMoved,
             };
 
-            ParserResult::Value(StmtVariant::Stmt(ast::Stmt::Do(ast::Do {
+            ParserResult::Value(StmtVariant::Stmt(ast::Stmt::Do(Box::new(ast::Do {
                 do_token,
                 block,
                 end_token,
-            })))
+            }))))
         }
 
         TokenType::Symbol { symbol: Symbol::If } => {
             let if_token = state.consume().unwrap();
 
-            ParserResult::Value(StmtVariant::Stmt(ast::Stmt::If(
+            ParserResult::Value(StmtVariant::Stmt(ast::Stmt::If(Box::new(
                 match expect_if_stmt(state, if_token) {
                     Ok(if_stmt) => if_stmt,
                     Err(()) => return ParserResult::LexerMoved,
                 },
-            )))
+            ))))
         }
 
         TokenType::Symbol {
@@ -232,7 +234,7 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
             };
 
             ParserResult::Value(StmtVariant::Stmt(ast::Stmt::FunctionDeclaration(
-                function_declaration,
+                Box::new(function_declaration),
             )))
         }
 
@@ -254,12 +256,12 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
         } => {
             let while_token = state.consume().unwrap();
 
-            ParserResult::Value(StmtVariant::Stmt(ast::Stmt::While(
+            ParserResult::Value(StmtVariant::Stmt(ast::Stmt::While(Box::new(
                 match expect_while_stmt(state, while_token) {
                     Ok(while_stmt) => while_stmt,
                     Err(()) => return ParserResult::LexerMoved,
                 },
-            )))
+            ))))
         }
 
         TokenType::Symbol {
@@ -363,7 +365,7 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                                     if let Some(function_token) = state.consume_if(Symbol::Function)
                                     {
                                         return ParserResult::Value(StmtVariant::Stmt(
-                                            ast::Stmt::ExportedTypeFunction(
+                                            ast::Stmt::ExportedTypeFunction(Box::new(
                                                 ast::ExportedTypeFunction {
                                                     export_token,
                                                     type_function: match expect_type_function(
@@ -375,12 +377,12 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                                                         Err(()) => return ParserResult::LexerMoved,
                                                     },
                                                 },
-                                            ),
+                                            )),
                                         ));
                                     }
 
                                     return ParserResult::Value(StmtVariant::Stmt(
-                                        ast::Stmt::ExportedTypeDeclaration(
+                                        ast::Stmt::ExportedTypeDeclaration(Box::new(
                                             ast::ExportedTypeDeclaration {
                                                 export_token,
                                                 type_declaration: match expect_type_declaration(
@@ -390,7 +392,7 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                                                     Err(()) => return ParserResult::LexerMoved,
                                                 },
                                             },
-                                        ),
+                                        )),
                                     ));
                                 }
                                 TokenType::Identifier { identifier }
@@ -401,7 +403,7 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                                     if let Some(function_token) = state.consume_if(Symbol::Function)
                                     {
                                         return ParserResult::Value(StmtVariant::Stmt(
-                                            ast::Stmt::TypeFunction(
+                                            ast::Stmt::TypeFunction(Box::new(
                                                 match expect_type_function(
                                                     state,
                                                     type_token,
@@ -410,17 +412,17 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                                                     Ok(type_function) => type_function,
                                                     Err(()) => return ParserResult::LexerMoved,
                                                 },
-                                            ),
+                                            )),
                                         ));
                                     }
 
                                     return ParserResult::Value(StmtVariant::Stmt(
-                                        ast::Stmt::TypeDeclaration(
+                                        ast::Stmt::TypeDeclaration(Box::new(
                                             match expect_type_declaration(state, type_token) {
                                                 Ok(type_declaration) => type_declaration,
                                                 Err(()) => return ParserResult::LexerMoved,
                                             },
-                                        ),
+                                        )),
                                     ));
                                 }
                                 TokenType::Identifier { identifier }
@@ -470,7 +472,9 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                                                     Err(()) => return ParserResult::LexerMoved,
                                                 };
                                             return ParserResult::Value(StmtVariant::Stmt(
-                                                ast::Stmt::ConstFunction(const_function),
+                                                ast::Stmt::ConstFunction(Box::new(
+                                                    const_function,
+                                                )),
                                             ));
                                         }
 
@@ -683,7 +687,7 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                         };
 
                     ParserResult::Value(StmtVariant::Stmt(ast::Stmt::FunctionDeclaration(
-                        function_declaration.with_attributes(attributes),
+                        Box::new(function_declaration.with_attributes(attributes)),
                     )))
                 }
                 Ok(token) if token.is_symbol(Symbol::Local) => {
@@ -702,7 +706,7 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                             };
 
                             ParserResult::Value(StmtVariant::Stmt(ast::Stmt::LocalFunction(
-                                local_function.with_attributes(attributes),
+                                Box::new(local_function.with_attributes(attributes)),
                             )))
                         }
                         Ok(token) => {
@@ -732,7 +736,7 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                             };
 
                             ParserResult::Value(StmtVariant::Stmt(ast::Stmt::ConstFunction(
-                                const_function.with_attributes(attributes),
+                                Box::new(const_function.with_attributes(attributes)),
                             )))
                         }
                         Ok(token) => {
@@ -864,13 +868,13 @@ fn expect_function_declaration(
     };
 
     let function_body = match parse_function_body(state) {
-        ParserResult::Value(body) => body,
+        ParserResult::Value(body) => Box::new(body),
 
-        ParserResult::LexerMoved => ast::FunctionBody::new(),
+        ParserResult::LexerMoved => Box::new(ast::FunctionBody::new()),
 
         ParserResult::NotFound => {
             state.token_error(function_token.clone(), "expected a function body");
-            ast::FunctionBody::new()
+            Box::new(ast::FunctionBody::new())
         }
     };
 
@@ -900,7 +904,7 @@ fn expect_local_function_declaration(
     };
 
     let function_body = match parse_function_body(state) {
-        ParserResult::Value(function_body) => function_body,
+        ParserResult::Value(function_body) => Box::new(function_body),
         ParserResult::NotFound => {
             state.token_error(function_token, "expected a function body");
             return Err(());
@@ -936,11 +940,11 @@ fn expect_for_stmt(state: &mut ParserState, for_token: TokenReference) -> Result
     debug_assert!(!name_list.is_empty());
 
     if name_list.len() == 1 && current_token.is_symbol(Symbol::Equal) {
-        return Ok(ast::Stmt::NumericFor(expect_numeric_for_stmt(
+        return Ok(ast::Stmt::NumericFor(Box::new(expect_numeric_for_stmt(
             state,
             for_token,
             name_list.into_iter().next().unwrap(),
-        )?));
+        )?)));
     }
 
     let in_token = match current_token {
@@ -961,7 +965,7 @@ fn expect_for_stmt(state: &mut ParserState, for_token: TokenReference) -> Result
     };
 
     let Some(do_token) = state.require(Symbol::Do, "expected `do` after expression list") else {
-        return Ok(ast::Stmt::GenericFor(ast::GenericFor {
+        return Ok(ast::Stmt::GenericFor(Box::new(ast::GenericFor {
             for_token,
             names: name_list
                 .clone()
@@ -978,7 +982,7 @@ fn expect_for_stmt(state: &mut ParserState, for_token: TokenReference) -> Result
             do_token: TokenReference::basic_symbol("do"),
             block: ast::Block::new(),
             end_token: TokenReference::basic_symbol("end"),
-        }));
+        })));
     };
 
     let (block, end) = match expect_block_with_end(state, "for loop", &do_token) {
@@ -986,7 +990,7 @@ fn expect_for_stmt(state: &mut ParserState, for_token: TokenReference) -> Result
         Err(()) => (ast::Block::new(), TokenReference::basic_symbol("end")),
     };
 
-    Ok(ast::Stmt::GenericFor(ast::GenericFor {
+    Ok(ast::Stmt::GenericFor(Box::new(ast::GenericFor {
         for_token,
         names: name_list
             .clone()
@@ -1003,7 +1007,7 @@ fn expect_for_stmt(state: &mut ParserState, for_token: TokenReference) -> Result
         do_token,
         block,
         end_token: end,
-    }))
+    })))
 }
 
 fn expect_numeric_for_stmt(
@@ -1064,13 +1068,13 @@ fn expect_numeric_for_stmt(
         for_token,
         index_variable: index_variable.name,
         #[cfg(feature = "luau")]
-        type_specifier: index_variable.type_specifier,
+        type_specifier: index_variable.type_specifier.map(Box::new),
         equal_token,
-        start,
+        start: Box::new(start),
         start_end_comma,
-        end,
+        end: Box::new(end),
         end_step_comma,
-        step,
+        step: step.map(Box::new),
         do_token,
         block,
         end_token,
@@ -1188,7 +1192,7 @@ fn expect_if_stmt(state: &mut ParserState, if_token: TokenReference) -> Result<a
 
     Ok(ast::If {
         if_token,
-        condition,
+        condition: Box::new(condition),
         then_token,
         block: then_block,
         else_if: else_if_optional(else_if),
@@ -1380,7 +1384,7 @@ fn expect_const_function_declaration(
     };
 
     let function_body = match parse_function_body(state) {
-        ParserResult::Value(function_body) => function_body,
+        ParserResult::Value(function_body) => Box::new(function_body),
         ParserResult::NotFound => {
             state.token_error(function_token, "expected a function body");
             return Err(());
@@ -1455,9 +1459,9 @@ fn expect_expression_key(
 
     Ok(ast::Field::ExpressionKey {
         brackets: ContainedSpan::new(left_bracket, right_bracket),
-        key: expression,
+        key: Box::new(expression),
         equal: equal_token,
-        value,
+        value: Box::new(value),
     })
 }
 
@@ -1524,7 +1528,7 @@ fn force_table_constructor(
                 ast::Field::NameKey {
                     key,
                     equal: equal_token,
-                    value,
+                    value: Box::new(value),
                 }
             }
 
@@ -1628,7 +1632,7 @@ fn expect_repeat_stmt(
     };
 
     let Some(until_token) = state.require(Symbol::Until, "expected `until` after block") else {
-        return Ok(ast::Stmt::Do(ast::Do::new().with_block(block)));
+        return Ok(ast::Stmt::Do(Box::new(ast::Do::new().with_block(block))));
     };
 
     let condition = match parse_expression(state) {
@@ -1636,20 +1640,20 @@ fn expect_repeat_stmt(
 
         ParserResult::NotFound => {
             state.token_error(until_token, "expected a condition after `until`");
-            return Ok(ast::Stmt::Do(ast::Do::new().with_block(block)));
+            return Ok(ast::Stmt::Do(Box::new(ast::Do::new().with_block(block))));
         }
 
         ParserResult::LexerMoved => {
-            return Ok(ast::Stmt::Do(ast::Do::new().with_block(block)));
+            return Ok(ast::Stmt::Do(Box::new(ast::Do::new().with_block(block))));
         }
     };
 
-    Ok(ast::Stmt::Repeat(ast::Repeat {
+    Ok(ast::Stmt::Repeat(Box::new(ast::Repeat {
         repeat_token,
         block,
-        until: condition,
+        until: Box::new(condition),
         until_token,
-    }))
+    })))
 }
 
 fn expect_while_stmt(
@@ -1684,7 +1688,7 @@ fn expect_while_stmt(
 
     Ok(ast::While {
         while_token,
-        condition,
+        condition: Box::new(condition),
         do_token,
         block,
         end_token,
@@ -1746,7 +1750,7 @@ fn expect_type_function(
     };
 
     let function_body = match parse_function_body(state) {
-        ParserResult::Value(body) => body,
+        ParserResult::Value(body) => Box::new(body),
         ParserResult::LexerMoved => return Err(()),
         ParserResult::NotFound => {
             state.token_error(function_token, "expected a type function body");
@@ -1846,9 +1850,9 @@ fn parse_arguments(state: &mut ParserState) -> ParserResult<ast::FunctionArgs> {
         } => {
             let left_brace = state.consume().unwrap();
 
-            ParserResult::Value(ast::FunctionArgs::TableConstructor(
+            ParserResult::Value(ast::FunctionArgs::TableConstructor(Box::new(
                 force_table_constructor(state, left_brace),
-            ))
+            )))
         }
 
         TokenType::StringLiteral { .. } => {
@@ -1936,7 +1940,7 @@ fn parse_suffix(state: &mut ParserState) -> ParserResult<ast::Suffix> {
 
             ParserResult::Value(ast::Suffix::Index(ast::Index::Brackets {
                 brackets: ContainedSpan::new(left_bracket, right_bracket),
-                expression,
+                expression: Box::new(expression),
             }))
         }
 
@@ -1945,7 +1949,9 @@ fn parse_suffix(state: &mut ParserState) -> ParserResult<ast::Suffix> {
         }
         | TokenType::StringLiteral { .. } => {
             let arguments = try_parser!(parse_arguments(state)).unwrap();
-            ParserResult::Value(ast::Suffix::Call(ast::Call::AnonymousCall(arguments)))
+            ParserResult::Value(ast::Suffix::Call(ast::Call::AnonymousCall(Box::new(
+                arguments,
+            ))))
         }
 
         #[cfg(feature = "luau")]
@@ -1962,7 +1968,9 @@ fn parse_suffix(state: &mut ParserState) -> ParserResult<ast::Suffix> {
             let outer_0 = state.consume().unwrap();
             match expect_type_instantiation(state, outer_0) {
                 Ok(type_instantiation) => {
-                    ParserResult::Value(ast::Suffix::TypeInstantiation(type_instantiation))
+                    ParserResult::Value(ast::Suffix::TypeInstantiation(Box::new(
+                        type_instantiation,
+                    )))
                 }
 
                 Err(_) => ParserResult::LexerMoved,
@@ -1998,7 +2006,7 @@ fn parse_suffix(state: &mut ParserState) -> ParserResult<ast::Suffix> {
                     ) {
                         let outer_0 = state.consume().unwrap();
                         match expect_type_instantiation(state, outer_0) {
-                            Ok(instantiation) => Some(instantiation),
+                            Ok(instantiation) => Some(Box::new(instantiation)),
                             Err(()) => return ParserResult::LexerMoved,
                         }
                     } else {
@@ -2020,14 +2028,16 @@ fn parse_suffix(state: &mut ParserState) -> ParserResult<ast::Suffix> {
                 }
             };
 
-            ParserResult::Value(ast::Suffix::Call(ast::Call::MethodCall(ast::MethodCall {
-                colon_token,
-                name,
-                args,
+            ParserResult::Value(ast::Suffix::Call(ast::Call::MethodCall(Box::new(
+                ast::MethodCall {
+                    colon_token,
+                    name,
+                    args: Box::new(args),
 
-                #[cfg(feature = "luau")]
-                type_instantiation,
-            })))
+                    #[cfg(feature = "luau")]
+                    type_instantiation,
+                },
+            ))))
         }
 
         _ => ParserResult::NotFound,
@@ -2093,7 +2103,7 @@ fn parse_primary_expression(state: &mut ParserState) -> ParserResult<Expression>
                 Ok(token) if token.is_symbol(Symbol::Function) => {
                     let function_token = state.consume().unwrap();
                     let function_body = match parse_function_body(state) {
-                        ParserResult::Value(body) => body,
+                        ParserResult::Value(body) => Box::new(body),
                         ParserResult::LexerMoved => return ParserResult::LexerMoved,
                         ParserResult::NotFound => {
                             state.token_error(function_token, "expected a function body");
@@ -2121,7 +2131,7 @@ fn parse_primary_expression(state: &mut ParserState) -> ParserResult<Expression>
         } => {
             let function_token = state.consume().unwrap();
             let function_body = match parse_function_body(state) {
-                ParserResult::Value(body) => body,
+                ParserResult::Value(body) => Box::new(body),
                 ParserResult::LexerMoved => return ParserResult::LexerMoved,
                 ParserResult::NotFound => {
                     state.token_error(function_token, "expected a function body");
@@ -2202,8 +2212,8 @@ fn parse_primary_expression(state: &mut ParserState) -> ParserResult<Expression>
             symbol: Symbol::LeftBrace,
         } => {
             let left_brace = state.consume().unwrap();
-            ParserResult::Value(ast::Expression::TableConstructor(force_table_constructor(
-                state, left_brace,
+            ParserResult::Value(ast::Expression::TableConstructor(Box::new(
+                force_table_constructor(state, left_brace),
             )))
         }
 
@@ -2212,7 +2222,7 @@ fn parse_primary_expression(state: &mut ParserState) -> ParserResult<Expression>
             let if_token = state.consume().unwrap();
             match expect_if_else_expression(state, if_token) {
                 Ok(if_expression) => {
-                    ParserResult::Value(ast::Expression::IfExpression(if_expression))
+                    ParserResult::Value(ast::Expression::IfExpression(Box::new(if_expression)))
                 }
                 Err(_) => ParserResult::LexerMoved,
             }
@@ -2225,16 +2235,16 @@ fn parse_primary_expression(state: &mut ParserState) -> ParserResult<Expression>
 
             match kind {
                 InterpolatedStringKind::Simple => ParserResult::Value(
-                    ast::Expression::InterpolatedString(ast::InterpolatedString {
+                    ast::Expression::InterpolatedString(Box::new(ast::InterpolatedString {
                         segments: Vec::new(),
                         last_string: interpolated_string_begin,
-                    }),
+                    })),
                 ),
 
                 InterpolatedStringKind::Begin => {
-                    ParserResult::Value(ast::Expression::InterpolatedString(
+                    ParserResult::Value(ast::Expression::InterpolatedString(Box::new(
                         expect_interpolated_string(state, interpolated_string_begin),
-                    ))
+                    )))
                 }
 
                 _ => ParserResult::NotFound,
@@ -2254,10 +2264,10 @@ fn parse_primary_expression(state: &mut ParserState) -> ParserResult<Expression>
 
                 ParserResult::Value(ast::Expression::TypeAssertion {
                     expression: Box::new(expression),
-                    type_assertion: ast::TypeAssertion {
+                    type_assertion: Box::new(ast::TypeAssertion {
                         assertion_op,
-                        cast_to,
-                    },
+                        cast_to: Box::new(cast_to),
+                    }),
                 })
             } else {
                 ParserResult::Value(expression)
@@ -2402,7 +2412,7 @@ fn parse_function_body(state: &mut ParserState) -> ParserResult<FunctionBody> {
 
     #[cfg(feature = "luau")]
     let generics = match parse_generic_type_list(state, TypeListStyle::Plain) {
-        ParserResult::Value(generic_declaration) => Some(generic_declaration),
+        ParserResult::Value(generic_declaration) => Some(Box::new(generic_declaration)),
         ParserResult::NotFound => None,
         ParserResult::LexerMoved => return ParserResult::LexerMoved,
     };
@@ -2481,7 +2491,7 @@ fn parse_function_body(state: &mut ParserState) -> ParserResult<FunctionBody> {
 
                         Some(ast::TypeSpecifier {
                             punctuation: colon,
-                            type_info,
+                            type_info: Box::new(type_info),
                         })
                     } else {
                         None
@@ -2557,10 +2567,10 @@ fn parse_function_body(state: &mut ParserState) -> ParserResult<FunctionBody> {
     let return_type = if state.lua_version().has_luau() {
         if let Some(punctuation) = state.consume_if(Symbol::Colon) {
             match parse_return_type(state) {
-                ParserResult::Value(type_info) => Some(ast::TypeSpecifier {
+                ParserResult::Value(type_info) => Some(Box::new(ast::TypeSpecifier {
                     punctuation,
-                    type_info,
-                }),
+                    type_info: Box::new(type_info),
+                })),
                 _ => return ParserResult::LexerMoved,
             }
         } else if let Some(punctuation) = state.consume_if(Symbol::ThinArrow) {
@@ -2569,10 +2579,10 @@ fn parse_function_body(state: &mut ParserState) -> ParserResult<FunctionBody> {
                 "function return type annotations should use `:` instead of `->`",
             );
             match parse_return_type(state) {
-                ParserResult::Value(type_info) => Some(ast::TypeSpecifier {
+                ParserResult::Value(type_info) => Some(Box::new(ast::TypeSpecifier {
                     punctuation,
-                    type_info,
-                }),
+                    type_info: Box::new(type_info),
+                })),
                 _ => return ParserResult::LexerMoved,
             }
         } else {
@@ -2633,9 +2643,9 @@ fn expect_if_else_expression(
         };
         else_if_expressions.push(ast::ElseIfExpression {
             else_if_token,
-            condition,
+            condition: Box::new(condition),
             then_token,
-            expression,
+            expression: Box::new(expression),
         })
     }
 
@@ -3180,10 +3190,10 @@ fn expect_type_table(
                 access,
                 key: ast::TypeFieldKey::IndexSignature {
                     brackets: ContainedSpan::new(left_brace, right_brace),
-                    inner: ast::TypeInfo::String(property),
+                    inner: Box::new(ast::TypeInfo::String(property)),
                 },
                 colon,
-                value,
+                value: Box::new(value),
             }
         } else if current_token.is_symbol(Symbol::LeftBracket) {
             let left_brace = state.consume().unwrap();
@@ -3235,10 +3245,10 @@ fn expect_type_table(
                 access,
                 key: ast::TypeFieldKey::IndexSignature {
                     brackets: ContainedSpan::new(left_brace, right_brace),
-                    inner: key,
+                    inner: Box::new(key),
                 },
                 colon,
-                value,
+                value: Box::new(value),
             }
         } else if fields.is_empty()
             && !has_indexer
@@ -3284,7 +3294,7 @@ fn expect_type_table(
                         access,
                         key: ast::TypeFieldKey::Name(name.name),
                         colon,
-                        value,
+                        value: Box::new(value),
                     }
                 }
                 ParserResult::NotFound => break,
@@ -3352,7 +3362,7 @@ fn expect_function_type(
             ParserResult::Value(type_info) => {
                 arguments.push(Pair::End(ast::TypeArgument {
                     name: None,
-                    type_info,
+                    type_info: Box::new(type_info),
                 }));
                 break;
             }
@@ -3376,7 +3386,10 @@ fn expect_function_type(
             return Err(());
         };
 
-        let type_argument = ast::TypeArgument { name, type_info };
+        let type_argument = ast::TypeArgument {
+            name,
+            type_info: Box::new(type_info),
+        };
 
         if !matches!(state.current(), Ok(token) if token.is_symbol(Symbol::Comma)) {
             arguments.push(Pair::End(type_argument));
@@ -3414,7 +3427,7 @@ fn expect_function_type(
         // Simple type wrapped in parentheses (not allowed to be a vararg type), or an allowed type pack
         if (arguments.len() == 1
             && !matches!(
-                arguments.iter().next().unwrap().type_info,
+                *arguments.iter().next().unwrap().type_info,
                 ast::TypeInfo::Variadic { .. }
             ))
             || style == SimpleTypeStyle::AllowPack
@@ -3423,7 +3436,7 @@ fn expect_function_type(
                 parentheses,
                 types: arguments
                     .into_pairs()
-                    .map(|pair| pair.map(|argument| argument.type_info))
+                    .map(|pair| pair.map(|argument| *argument.type_info))
                     .collect(),
             });
         }
@@ -3463,7 +3476,7 @@ fn expect_type_specifier(
 
     Ok(ast::TypeSpecifier {
         punctuation,
-        type_info,
+        type_info: Box::new(type_info),
     })
 }
 
@@ -3558,7 +3571,7 @@ fn parse_generic_type_list(
                     ParserResult::LexerMoved => return ParserResult::LexerMoved,
                 };
 
-                Some((equal_token, default_type))
+                Some((equal_token, Box::new(default_type)))
             } else {
                 if seen_default {
                     state.token_error(
@@ -3585,7 +3598,7 @@ fn parse_generic_type_list(
                     _ => return ParserResult::LexerMoved,
                 };
 
-                Some((equal_token, default_type))
+                Some((equal_token, Box::new(default_type)))
             } else {
                 if seen_default {
                     state.token_error(


### PR DESCRIPTION
The AST stored heavy nodes by value inside enums and structs.  Because an enum's size is its largest variant, this caused size inflation that propagated through the tree: Stmt was 4784 bytes per slot (dominated by NumericFor's three inline 880-byte Expressions), and the recursive parser carried several of these per stack frame. A trivial program could overflow the default thread stack.

Reproduces with this snippet under any thread that has less than ~2 MiB of stack:

    use full_moon;

    fn main() {
        std::thread::Builder::new()
            .stack_size(1024 * 1024)
            .spawn(|| {
                full_moon::parse(
                    "function Foo(bar: foobar.baz): foobar.qux
                         t.Free = function()
                             bar.free()
                         end
                     end",
                )
                .unwrap();
            })
            .unwrap()
            .join()
            .unwrap();
    }

For context: Rust's default `std::thread::spawn` stack is 2 MiB on tier-1 platforms; the Linux main thread gets 8 MiB; Tokio's multi-thread runtime workers default to 2 MiB; macOS, Windows, WASM and embedded contexts all routinely run threads with smaller budgets, and any of those would hit the overflow on real-world Luau input.

The fix is mechanical: box the heaviest enum variants and the heaviest struct fields throughout the AST so each slot is pointer-sized when its contents aren't being actively constructed. Largest results:

    Stmt:                4784 ->  352 bytes  (~14x)
    Expression:           880 ->  280 bytes  (~3x)
    AnonymousFunction:   2104 ->  168 bytes  (~13x)
    Call:                1144 ->   16 bytes  (~70x)
    TypeAssertion:        872 ->  144 bytes  (~6x)
    ElseIfExpression:     832 ->  288 bytes  (~3x)
    MethodCall:          1144 ->  288 bytes  (~4x)
    FunctionBody:        1944 ->  792 bytes  (~2x)

Stack thresholds for parsing the snippet above:

                  before     after    improvement
    debug         ~2 MiB     ~340 KiB ~6x
    release       ~384 KiB   ~88 KiB  ~4x

For the project's existing deepest stress test (12-level nested do blocks in roblox_cases/pass/multiline_expressions):

                  before     after    improvement
    debug         >2 MiB     ~512 KiB ~4x+
    release       ~256 KiB   ~112 KiB ~2x

Both are now comfortably under any common runtime's thread stack budget.

The remaining stack pressure in debug builds comes from the giant `match` expressions in parse_value and parse_stmt, where rustc reserves frame space for the union of all match arms' locals. That is invariant under AST shape changes and would need a parser refactor (extracting match arms into separate functions) to address, and I want to keep this commit easy to understand and relatively narrow in scope.

Notes:

  - Bumps full-moon to 3.0.0. The variant payload changes are SemVer-major: pattern matches that destructure by value need `Box::new(...)` at construction sites and `*` or auto-deref at binding sites. Code that uses accessor methods or matches by reference is unaffected (Box<T>: Deref<Target = T>).

  - serde representation is unchanged: Box<T> serializes transparently, so all existing snapshot files are byte-identical.