### PR TITLE
luau: allow separators before number prefixes and in exponents

### DIFF
--- a/full-moon/src/tokenizer/lexer.rs
+++ b/full-moon/src/tokenizer/lexer.rs
@@ -335,16 +335,28 @@ impl Lexer {
             }
 
             initial @ '0' => {
+                let mut number = String::from(initial);
+                if self.lua_version.has_luau() {
+                    while let Some(cur) = self.source.current() {
+                        if cur == '_' {
+                            number.push(cur);
+                            self.source.next();
+                        } else {
+                            break;
+                        }
+                    }
+                }
+
                 if matches!(self.source.current(), Some('x' | 'X')) {
-                    let hex_character = self.source.next().unwrap();
-                    self.read_hex_number(hex_character, start_position)
+                    number.push(self.source.next().unwrap());
+                    self.read_hex_number(number, start_position)
                 } else if (self.lua_version.has_luau() || self.lua_version.has_luajit())
                     && matches!(self.source.current(), Some('b' | 'B'))
                 {
-                    let binary_character = self.source.next().unwrap();
-                    self.read_binary_number(binary_character, start_position)
+                    number.push(self.source.next().unwrap());
+                    self.read_binary_number(number, start_position)
                 } else {
-                    self.read_number(start_position, initial.to_string())
+                    self.read_number(start_position, number)
                 }
             }
 
@@ -1075,10 +1087,10 @@ impl Lexer {
 
     fn read_hex_number(
         &mut self,
-        hex_character: char,
+        mut number: String,
         start_position: Position,
     ) -> Option<LexerResult<Token>> {
-        let mut number = String::from_iter(['0', hex_character]);
+        let prefix_len = number.len();
         let mut hit_decimal = false;
 
         while let Some(next) = self.source.current() {
@@ -1101,7 +1113,7 @@ impl Lexer {
                 }
 
                 'p' | 'P' if self.lua_version.has_lua52() => {
-                    if number.len() == 2 {
+                    if number.len() == prefix_len {
                         return Some(self.eat_invalid_number(start_position, number));
                     }
 
@@ -1116,7 +1128,7 @@ impl Lexer {
             }
         }
 
-        if number.len() == 2 {
+        if number.len() == prefix_len {
             return Some(self.eat_invalid_number(start_position, number));
         }
 
@@ -1130,12 +1142,11 @@ impl Lexer {
 
     fn read_binary_number(
         &mut self,
-        binary_character: char,
+        mut number: String,
         start_position: Position,
     ) -> Option<LexerResult<Token>> {
+        let prefix_len = number.len();
         debug_assert!(self.lua_version.has_luau() || self.lua_version.has_luajit());
-
-        let mut number = String::from_iter(['0', binary_character]);
 
         while let Some(next) = self.source.current() {
             match next {
@@ -1151,7 +1162,7 @@ impl Lexer {
             }
         }
 
-        if number.len() == 2 {
+        if number.len() == prefix_len {
             return Some(self.eat_invalid_number(start_position, number));
         }
 

--- a/full-moon/src/tokenizer/lexer.rs
+++ b/full-moon/src/tokenizer/lexer.rs
@@ -1052,6 +1052,30 @@ impl Lexer {
         }
     }
 
+    fn read_number_digits<F>(
+        &mut self,
+        number: &mut String,
+        allow_underscores: bool,
+        is_digit: F,
+    ) -> bool
+    where
+        F: Fn(char) -> bool,
+    {
+        let mut saw_digit = false;
+        while let Some(next) = self.source.current() {
+            if is_digit(next) {
+                saw_digit = true;
+                number.push(self.source.next().expect("peeked, but no next"));
+            } else if allow_underscores && next == '_' {
+                number.push(self.source.next().expect("peeked, but no next"));
+            } else {
+                break;
+            }
+        }
+
+        saw_digit
+    }
+
     // Starts from the exponent marker (like 'e')
     fn read_exponent_part(
         &mut self,
@@ -1065,16 +1089,10 @@ impl Lexer {
             number.push(self.source.next().expect("peeked, but no next"));
         }
 
-        if !matches!(self.source.current(), Some('0'..='9')) {
+        if !self.read_number_digits(&mut number, self.lua_version.has_luau(), |next| {
+            next.is_ascii_digit()
+        }) {
             return Some(self.eat_invalid_number(start_position, number));
-        }
-
-        while let Some(next) = self.source.current() {
-            if next.is_ascii_digit() || (self.lua_version.has_luau() && matches!(next, '_')) {
-                number.push(self.source.next().expect("peeked, but no next"));
-            } else {
-                break;
-            }
         }
 
         self.create(
@@ -1090,19 +1108,15 @@ impl Lexer {
         mut number: String,
         start_position: Position,
     ) -> Option<LexerResult<Token>> {
-        let prefix_len = number.len();
         let mut hit_decimal = false;
+        let mut saw_digit = self.read_number_digits(
+            &mut number,
+            self.lua_version.has_luau(),
+            |next| matches!(next, '0'..='9' | 'a'..='f' | 'A'..='F'),
+        );
 
         while let Some(next) = self.source.current() {
             match next {
-                '0'..='9' | 'a'..='f' | 'A'..='F' => {
-                    number.push(self.source.next().expect("peeked, but no next"));
-                }
-
-                '_' if self.lua_version.has_luau() => {
-                    number.push(self.source.next().expect("peeked, but no next"));
-                }
-
                 '.' if self.lua_version.has_lua52() => {
                     if hit_decimal {
                         return Some(self.eat_invalid_number(start_position, number));
@@ -1110,10 +1124,15 @@ impl Lexer {
 
                     hit_decimal = true;
                     number.push(self.source.next().expect("peeked, but no next"));
+                    saw_digit |= self.read_number_digits(
+                        &mut number,
+                        self.lua_version.has_luau(),
+                        |next| matches!(next, '0'..='9' | 'a'..='f' | 'A'..='F'),
+                    );
                 }
 
                 'p' | 'P' if self.lua_version.has_lua52() => {
-                    if number.len() == prefix_len {
+                    if !saw_digit {
                         return Some(self.eat_invalid_number(start_position, number));
                     }
 
@@ -1121,6 +1140,10 @@ impl Lexer {
                 }
 
                 'u' | 'U' | 'l' | 'L' | 'i' | 'I' if self.lua_version.has_luajit() => {
+                    if !saw_digit {
+                        return Some(self.eat_invalid_number(start_position, number));
+                    }
+
                     return self.read_luajit_number_suffix(start_position, number);
                 }
 
@@ -1128,7 +1151,7 @@ impl Lexer {
             }
         }
 
-        if number.len() == prefix_len {
+        if !saw_digit {
             return Some(self.eat_invalid_number(start_position, number));
         }
 
@@ -1145,16 +1168,17 @@ impl Lexer {
         mut number: String,
         start_position: Position,
     ) -> Option<LexerResult<Token>> {
-        let prefix_len = number.len();
         debug_assert!(self.lua_version.has_luau() || self.lua_version.has_luajit());
+        let saw_digit =
+            self.read_number_digits(&mut number, true, |next| matches!(next, '0' | '1'));
 
         while let Some(next) = self.source.current() {
             match next {
-                '0' | '1' | '_' => {
-                    number.push(self.source.next().expect("peeked, but no next"));
-                }
-
                 'u' | 'U' | 'l' | 'L' | 'i' | 'I' if self.lua_version.has_luajit() => {
+                    if !saw_digit {
+                        return Some(self.eat_invalid_number(start_position, number));
+                    }
+
                     return self.read_luajit_number_suffix(start_position, number);
                 }
 
@@ -1162,7 +1186,7 @@ impl Lexer {
             }
         }
 
-        if number.len() == prefix_len {
+        if !saw_digit {
             return Some(self.eat_invalid_number(start_position, number));
         }
 

--- a/full-moon/tests/roblox_cases/pass/decimal_seperators/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/decimal_seperators/ast.snap
@@ -880,5 +880,116 @@ stmts:
                     token_type:
                       type: Number
                       text: 0_b_1010_1010_1010_1010
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 220
+                        line: 8
+                        character: 37
+                      end_position:
+                        bytes: 221
+                        line: 8
+                        character: 37
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+    - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 221
+              line: 9
+              character: 1
+            end_position:
+              bytes: 226
+              line: 9
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 226
+                line: 9
+                character: 6
+              end_position:
+                bytes: 227
+                line: 9
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 227
+                    line: 9
+                    character: 7
+                  end_position:
+                    bytes: 231
+                    line: 9
+                    character: 11
+                  token_type:
+                    type: Identifier
+                    identifier: num9
+                trailing_trivia:
+                  - start_position:
+                      bytes: 231
+                      line: 9
+                      character: 11
+                    end_position:
+                      bytes: 232
+                      line: 9
+                      character: 12
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 232
+              line: 9
+              character: 12
+            end_position:
+              bytes: 233
+              line: 9
+              character: 13
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 233
+                line: 9
+                character: 13
+              end_position:
+                bytes: 234
+                line: 9
+                character: 14
+              token_type:
+                type: Whitespace
+                characters: " "
+        expr_list:
+          pairs:
+            - End:
+                Number:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 234
+                      line: 9
+                      character: 14
+                    end_position:
+                      bytes: 239
+                      line: 9
+                      character: 19
+                    token_type:
+                      type: Number
+                      text: 1e+_2
                   trailing_trivia: []
     - ~

--- a/full-moon/tests/roblox_cases/pass/decimal_seperators/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/decimal_seperators/ast.snap
@@ -1,6 +1,6 @@
 ---
 source: full-moon/tests/pass_cases.rs
-assertion_line: 52
+assertion_line: 47
 expression: ast.nodes()
 input_file: full-moon/tests/roblox_cases/pass/decimal_seperators
 ---
@@ -658,6 +658,227 @@ stmts:
                     token_type:
                       type: Number
                       text: 1e-512_412
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 155
+                        line: 6
+                        character: 24
+                      end_position:
+                        bytes: 156
+                        line: 6
+                        character: 24
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+    - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 156
+              line: 7
+              character: 1
+            end_position:
+              bytes: 161
+              line: 7
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 161
+                line: 7
+                character: 6
+              end_position:
+                bytes: 162
+                line: 7
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 162
+                    line: 7
+                    character: 7
+                  end_position:
+                    bytes: 166
+                    line: 7
+                    character: 11
+                  token_type:
+                    type: Identifier
+                    identifier: num7
+                trailing_trivia:
+                  - start_position:
+                      bytes: 166
+                      line: 7
+                      character: 11
+                    end_position:
+                      bytes: 167
+                      line: 7
+                      character: 12
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 167
+              line: 7
+              character: 12
+            end_position:
+              bytes: 168
+              line: 7
+              character: 13
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 168
+                line: 7
+                character: 13
+              end_position:
+                bytes: 169
+                line: 7
+                character: 14
+              token_type:
+                type: Whitespace
+                characters: " "
+        expr_list:
+          pairs:
+            - End:
+                Number:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 169
+                      line: 7
+                      character: 14
+                    end_position:
+                      bytes: 183
+                      line: 7
+                      character: 28
+                    token_type:
+                      type: Number
+                      text: 0_xFF_FF_FF_FF
+                  trailing_trivia:
+                    - start_position:
+                        bytes: 183
+                        line: 7
+                        character: 28
+                      end_position:
+                        bytes: 184
+                        line: 7
+                        character: 28
+                      token_type:
+                        type: Whitespace
+                        characters: "\n"
+    - ~
+  - - LocalAssignment:
+        local_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 184
+              line: 8
+              character: 1
+            end_position:
+              bytes: 189
+              line: 8
+              character: 6
+            token_type:
+              type: Symbol
+              symbol: local
+          trailing_trivia:
+            - start_position:
+                bytes: 189
+                line: 8
+                character: 6
+              end_position:
+                bytes: 190
+                line: 8
+                character: 7
+              token_type:
+                type: Whitespace
+                characters: " "
+        name_list:
+          pairs:
+            - End:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 190
+                    line: 8
+                    character: 7
+                  end_position:
+                    bytes: 194
+                    line: 8
+                    character: 11
+                  token_type:
+                    type: Identifier
+                    identifier: num8
+                trailing_trivia:
+                  - start_position:
+                      bytes: 194
+                      line: 8
+                      character: 11
+                    end_position:
+                      bytes: 195
+                      line: 8
+                      character: 12
+                    token_type:
+                      type: Whitespace
+                      characters: " "
+        equal_token:
+          leading_trivia: []
+          token:
+            start_position:
+              bytes: 195
+              line: 8
+              character: 12
+            end_position:
+              bytes: 196
+              line: 8
+              character: 13
+            token_type:
+              type: Symbol
+              symbol: "="
+          trailing_trivia:
+            - start_position:
+                bytes: 196
+                line: 8
+                character: 13
+              end_position:
+                bytes: 197
+                line: 8
+                character: 14
+              token_type:
+                type: Whitespace
+                characters: " "
+        expr_list:
+          pairs:
+            - End:
+                Number:
+                  leading_trivia: []
+                  token:
+                    start_position:
+                      bytes: 197
+                      line: 8
+                      character: 14
+                    end_position:
+                      bytes: 220
+                      line: 8
+                      character: 37
+                    token_type:
+                      type: Number
+                      text: 0_b_1010_1010_1010_1010
                   trailing_trivia: []
     - ~
-

--- a/full-moon/tests/roblox_cases/pass/decimal_seperators/source.lua
+++ b/full-moon/tests/roblox_cases/pass/decimal_seperators/source.lua
@@ -6,3 +6,4 @@ local num5 = 1e512_412
 local num6 = 1e-512_412
 local num7 = 0_xFF_FF_FF_FF
 local num8 = 0_b_1010_1010_1010_1010
+local num9 = 1e+_2

--- a/full-moon/tests/roblox_cases/pass/decimal_seperators/source.lua
+++ b/full-moon/tests/roblox_cases/pass/decimal_seperators/source.lua
@@ -4,3 +4,5 @@ local num3 = 0b_0101_0101
 local num4 = 1_523_423.132_452_312
 local num5 = 1e512_412
 local num6 = 1e-512_412
+local num7 = 0_xFF_FF_FF_FF
+local num8 = 0_b_1010_1010_1010_1010

--- a/full-moon/tests/roblox_cases/pass/decimal_seperators/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/decimal_seperators/tokens.snap
@@ -1,8 +1,8 @@
 ---
 source: full-moon/tests/pass_cases.rs
+assertion_line: 39
 expression: tokens
 input_file: full-moon/tests/roblox_cases/pass/decimal_seperators
-
 ---
 - start_position:
     bytes: 0
@@ -526,9 +526,184 @@ input_file: full-moon/tests/roblox_cases/pass/decimal_seperators
     line: 6
     character: 24
   end_position:
-    bytes: 155
+    bytes: 156
     line: 6
     character: 24
   token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 156
+    line: 7
+    character: 1
+  end_position:
+    bytes: 161
+    line: 7
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 161
+    line: 7
+    character: 6
+  end_position:
+    bytes: 162
+    line: 7
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 162
+    line: 7
+    character: 7
+  end_position:
+    bytes: 166
+    line: 7
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: num7
+- start_position:
+    bytes: 166
+    line: 7
+    character: 11
+  end_position:
+    bytes: 167
+    line: 7
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 167
+    line: 7
+    character: 12
+  end_position:
+    bytes: 168
+    line: 7
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 168
+    line: 7
+    character: 13
+  end_position:
+    bytes: 169
+    line: 7
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 169
+    line: 7
+    character: 14
+  end_position:
+    bytes: 183
+    line: 7
+    character: 28
+  token_type:
+    type: Number
+    text: 0_xFF_FF_FF_FF
+- start_position:
+    bytes: 183
+    line: 7
+    character: 28
+  end_position:
+    bytes: 184
+    line: 7
+    character: 28
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 184
+    line: 8
+    character: 1
+  end_position:
+    bytes: 189
+    line: 8
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 189
+    line: 8
+    character: 6
+  end_position:
+    bytes: 190
+    line: 8
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 190
+    line: 8
+    character: 7
+  end_position:
+    bytes: 194
+    line: 8
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: num8
+- start_position:
+    bytes: 194
+    line: 8
+    character: 11
+  end_position:
+    bytes: 195
+    line: 8
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 195
+    line: 8
+    character: 12
+  end_position:
+    bytes: 196
+    line: 8
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 196
+    line: 8
+    character: 13
+  end_position:
+    bytes: 197
+    line: 8
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 197
+    line: 8
+    character: 14
+  end_position:
+    bytes: 220
+    line: 8
+    character: 37
+  token_type:
+    type: Number
+    text: 0_b_1010_1010_1010_1010
+- start_position:
+    bytes: 220
+    line: 8
+    character: 37
+  end_position:
+    bytes: 220
+    line: 8
+    character: 37
+  token_type:
     type: Eof
-

--- a/full-moon/tests/roblox_cases/pass/decimal_seperators/tokens.snap
+++ b/full-moon/tests/roblox_cases/pass/decimal_seperators/tokens.snap
@@ -702,8 +702,96 @@ input_file: full-moon/tests/roblox_cases/pass/decimal_seperators
     line: 8
     character: 37
   end_position:
-    bytes: 220
+    bytes: 221
     line: 8
     character: 37
+  token_type:
+    type: Whitespace
+    characters: "\n"
+- start_position:
+    bytes: 221
+    line: 9
+    character: 1
+  end_position:
+    bytes: 226
+    line: 9
+    character: 6
+  token_type:
+    type: Symbol
+    symbol: local
+- start_position:
+    bytes: 226
+    line: 9
+    character: 6
+  end_position:
+    bytes: 227
+    line: 9
+    character: 7
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 227
+    line: 9
+    character: 7
+  end_position:
+    bytes: 231
+    line: 9
+    character: 11
+  token_type:
+    type: Identifier
+    identifier: num9
+- start_position:
+    bytes: 231
+    line: 9
+    character: 11
+  end_position:
+    bytes: 232
+    line: 9
+    character: 12
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 232
+    line: 9
+    character: 12
+  end_position:
+    bytes: 233
+    line: 9
+    character: 13
+  token_type:
+    type: Symbol
+    symbol: "="
+- start_position:
+    bytes: 233
+    line: 9
+    character: 13
+  end_position:
+    bytes: 234
+    line: 9
+    character: 14
+  token_type:
+    type: Whitespace
+    characters: " "
+- start_position:
+    bytes: 234
+    line: 9
+    character: 14
+  end_position:
+    bytes: 239
+    line: 9
+    character: 19
+  token_type:
+    type: Number
+    text: 1e+_2
+- start_position:
+    bytes: 239
+    line: 9
+    character: 19
+  end_position:
+    bytes: 239
+    line: 9
+    character: 19
   token_type:
     type: Eof


### PR DESCRIPTION
Luau allows underscores between the leading zero and the number prefix:

```luau
return 0_x40 --> 64
return 0__b11 --> 3
```

The lexer already supports separators in numbers, but only *after* the prefix. This PR adds support for separators *before* the prefix as well.