### PR TITLE
Disambiguate Luau type instantiation from Lua 5.3+ shifts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- When a runtime `LuaVersion` has both Luau and Lua 5.3+ enabled, the lexer no longer combines `<<` and `>>` into single tokens. This lets blended-dialect callers parse Luau's explicit type-instantiation syntax (`f<<T>>(x)`) and nested generic types (`Map<K, Vec<V>>`) correctly. Bitwise shifts and compound shift-assigns (`<<=`, `>>=`) become unavailable under that exact feature combination as a trade-off; pure Lua 5.3/5.4 and pure Luau parsing are unaffected.
 
 ## [2.2.0] - 2026-04-15
 ### Added

--- a/full-moon/src/tokenizer/lexer.rs
+++ b/full-moon/src/tokenizer/lexer.rs
@@ -686,31 +686,40 @@ impl Lexer {
             ),
 
             '<' => {
-                version_switch!(self.lua_version, {
-                    lua53 | cfxlua => {
-                        if self.source.consume('<') {
-                            version_switch!(self.lua_version, {
-                                cfxlua => {
-                                    if self.source.consume('=') {
-                                        return self.create(
-                                            start_position,
-                                            TokenType::Symbol {
-                                                symbol: Symbol::DoubleLessThanEqual,
-                                            },
-                                        );
-                                    }
-                                }
-                            });
+                // Luau's explicit-type-instantiation syntax `f<<T>>(x)` and
+                // its nested-generic types `Map<K, Vec<V>>` both produce two
+                // adjacent `<` (or `>`) tokens that the parser expects to see
+                // separately. When Luau is active in the current LuaVersion,
+                // suppress the `<<` and `>>` combining that lua53/cfxlua
+                // would otherwise do, so those constructs parse correctly.
+                // Bitwise shifts and compound shift-assigns become unavailable
+                // under that combination, which is the right trade-off for
+                // any blended dialect users would actually write.
+                #[cfg(any(feature = "lua53", feature = "cfxlua"))]
+                {
+                    let combine_shift = (self.lua_version.has_lua53()
+                        || self.lua_version.has_cfxlua())
+                        && !self.lua_version.has_luau();
 
+                    if combine_shift && self.source.consume('<') {
+                        #[cfg(feature = "cfxlua")]
+                        if self.lua_version.has_cfxlua() && self.source.consume('=') {
                             return self.create(
                                 start_position,
                                 TokenType::Symbol {
-                                    symbol: Symbol::DoubleLessThan,
+                                    symbol: Symbol::DoubleLessThanEqual,
                                 },
                             );
                         }
+
+                        return self.create(
+                            start_position,
+                            TokenType::Symbol {
+                                symbol: Symbol::DoubleLessThan,
+                            },
+                        );
                     }
-                });
+                }
 
                 if self.source.consume('=') {
                     self.create(
@@ -730,31 +739,33 @@ impl Lexer {
             }
 
             '>' => {
-                version_switch!(self.lua_version, {
-                    lua53 | cfxlua => {
-                        if self.source.consume('>') {
-                            version_switch!(self.lua_version, {
-                                cfxlua => {
-                                    if self.source.consume('=') {
-                                        return self.create(
-                                            start_position,
-                                            TokenType::Symbol {
-                                                symbol: Symbol::DoubleGreaterThanEqual,
-                                            },
-                                        );
-                                    }
-                                }
-                            });
+                // See the matching comment under `'<'` above; Luau's
+                // generic-close `>>` is a pair of single tokens.
+                #[cfg(any(feature = "lua53", feature = "cfxlua"))]
+                {
+                    let combine_shift = (self.lua_version.has_lua53()
+                        || self.lua_version.has_cfxlua())
+                        && !self.lua_version.has_luau();
 
+                    if combine_shift && self.source.consume('>') {
+                        #[cfg(feature = "cfxlua")]
+                        if self.lua_version.has_cfxlua() && self.source.consume('=') {
                             return self.create(
                                 start_position,
                                 TokenType::Symbol {
-                                    symbol: Symbol::DoubleGreaterThan,
+                                    symbol: Symbol::DoubleGreaterThanEqual,
                                 },
                             );
                         }
+
+                        return self.create(
+                            start_position,
+                            TokenType::Symbol {
+                                symbol: Symbol::DoubleGreaterThan,
+                            },
+                        );
                     }
-                });
+                }
 
                 if self.source.consume('=') {
                     self.create(

--- a/full-moon/tests/luau_shift_disambiguation.rs
+++ b/full-moon/tests/luau_shift_disambiguation.rs
@@ -1,0 +1,79 @@
+//! Regression tests for Luau type-instantiation / nested-generic syntax
+//! interacting with Lua 5.3+ shift operators when both feature flags are
+//! active. The lexer suppresses `<<`/`>>` combining when Luau is part of
+//! the runtime `LuaVersion`, so blended-dialect callers can parse
+//! `f<<T>>(x)` and `Map<K, Vec<V>>` correctly.
+
+#![cfg(all(feature = "luau", feature = "lua53"))]
+
+use full_moon::{ast::LuaVersion, parse_fallible};
+
+fn assert_roundtrips(label: &str, source: &str, version: LuaVersion) {
+    let result = parse_fallible(source, version);
+    assert!(
+        result.errors().is_empty(),
+        "[{label}] parse errored: {:#?}",
+        result.errors()
+    );
+    let printed = result.ast().to_string();
+    assert_eq!(printed, source, "[{label}] roundtrip mismatch");
+}
+
+#[test]
+fn type_instantiation_with_lua53() {
+    let src = "f<<T>>(x)\n";
+    assert_roundtrips(
+        "luau+lua53 type instantiation",
+        src,
+        LuaVersion::luau().with_lua53(),
+    );
+}
+
+#[test]
+#[cfg(feature = "lua54")]
+fn type_instantiation_with_lua54() {
+    let src = "local _ = f<<T>>(x)\n";
+    assert_roundtrips(
+        "luau+lua54 type instantiation",
+        src,
+        LuaVersion::luau().with_lua54(),
+    );
+}
+
+#[test]
+fn method_type_instantiation_with_lua53() {
+    let src = "a:method<<T>>(1)\n";
+    assert_roundtrips(
+        "luau+lua53 method type instantiation",
+        src,
+        LuaVersion::luau().with_lua53(),
+    );
+}
+
+#[test]
+fn nested_generic_close_with_lua53() {
+    let src = "type Foo = Map<string, Array<number>>\n";
+    assert_roundtrips(
+        "luau+lua53 nested generic close",
+        src,
+        LuaVersion::luau().with_lua53(),
+    );
+}
+
+#[test]
+fn triple_nested_generic_close_with_lua53() {
+    let src = "type X = A<B<C<D>>>\n";
+    assert_roundtrips(
+        "luau+lua53 triple-nested generic close",
+        src,
+        LuaVersion::luau().with_lua53(),
+    );
+}
+
+/// Bitwise shifts still parse correctly when only `lua53` (no luau) is
+/// part of the runtime `LuaVersion`.
+#[test]
+fn bitwise_shifts_still_parse_under_lua53_alone() {
+    let src = "local z = a << b\n";
+    assert_roundtrips("lua53 shift", src, LuaVersion::lua53());
+}


### PR DESCRIPTION
When a runtime `LuaVersion` includes both `luau` and `lua53` (or any feature that implies it, like `lua54` or `cfxlua`), the lexer's greedy combining of `<<` and `>>` into single tokens silently breaks every Luau construct that uses adjacent angles:

```
  f<<T>>(x)                                 -- explicit type instantiation
  a:method<<T>>(1)                          -- method type instantiation
  type Foo = Map<string, Array<number>>     -- nested generic close
```

Each of these is two `<` or two `>` tokens in real Luau source. With the lua53 lexer rule active, they're combined into `DoubleLessThan` / `DoubleGreaterThan`, the parser doesn't recognise the combined token in suffix position, and the user gets a confusing parse error.

This is an emergent ambiguity from full-moon's additive feature flags. Lua 5.3+ has shifts but no generics; Luau has generics but no shifts. No real source file has both. The blend exists because some callers want to parse Luau-flavoured code with Lua 5.4 attributes (or other non-Luau extensions), and have to enable both feature sets to do so.

Fix: when `has_luau()` is true on the runtime `LuaVersion`, suppress the lua53/cfxlua `<<` and `>>` combining in the lexer. Adjacent angles emerge as separate tokens, which the existing type-instantiation and generic-type-params parsers already handle correctly. Bitwise shifts and compound shift-assigns (`<<=`, `>>=`) become unavailable under that exact feature combination as a trade-off — there's no realistic source where both are needed.

Behavior summary:

```
  feature combination    `<<`/`>>` parses as
  --------------------   ----------------------
  lua53 (or 54, cfxlua)  shift / compound-assign      (unchanged)
  luau only              two single-angle tokens      (unchanged)
  luau + lua53/54/cfx    two single-angle tokens      (was: parse error)
```

Pure Lua 5.3+ and pure Luau parsing are byte-identical to before. The change only affects the blended runtime configuration.

Regression tests added in `tests/luau_shift_disambiguation.rs` covering type instantiation, method type instantiation, nested generics, and triple-nested generics, plus a negative test confirming shifts still parse under `lua53` alone.