### PR TITLE
luau: parse attribute params (@[name(...)])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Luau: support parsing attributes with bracketed parameters (`@[name]`, `@[name(args...)]`, `@[name literal]`, and comma-grouped `@[a, b(x), c]`), per the [Function Attribute Parameters RFC](https://rfcs.luau.org/syntax-attributes-functions-parameters.html). Previously `parse_attributes` only accepted bare `@name` and errored on `@[`.
 
 ## [2.1.1] - 2026-01-22
 ### Fixed

--- a/full-moon/src/ast/luau.rs
+++ b/full-moon/src/ast/luau.rs
@@ -3,11 +3,12 @@
 //! It will be renamed to "luau" in the future.
 use super::{punctuated::Punctuated, span::ContainedSpan, *};
 use crate::{
-    util::display_option,
+    util::{display_option, empty_optional_vector, join_iterators, join_vec},
     visitors::{Visit, VisitMut},
     ShortString,
 };
 use derive_more::Display;
+use std::fmt;
 
 /// Any type, such as `string`, `boolean?`, `number | boolean`, etc.
 #[derive(Clone, Debug, Display, PartialEq, Node)]
@@ -1206,21 +1207,21 @@ impl<'a> Iterator for ExpressionsIterator<'a> {
     }
 }
 
-/// An attribute, such as `@native`
+/// An attribute, such as `@native`, `@[native]`, or `@[deprecated("use bar instead")]`
 #[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
-#[display("{at_sign}{name}")]
+#[display("{at_sign}{kind}")]
 pub struct LuauAttribute {
     pub(crate) at_sign: TokenReference,
-    pub(crate) name: TokenReference,
+    pub(crate) kind: LuauAttributeKind,
 }
 
 impl LuauAttribute {
-    /// Creates a new ElseIf from the given condition
+    /// Creates a new LuauAttribute with the given name in bare (unbracketed) form
     pub fn new(name: TokenReference) -> Self {
         Self {
             at_sign: TokenReference::symbol("@").unwrap(),
-            name,
+            kind: LuauAttributeKind::Name(name),
         }
     }
 
@@ -1229,9 +1230,25 @@ impl LuauAttribute {
         &self.at_sign
     }
 
-    /// The name of the attribute, `native` in `@native`
-    pub fn name(&self) -> &TokenReference {
-        &self.name
+    /// The name of the attribute, `native` in `@native`. `None` for a bracketed
+    /// list with more than one attribute in it -- use [`LuauAttribute::kind`] for that.
+    pub fn name(&self) -> Option<&TokenReference> {
+        match &self.kind {
+            LuauAttributeKind::Name(name) => Some(name),
+            LuauAttributeKind::Bracketed { attributes, .. } => {
+                if attributes.len() == 1 {
+                    attributes.iter().next().map(|item| item.name())
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    /// The contents of the attribute after the `@`: either a bare name, or a
+    /// bracketed (`@[...]`) list of one or more named attributes with optional params.
+    pub fn kind(&self) -> &LuauAttributeKind {
+        &self.kind
     }
 
     /// Returns a new Attribute with the given `@` token
@@ -1239,9 +1256,324 @@ impl LuauAttribute {
         Self { at_sign, ..self }
     }
 
-    /// Returns a new Attribute with the given name
+    /// Returns a new Attribute with the given kind
+    pub fn with_kind(self, kind: LuauAttributeKind) -> Self {
+        Self { kind, ..self }
+    }
+}
+
+/// The contents of a [`LuauAttribute`] after the `@` sign.
+// NOTE: Visit/VisitMut are implemented manually in `luau_visitors.rs`, since the derive
+// macro doesn't support `#[visit(contains = "...")]` on enum variants (it would otherwise
+// visit the closing `]` before the attributes it contains).
+#[derive(Clone, Debug, Display, PartialEq, Node)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub enum LuauAttributeKind {
+    /// A bare attribute name with no brackets, such as `native` in `@native`
+    #[display("{_0}")]
+    Name(TokenReference),
+
+    /// A bracketed list of one or more attributes, such as `[native]` in `@[native]`,
+    /// or `[native, deprecated("reason")]` in `@[native, deprecated("reason")]`
+    #[display("{}{}{}", brackets.tokens().0, attributes, brackets.tokens().1)]
+    Bracketed {
+        /// The `[` and `]` surrounding the attribute list
+        #[node(full_range)]
+        brackets: ContainedSpan,
+        /// The comma separated attributes within the brackets
+        attributes: Punctuated<LuauAttributeItem>,
+    },
+}
+
+/// A single named attribute with optional params, as used within a bracketed
+/// attribute list: the `deprecated("reason")` in `@[deprecated("reason")]`
+#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[display("{name}{}", display_option(params))]
+pub struct LuauAttributeItem {
+    pub(crate) name: TokenReference,
+    pub(crate) params: Option<LuauAttributeParams>,
+}
+
+impl LuauAttributeItem {
+    /// Creates a new LuauAttributeItem with the given name and no params
+    pub fn new(name: TokenReference) -> Self {
+        Self { name, params: None }
+    }
+
+    /// The name of the attribute, e.g. `deprecated` in `deprecated("reason")`
+    pub fn name(&self) -> &TokenReference {
+        &self.name
+    }
+
+    /// The params passed to the attribute, if any
+    pub fn params(&self) -> Option<&LuauAttributeParams> {
+        self.params.as_ref()
+    }
+
+    /// Returns a new LuauAttributeItem with the given name
     pub fn with_name(self, name: TokenReference) -> Self {
         Self { name, ..self }
+    }
+
+    /// Returns a new LuauAttributeItem with the given params
+    pub fn with_params(self, params: Option<LuauAttributeParams>) -> Self {
+        Self { params, ..self }
+    }
+}
+
+/// The params passed to a single attribute within a bracketed attribute list.
+// NOTE: Visit/VisitMut are implemented manually in `luau_visitors.rs`, for the same
+// reason as `LuauAttributeKind` above.
+#[derive(Clone, Debug, Display, PartialEq, Node)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub enum LuauAttributeParams {
+    /// Parenthesized, comma separated literal arguments, such as `("a", "b")` in
+    /// `@[deprecated("a", "b")]`
+    #[display("{}{}{}", parens.tokens().0, arguments, parens.tokens().1)]
+    Parens {
+        /// The `(` and `)` surrounding the arguments
+        #[node(full_range)]
+        parens: ContainedSpan,
+        /// The literal arguments passed to the attribute
+        arguments: Punctuated<LuauAttributeArgument>,
+    },
+
+    /// A single literal argument with no surrounding parens, such as `"reason"` in
+    /// `@[deprecated "reason"]`
+    #[display("{_0}")]
+    Literal(LuauAttributeArgument),
+}
+
+/// A literal value passed as a parameter to a [`LuauAttribute`] -- the RFC only
+/// allows literals here (nil/bool/number/string/table), not arbitrary expressions.
+#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub enum LuauAttributeArgument {
+    /// The `nil` literal
+    #[display("{_0}")]
+    Nil(TokenReference),
+    /// The `true` literal
+    #[display("{_0}")]
+    True(TokenReference),
+    /// The `false` literal
+    #[display("{_0}")]
+    False(TokenReference),
+    /// A number literal, such as `1` or `3.5`
+    #[display("{_0}")]
+    Number(TokenReference),
+    /// A string literal, such as `"foo"`
+    #[display("{_0}")]
+    Str(TokenReference),
+    /// A table constructor literal, such as `{ foo = "bar" }`
+    #[display("{_0}")]
+    Table(TableConstructor),
+}
+
+/// An assignment declared with `const`, such as `const x = 1`. `const` is a
+/// contextual keyword valid anywhere `local` is, with the caveat that (unlike
+/// `local`) an initializer is required.
+#[derive(Clone, Debug, PartialEq, Node, Visit)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct ConstAssignment {
+    pub(crate) const_token: TokenReference,
+    #[cfg_attr(
+        feature = "serde",
+        serde(skip_serializing_if = "empty_optional_vector")
+    )]
+    pub(crate) type_specifiers: Vec<Option<TypeSpecifier>>,
+    pub(crate) name_list: Punctuated<TokenReference>,
+    pub(crate) equal_token: Option<TokenReference>,
+    pub(crate) expr_list: Punctuated<Expression>,
+}
+
+// `const` is a contextual keyword, not a real symbol in the tokenizer (it's just an
+// identifier that the parser treats specially in statement-start position), so unlike
+// `local` it can't be built with `TokenReference::basic_symbol`.
+fn const_token_reference() -> TokenReference {
+    TokenReference::new(
+        Vec::new(),
+        Token::new(TokenType::Identifier {
+            identifier: "const".into(),
+        }),
+        vec![Token::new(TokenType::spaces(1))],
+    )
+}
+
+impl ConstAssignment {
+    /// Creates a new ConstAssignment from the given name list
+    pub fn new(name_list: Punctuated<TokenReference>) -> Self {
+        Self {
+            const_token: const_token_reference(),
+            type_specifiers: Vec::new(),
+            name_list,
+            equal_token: None,
+            expr_list: Punctuated::new(),
+        }
+    }
+
+    /// The `const` token
+    pub fn const_token(&self) -> &TokenReference {
+        &self.const_token
+    }
+
+    /// The `=` token in between `const x = y`, if one exists
+    pub fn equal_token(&self) -> Option<&TokenReference> {
+        self.equal_token.as_ref()
+    }
+
+    /// Returns the punctuated sequence of the expressions being assigned.
+    /// This is the `1, 2` part of `const x, y = 1, 2`
+    pub fn expressions(&self) -> &Punctuated<Expression> {
+        &self.expr_list
+    }
+
+    /// Returns the punctuated sequence of names being assigned to.
+    /// This is the `x, y` part of `const x, y = 1, 2`
+    pub fn names(&self) -> &Punctuated<TokenReference> {
+        &self.name_list
+    }
+
+    /// The type specifiers of the variables, in the order that they were assigned.
+    /// `const foo: number, bar` returns an iterator containing:
+    /// `Some(TypeSpecifier(number)), None`
+    pub fn type_specifiers(&self) -> impl Iterator<Item = Option<&TypeSpecifier>> {
+        self.type_specifiers.iter().map(Option::as_ref)
+    }
+
+    /// Returns a new ConstAssignment with the given `const` token
+    pub fn with_const_token(self, const_token: TokenReference) -> Self {
+        Self {
+            const_token,
+            ..self
+        }
+    }
+
+    /// Returns a new ConstAssignment with the given type specifiers
+    pub fn with_type_specifiers(self, type_specifiers: Vec<Option<TypeSpecifier>>) -> Self {
+        Self {
+            type_specifiers,
+            ..self
+        }
+    }
+
+    /// Returns a new ConstAssignment with the given name list
+    pub fn with_names(self, name_list: Punctuated<TokenReference>) -> Self {
+        Self { name_list, ..self }
+    }
+
+    /// Returns a new ConstAssignment with the given `=` token
+    pub fn with_equal_token(self, equal_token: Option<TokenReference>) -> Self {
+        Self {
+            equal_token,
+            ..self
+        }
+    }
+
+    /// Returns a new ConstAssignment with the given expression list
+    pub fn with_expressions(self, expr_list: Punctuated<Expression>) -> Self {
+        Self { expr_list, ..self }
+    }
+}
+
+impl fmt::Display for ConstAssignment {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        let type_specifiers = self.type_specifiers().chain(std::iter::repeat(None));
+
+        write!(
+            formatter,
+            "{}{}{}{}",
+            self.const_token,
+            join_iterators(
+                &self.name_list,
+                type_specifiers,
+                std::iter::repeat_with(|| None::<TokenReference>)
+            ),
+            display_option(&self.equal_token),
+            self.expr_list
+        )
+    }
+}
+
+/// A declaration of a function with `const`, such as `const function x() end`,
+/// equivalent to `local function x() end` but using the `const` keyword.
+#[derive(Clone, Debug, Display, PartialEq, Node, Visit)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[display("{}{}{}{}{}", join_vec(attributes), const_token, function_token, name, body)]
+pub struct ConstFunction {
+    pub(crate) attributes: Vec<LuauAttribute>,
+    pub(crate) const_token: TokenReference,
+    pub(crate) function_token: TokenReference,
+    pub(crate) name: TokenReference,
+    pub(crate) body: FunctionBody,
+}
+
+impl ConstFunction {
+    /// Returns a new ConstFunction from the given name
+    pub fn new(name: TokenReference) -> Self {
+        ConstFunction {
+            attributes: Vec::new(),
+            const_token: const_token_reference(),
+            function_token: TokenReference::basic_symbol("function "),
+            name,
+            body: FunctionBody::new(),
+        }
+    }
+
+    /// The attributes in the function, e.g. `@native`
+    pub fn attributes(&self) -> impl Iterator<Item = &LuauAttribute> {
+        self.attributes.iter()
+    }
+
+    /// The `const` token
+    pub fn const_token(&self) -> &TokenReference {
+        &self.const_token
+    }
+
+    /// The `function` token
+    pub fn function_token(&self) -> &TokenReference {
+        &self.function_token
+    }
+
+    /// The function body, everything except `const function x` in `const function x(a, b, c) call() end`
+    pub fn body(&self) -> &FunctionBody {
+        &self.body
+    }
+
+    /// The name of the function, the `x` part of `const function x() end`
+    pub fn name(&self) -> &TokenReference {
+        &self.name
+    }
+
+    /// Returns a new ConstFunction with the given attributes (e.g. `@native`)
+    pub fn with_attributes(self, attributes: Vec<LuauAttribute>) -> Self {
+        Self { attributes, ..self }
+    }
+
+    /// Returns a new ConstFunction with the given `const` token
+    pub fn with_const_token(self, const_token: TokenReference) -> Self {
+        Self {
+            const_token,
+            ..self
+        }
+    }
+
+    /// Returns a new ConstFunction with the given `function` token
+    pub fn with_function_token(self, function_token: TokenReference) -> Self {
+        Self {
+            function_token,
+            ..self
+        }
+    }
+
+    /// Returns a new ConstFunction with the given name
+    pub fn with_name(self, name: TokenReference) -> Self {
+        Self { name, ..self }
+    }
+
+    /// Returns a new ConstFunction with the given function body
+    pub fn with_body(self, body: FunctionBody) -> Self {
+        Self { body, ..self }
     }
 }
 

--- a/full-moon/src/ast/luau_visitors.rs
+++ b/full-moon/src/ast/luau_visitors.rs
@@ -430,3 +430,89 @@ impl VisitMut for TypeInstantiation {
         self
     }
 }
+
+// Same story as TypeInfo/IndexedTypeInfo/TypeFieldKey above: the `Bracketed` variant
+// holds a `ContainedSpan`, and the derive macro can't interleave `contains` on enums.
+impl Visit for LuauAttributeKind {
+    fn visit<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_luau_attribute_kind(self);
+        match self {
+            LuauAttributeKind::Name(name) => {
+                name.visit(visitor);
+            }
+            LuauAttributeKind::Bracketed {
+                brackets,
+                attributes,
+            } => {
+                brackets.tokens.0.visit(visitor);
+                attributes.visit(visitor);
+                brackets.tokens.1.visit(visitor);
+            }
+        };
+        visitor.visit_luau_attribute_kind_end(self);
+    }
+}
+
+impl VisitMut for LuauAttributeKind {
+    fn visit_mut<V: VisitorMut>(mut self, visitor: &mut V) -> Self {
+        self = visitor.visit_luau_attribute_kind(self);
+        self = match self {
+            LuauAttributeKind::Name(name) => LuauAttributeKind::Name(name.visit_mut(visitor)),
+            LuauAttributeKind::Bracketed {
+                mut brackets,
+                mut attributes,
+            } => {
+                brackets.tokens.0 = brackets.tokens.0.visit_mut(visitor);
+                attributes = attributes.visit_mut(visitor);
+                brackets.tokens.1 = brackets.tokens.1.visit_mut(visitor);
+
+                LuauAttributeKind::Bracketed {
+                    brackets,
+                    attributes,
+                }
+            }
+        };
+        self = visitor.visit_luau_attribute_kind_end(self);
+        self
+    }
+}
+
+impl Visit for LuauAttributeParams {
+    fn visit<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_luau_attribute_params(self);
+        match self {
+            LuauAttributeParams::Parens { parens, arguments } => {
+                parens.tokens.0.visit(visitor);
+                arguments.visit(visitor);
+                parens.tokens.1.visit(visitor);
+            }
+            LuauAttributeParams::Literal(argument) => {
+                argument.visit(visitor);
+            }
+        };
+        visitor.visit_luau_attribute_params_end(self);
+    }
+}
+
+impl VisitMut for LuauAttributeParams {
+    fn visit_mut<V: VisitorMut>(mut self, visitor: &mut V) -> Self {
+        self = visitor.visit_luau_attribute_params(self);
+        self = match self {
+            LuauAttributeParams::Parens {
+                mut parens,
+                mut arguments,
+            } => {
+                parens.tokens.0 = parens.tokens.0.visit_mut(visitor);
+                arguments = arguments.visit_mut(visitor);
+                parens.tokens.1 = parens.tokens.1.visit_mut(visitor);
+
+                LuauAttributeParams::Parens { parens, arguments }
+            }
+            LuauAttributeParams::Literal(argument) => {
+                LuauAttributeParams::Literal(argument.visit_mut(visitor))
+            }
+        };
+        self = visitor.visit_luau_attribute_params_end(self);
+        self
+    }
+}

--- a/full-moon/src/ast/mod.rs
+++ b/full-moon/src/ast/mod.rs
@@ -479,6 +479,16 @@ pub enum Stmt {
     #[cfg(any(feature = "luau", feature = "cfxlua"))]
     #[display("{_0}")]
     CompoundAssignment(CompoundAssignment),
+    /// An assignment declared with `const`, such as `const x = 1`
+    /// Only available when the "luau" feature flag is enabled.
+    #[cfg(feature = "luau")]
+    #[display("{_0}")]
+    ConstAssignment(ConstAssignment),
+    /// A function declared with `const`, such as `const function x() end`
+    /// Only available when the "luau" feature flag is enabled.
+    #[cfg(feature = "luau")]
+    #[display("{_0}")]
+    ConstFunction(ConstFunction),
     /// An exported type declaration, such as `export type Meters = number`
     /// Only available when the "luau" feature flag is enabled.
     #[cfg(feature = "luau")]

--- a/full-moon/src/ast/parsers.rs
+++ b/full-moon/src/ast/parsers.rs
@@ -431,6 +431,65 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                                         ast::LastStmt::Continue(continue_token),
                                     ));
                                 }
+                                TokenType::Identifier { identifier }
+                                    if identifier.as_str() == "const" =>
+                                {
+                                    let const_token = token;
+
+                                    match state.current() {
+                                        Ok(next_token)
+                                            if next_token.token_kind()
+                                                == TokenKind::Identifier =>
+                                        {
+                                            return ParserResult::Value(StmtVariant::Stmt(
+                                                ast::Stmt::ConstAssignment(
+                                                    match expect_const_assignment(
+                                                        state,
+                                                        const_token,
+                                                    ) {
+                                                        Ok(const_assignment) => const_assignment,
+                                                        Err(()) => {
+                                                            return ParserResult::LexerMoved
+                                                        }
+                                                    },
+                                                ),
+                                            ));
+                                        }
+
+                                        Ok(next_token)
+                                            if next_token.is_symbol(Symbol::Function) =>
+                                        {
+                                            let function_token = state.consume().unwrap();
+
+                                            let const_function =
+                                                match expect_const_function_declaration(
+                                                    state,
+                                                    const_token,
+                                                    function_token,
+                                                ) {
+                                                    Ok(const_function) => const_function,
+                                                    Err(()) => {
+                                                        return ParserResult::LexerMoved
+                                                    }
+                                                };
+
+                                            return ParserResult::Value(StmtVariant::Stmt(
+                                                ast::Stmt::ConstFunction(const_function),
+                                            ));
+                                        }
+
+                                        Ok(next_token) => {
+                                            state.token_error(
+                                                next_token.clone(),
+                                                "expected either a variable name or `function` after `const`",
+                                            );
+
+                                            return ParserResult::LexerMoved;
+                                        }
+
+                                        Err(()) => return ParserResult::LexerMoved,
+                                    }
+                                }
                                 _ => (),
                             }
                         }
@@ -661,10 +720,41 @@ fn parse_stmt(state: &mut ParserState) -> ParserResult<StmtVariant> {
                         Err(()) => ParserResult::LexerMoved,
                     }
                 }
+                Ok(token)
+                    if matches!(token.token_type(), TokenType::Identifier { identifier } if identifier.as_str() == "const") =>
+                {
+                    let const_token = state.consume().unwrap();
+                    match state.current() {
+                        Ok(token) if token.is_symbol(Symbol::Function) => {
+                            let function_token = state.consume().unwrap();
+
+                            let const_function = match expect_const_function_declaration(
+                                state,
+                                const_token,
+                                function_token,
+                            ) {
+                                Ok(const_function) => const_function,
+                                Err(()) => return ParserResult::LexerMoved,
+                            };
+
+                            ParserResult::Value(StmtVariant::Stmt(ast::Stmt::ConstFunction(
+                                const_function.with_attributes(attributes),
+                            )))
+                        }
+                        Ok(token) => {
+                            state.token_error(
+                                token.clone(),
+                                "expected `const function` after attribute",
+                            );
+                            ParserResult::LexerMoved
+                        }
+                        Err(()) => ParserResult::LexerMoved,
+                    }
+                }
                 Ok(token) => {
                     state.token_error(
                         token.clone(),
-                        "expected `function` or `local function` after attribute",
+                        "expected `function`, `local function`, or `const function` after attribute",
                     );
                     ParserResult::LexerMoved
                 }
@@ -1184,6 +1274,100 @@ fn expect_local_assignment(
     };
 
     Ok(local_assignment)
+}
+
+// `const` is a contextual keyword valid anywhere `local` is, with one difference:
+// unlike `local`, an initializer is required (`const x` with no `= ...` is an error).
+#[cfg(feature = "luau")]
+fn expect_const_assignment(
+    state: &mut ParserState,
+    const_token: TokenReference,
+) -> Result<ast::ConstAssignment, ()> {
+    let names = match one_or_more(state, parse_name_with_attributes, Symbol::Comma) {
+        ParserResult::Value(names) => names,
+        ParserResult::NotFound => {
+            unreachable!("expect_const_assignment called without upcoming identifier");
+        }
+        ParserResult::LexerMoved => return Err(()),
+    };
+
+    let mut name_list = Punctuated::new();
+    let mut type_specifiers = Vec::new();
+
+    for name in names.into_pairs() {
+        let (name, punctuation) = name.into_tuple();
+
+        type_specifiers.push(name.type_specifier);
+
+        name_list.push(match punctuation {
+            Some(punctuation) => Pair::Punctuated(name.name, punctuation),
+            None => Pair::End(name.name),
+        });
+    }
+
+    let mut const_assignment = ast::ConstAssignment {
+        const_token,
+        type_specifiers,
+        name_list,
+        equal_token: None,
+        expr_list: Punctuated::new(),
+    };
+
+    let Some(equal_token) = state.require(
+        Symbol::Equal,
+        "expected `=` after variable list (const declarations must be initialized)",
+    ) else {
+        return Ok(const_assignment);
+    };
+
+    const_assignment.equal_token = Some(equal_token.clone());
+
+    match parse_expression_list(state) {
+        ParserResult::Value(expr_list) => const_assignment.expr_list = expr_list,
+
+        ParserResult::NotFound => {
+            state.token_error(equal_token, "expected an expression");
+        }
+
+        ParserResult::LexerMoved => {}
+    };
+
+    Ok(const_assignment)
+}
+
+#[cfg(feature = "luau")]
+fn expect_const_function_declaration(
+    state: &mut ParserState,
+    const_token: TokenReference,
+    function_token: TokenReference,
+) -> Result<ast::ConstFunction, ()> {
+    let function_name = match state.current() {
+        Ok(token) if token.token_kind() == TokenKind::Identifier => state.consume().unwrap(),
+
+        Ok(token) => {
+            state.token_error(token.clone(), "expected a function name");
+            return Err(());
+        }
+
+        Err(()) => return Err(()),
+    };
+
+    let function_body = match parse_function_body(state) {
+        ParserResult::Value(function_body) => function_body,
+        ParserResult::NotFound => {
+            state.token_error(function_token, "expected a function body");
+            return Err(());
+        }
+        ParserResult::LexerMoved => return Err(()),
+    };
+
+    Ok(ast::ConstFunction {
+        attributes: Vec::new(),
+        const_token,
+        function_token,
+        name: function_name,
+        body: function_body,
+    })
 }
 
 fn expect_expression_key(
@@ -3481,22 +3665,170 @@ fn parse_attributes(state: &mut ParserState) -> ParserResult<Vec<ast::LuauAttrib
     let mut attributes = Vec::new();
 
     while let Some(at_sign) = state.consume_if(Symbol::AtSign) {
-        let name = match parse_name(state) {
-            ParserResult::Value(name) => name.name,
-            ParserResult::NotFound => {
-                state.token_error(
-                    state.current().unwrap().clone(),
-                    "expected identifier after `@`",
-                );
-                return ParserResult::LexerMoved;
+        let kind = if let Some(left_bracket) = state.consume_if(Symbol::LeftBracket) {
+            let mut items = Punctuated::new();
+
+            loop {
+                let name = match parse_name(state) {
+                    ParserResult::Value(name) => name.name,
+                    ParserResult::NotFound => {
+                        state.token_error(
+                            state.current().unwrap().clone(),
+                            "expected identifier when parsing attribute name",
+                        );
+                        return ParserResult::LexerMoved;
+                    }
+                    ParserResult::LexerMoved => return ParserResult::LexerMoved,
+                };
+
+                let params = match parse_attribute_params(state) {
+                    Ok(params) => params,
+                    Err(()) => return ParserResult::LexerMoved,
+                };
+
+                let item = ast::LuauAttributeItem { name, params };
+
+                match state.consume_if(Symbol::Comma) {
+                    Some(comma) => items.push(Pair::Punctuated(item, comma)),
+                    None => {
+                        items.push(Pair::End(item));
+                        break;
+                    }
+                }
             }
-            ParserResult::LexerMoved => return ParserResult::LexerMoved,
+
+            let Some(right_bracket) = state.require(
+                Symbol::RightBracket,
+                "expected `]` to close attribute list",
+            ) else {
+                return ParserResult::LexerMoved;
+            };
+
+            ast::LuauAttributeKind::Bracketed {
+                brackets: ContainedSpan::new(left_bracket, right_bracket),
+                attributes: items,
+            }
+        } else {
+            let name = match parse_name(state) {
+                ParserResult::Value(name) => name.name,
+                ParserResult::NotFound => {
+                    state.token_error(
+                        state.current().unwrap().clone(),
+                        "expected identifier after `@`",
+                    );
+                    return ParserResult::LexerMoved;
+                }
+                ParserResult::LexerMoved => return ParserResult::LexerMoved,
+            };
+
+            ast::LuauAttributeKind::Name(name)
         };
 
-        attributes.push(ast::LuauAttribute { at_sign, name });
+        attributes.push(ast::LuauAttribute { at_sign, kind });
     }
 
     ParserResult::Value(attributes)
+}
+
+// Parses the optional params following an attribute name inside a bracketed
+// attribute list, e.g. the `("reason")` in `@[deprecated("reason")]`, or the bare
+// `"reason"` in `@[deprecated "reason"]`. Per the Luau RFC, only literals
+// (nil/booleans/numbers/strings/table constructors) are valid here.
+#[cfg(feature = "luau")]
+fn parse_attribute_params(
+    state: &mut ParserState,
+) -> Result<Option<ast::LuauAttributeParams>, ()> {
+    if let Some(left_paren) = state.consume_if(Symbol::LeftParen) {
+        let mut arguments = Punctuated::new();
+
+        if !matches!(state.current(), Ok(token) if token.is_symbol(Symbol::RightParen)) {
+            loop {
+                let argument = parse_attribute_argument(state)?;
+
+                match state.consume_if(Symbol::Comma) {
+                    Some(comma) => arguments.push(Pair::Punctuated(argument, comma)),
+                    None => {
+                        arguments.push(Pair::End(argument));
+                        break;
+                    }
+                }
+            }
+        }
+
+        let Some(right_paren) = state.require(
+            Symbol::RightParen,
+            "expected `)` to close attribute arguments",
+        ) else {
+            return Err(());
+        };
+
+        Ok(Some(ast::LuauAttributeParams::Parens {
+            parens: ContainedSpan::new(left_paren, right_paren),
+            arguments,
+        }))
+    } else if is_attribute_argument_start(state) {
+        Ok(Some(ast::LuauAttributeParams::Literal(
+            parse_attribute_argument(state)?,
+        )))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "luau")]
+fn is_attribute_argument_start(state: &mut ParserState) -> bool {
+    matches!(
+        state.current(),
+        Ok(token) if matches!(
+            token.token_type(),
+            TokenType::Symbol {
+                symbol: Symbol::Nil | Symbol::True | Symbol::False | Symbol::LeftBrace
+            } | TokenType::Number { .. }
+                | TokenType::StringLiteral { .. }
+        )
+    )
+}
+
+#[cfg(feature = "luau")]
+fn parse_attribute_argument(state: &mut ParserState) -> Result<ast::LuauAttributeArgument, ()> {
+    let Ok(current_token) = state.current() else {
+        return Err(());
+    };
+
+    match current_token.token_type() {
+        TokenType::Symbol { symbol: Symbol::Nil } => {
+            Ok(ast::LuauAttributeArgument::Nil(state.consume().unwrap()))
+        }
+        TokenType::Symbol {
+            symbol: Symbol::True,
+        } => Ok(ast::LuauAttributeArgument::True(state.consume().unwrap())),
+        TokenType::Symbol {
+            symbol: Symbol::False,
+        } => Ok(ast::LuauAttributeArgument::False(
+            state.consume().unwrap(),
+        )),
+        TokenType::Number { .. } => Ok(ast::LuauAttributeArgument::Number(
+            state.consume().unwrap(),
+        )),
+        TokenType::StringLiteral { .. } => {
+            Ok(ast::LuauAttributeArgument::Str(state.consume().unwrap()))
+        }
+        TokenType::Symbol {
+            symbol: Symbol::LeftBrace,
+        } => {
+            let left_brace = state.consume().unwrap();
+            Ok(ast::LuauAttributeArgument::Table(force_table_constructor(
+                state, left_brace,
+            )))
+        }
+        _ => {
+            state.token_error(
+                current_token.clone(),
+                "expected a literal (nil, boolean, number, string, or table) as an attribute argument",
+            );
+            Err(())
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/full-moon/src/visitors.rs
+++ b/full-moon/src/visitors.rs
@@ -280,6 +280,12 @@ create_visitor!(ast: {
     // Types
     #[cfg(feature = "luau")] {
         visit_luau_attribute => LuauAttribute,
+        visit_luau_attribute_kind => LuauAttributeKind,
+        visit_luau_attribute_item => LuauAttributeItem,
+        visit_luau_attribute_params => LuauAttributeParams,
+        visit_luau_attribute_argument => LuauAttributeArgument,
+        visit_const_assignment => ConstAssignment,
+        visit_const_function => ConstFunction,
         visit_else_if_expression => ElseIfExpression,
         visit_exported_type_declaration => ExportedTypeDeclaration,
         visit_exported_type_function => ExportedTypeFunction,

--- a/full-moon/tests/roblox_cases/pass/attributes/ast.snap
+++ b/full-moon/tests/roblox_cases/pass/attributes/ast.snap
@@ -2,7 +2,6 @@
 source: full-moon/tests/pass_cases.rs
 expression: ast.nodes()
 input_file: full-moon/tests/roblox_cases/pass/attributes
-snapshot_kind: text
 ---
 stmts:
   - - FunctionDeclaration:
@@ -22,32 +21,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 1
-                  line: 1
-                  character: 2
-                end_position:
-                  bytes: 8
-                  line: 1
-                  character: 9
-                token_type:
-                  type: Identifier
-                  identifier: example
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 1
+                    line: 1
+                    character: 2
+                  end_position:
                     bytes: 8
                     line: 1
                     character: 9
-                  end_position:
-                    bytes: 9
-                    line: 1
-                    character: 9
                   token_type:
-                    type: Whitespace
-                    characters: "\n"
+                    type: Identifier
+                    identifier: example
+                trailing_trivia:
+                  - start_position:
+                      bytes: 8
+                      line: 1
+                      character: 9
+                    end_position:
+                      bytes: 9
+                      line: 1
+                      character: 9
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
         function_token:
           leading_trivia: []
           token:
@@ -196,32 +196,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 30
-                  line: 5
-                  character: 2
-                end_position:
-                  bytes: 36
-                  line: 5
-                  character: 8
-                token_type:
-                  type: Identifier
-                  identifier: native
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 30
+                    line: 5
+                    character: 2
+                  end_position:
                     bytes: 36
                     line: 5
                     character: 8
-                  end_position:
-                    bytes: 37
-                    line: 5
-                    character: 8
                   token_type:
-                    type: Whitespace
-                    characters: "\n"
+                    type: Identifier
+                    identifier: native
+                trailing_trivia:
+                  - start_position:
+                      bytes: 36
+                      line: 5
+                      character: 8
+                    end_position:
+                      bytes: 37
+                      line: 5
+                      character: 8
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
         local_token:
           leading_trivia: []
           token:
@@ -476,32 +477,33 @@ stmts:
                             type: Symbol
                             symbol: "@"
                         trailing_trivia: []
-                      name:
-                        leading_trivia: []
-                        token:
-                          start_position:
-                            bytes: 76
-                            line: 9
-                            character: 14
-                          end_position:
-                            bytes: 83
-                            line: 9
-                            character: 21
-                          token_type:
-                            type: Identifier
-                            identifier: example
-                        trailing_trivia:
-                          - start_position:
+                      kind:
+                        Name:
+                          leading_trivia: []
+                          token:
+                            start_position:
+                              bytes: 76
+                              line: 9
+                              character: 14
+                            end_position:
                               bytes: 83
                               line: 9
                               character: 21
-                            end_position:
-                              bytes: 84
-                              line: 9
-                              character: 22
                             token_type:
-                              type: Whitespace
-                              characters: " "
+                              type: Identifier
+                              identifier: example
+                          trailing_trivia:
+                            - start_position:
+                                bytes: 83
+                                line: 9
+                                character: 21
+                              end_position:
+                                bytes: 84
+                                line: 9
+                                character: 22
+                              token_type:
+                                type: Whitespace
+                                characters: " "
                   function_token:
                     leading_trivia: []
                     token:
@@ -620,32 +622,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 101
-                  line: 11
-                  character: 2
-                end_position:
-                  bytes: 108
-                  line: 11
-                  character: 9
-                token_type:
-                  type: Identifier
-                  identifier: example
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 101
+                    line: 11
+                    character: 2
+                  end_position:
                     bytes: 108
                     line: 11
                     character: 9
-                  end_position:
-                    bytes: 109
-                    line: 11
-                    character: 9
                   token_type:
-                    type: Whitespace
-                    characters: "\n"
+                    type: Identifier
+                    identifier: example
+                trailing_trivia:
+                  - start_position:
+                      bytes: 108
+                      line: 11
+                      character: 9
+                    end_position:
+                      bytes: 109
+                      line: 11
+                      character: 9
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
         function_token:
           leading_trivia: []
           token:
@@ -822,32 +825,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 134
-                  line: 15
-                  character: 2
-                end_position:
-                  bytes: 144
-                  line: 15
-                  character: 12
-                token_type:
-                  type: Identifier
-                  identifier: attribute1
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 134
+                    line: 15
+                    character: 2
+                  end_position:
                     bytes: 144
                     line: 15
                     character: 12
-                  end_position:
-                    bytes: 145
-                    line: 15
-                    character: 13
                   token_type:
-                    type: Whitespace
-                    characters: " "
+                    type: Identifier
+                    identifier: attribute1
+                trailing_trivia:
+                  - start_position:
+                      bytes: 144
+                      line: 15
+                      character: 12
+                    end_position:
+                      bytes: 145
+                      line: 15
+                      character: 13
+                    token_type:
+                      type: Whitespace
+                      characters: " "
           - at_sign:
               leading_trivia: []
               token:
@@ -863,32 +867,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 146
-                  line: 15
-                  character: 14
-                end_position:
-                  bytes: 156
-                  line: 15
-                  character: 24
-                token_type:
-                  type: Identifier
-                  identifier: attribute2
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 146
+                    line: 15
+                    character: 14
+                  end_position:
                     bytes: 156
                     line: 15
                     character: 24
-                  end_position:
-                    bytes: 157
-                    line: 15
-                    character: 25
                   token_type:
-                    type: Whitespace
-                    characters: " "
+                    type: Identifier
+                    identifier: attribute2
+                trailing_trivia:
+                  - start_position:
+                      bytes: 156
+                      line: 15
+                      character: 24
+                    end_position:
+                      bytes: 157
+                      line: 15
+                      character: 25
+                    token_type:
+                      type: Whitespace
+                      characters: " "
           - at_sign:
               leading_trivia: []
               token:
@@ -904,32 +909,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 158
-                  line: 15
-                  character: 26
-                end_position:
-                  bytes: 168
-                  line: 15
-                  character: 36
-                token_type:
-                  type: Identifier
-                  identifier: attribute3
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 158
+                    line: 15
+                    character: 26
+                  end_position:
                     bytes: 168
                     line: 15
                     character: 36
-                  end_position:
-                    bytes: 169
-                    line: 15
-                    character: 37
                   token_type:
-                    type: Whitespace
-                    characters: " "
+                    type: Identifier
+                    identifier: attribute3
+                trailing_trivia:
+                  - start_position:
+                      bytes: 168
+                      line: 15
+                      character: 36
+                    end_position:
+                      bytes: 169
+                      line: 15
+                      character: 37
+                    token_type:
+                      type: Whitespace
+                      characters: " "
           - at_sign:
               leading_trivia: []
               token:
@@ -945,32 +951,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 170
-                  line: 15
-                  character: 38
-                end_position:
-                  bytes: 180
-                  line: 15
-                  character: 48
-                token_type:
-                  type: Identifier
-                  identifier: attribute4
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 170
+                    line: 15
+                    character: 38
+                  end_position:
                     bytes: 180
                     line: 15
                     character: 48
-                  end_position:
-                    bytes: 181
-                    line: 15
-                    character: 49
                   token_type:
-                    type: Whitespace
-                    characters: " "
+                    type: Identifier
+                    identifier: attribute4
+                trailing_trivia:
+                  - start_position:
+                      bytes: 180
+                      line: 15
+                      character: 48
+                    end_position:
+                      bytes: 181
+                      line: 15
+                      character: 49
+                    token_type:
+                      type: Whitespace
+                      characters: " "
           - at_sign:
               leading_trivia: []
               token:
@@ -986,32 +993,33 @@ stmts:
                   type: Symbol
                   symbol: "@"
               trailing_trivia: []
-            name:
-              leading_trivia: []
-              token:
-                start_position:
-                  bytes: 182
-                  line: 15
-                  character: 50
-                end_position:
-                  bytes: 192
-                  line: 15
-                  character: 60
-                token_type:
-                  type: Identifier
-                  identifier: attribute5
-              trailing_trivia:
-                - start_position:
+            kind:
+              Name:
+                leading_trivia: []
+                token:
+                  start_position:
+                    bytes: 182
+                    line: 15
+                    character: 50
+                  end_position:
                     bytes: 192
                     line: 15
                     character: 60
-                  end_position:
-                    bytes: 193
-                    line: 15
-                    character: 60
                   token_type:
-                    type: Whitespace
-                    characters: "\n"
+                    type: Identifier
+                    identifier: attribute5
+                trailing_trivia:
+                  - start_position:
+                      bytes: 192
+                      line: 15
+                      character: 60
+                    end_position:
+                      bytes: 193
+                      line: 15
+                      character: 60
+                    token_type:
+                      type: Whitespace
+                      characters: "\n"
         local_token:
           leading_trivia: []
           token:


### PR DESCRIPTION
parse_attributes only understood bare @name, so @[name], @[name(args)], @[name literal], and grouped @[a, b(x)] all blew up the moment it hit the `[`. This adds the bracketed form per the attribute params RFC: https://rfcs.luau.org/syntax-attributes-functions-parameters.html

LuauAttribute::name() is now Option<&TokenReference> since a bracketed list can hold more than one attribute - use kind() for the general case.